### PR TITLE
Make GetOperationStatus attempts retryable

### DIFF
--- a/src/databricks/sql/thrift_backend.py
+++ b/src/databricks/sql/thrift_backend.py
@@ -15,6 +15,9 @@ from thrift.Thrift import TException
 
 from databricks.sql.thrift_api.TCLIService import TCLIService, ttypes
 from databricks.sql import *
+from databricks.sql.thrift_api.TCLIService.TCLIService import (
+    Client as TCLIServiceClient,
+)
 from databricks.sql.utils import (
     ArrowQueue,
     ExecuteResponse,
@@ -288,7 +291,10 @@ class ThriftBackend:
             """
 
             header_delay = extract_retry_delay(attempt)
-            if method.__name__ == "GetOperationStatus" and not header_delay:
+            if (
+                method.__name__ == TCLIServiceClient.GetOperationStatus.__name__
+                and not header_delay
+            ):
                 return make_bounded_delay(attempt, DEFAULT_RETRY_DELAY_AFTER)
 
             return header_delay

--- a/src/databricks/sql/thrift_backend.py
+++ b/src/databricks/sql/thrift_backend.py
@@ -42,7 +42,7 @@ _retry_policy = {  # (type, default, min, max)
     "_retry_delay_max": (float, 60, 5, 3600),
     "_retry_stop_after_attempts_count": (int, 30, 1, 60),
     "_retry_stop_after_attempts_duration": (float, 900, 1, 86400),
-    "_retry_delay_default": (float, 5, 1, 60)
+    "_retry_delay_default": (float, 5, None, None)
 }
 
 

--- a/tests/unit/test_thrift_backend.py
+++ b/tests/unit/test_thrift_backend.py
@@ -19,6 +19,7 @@ def retry_policy_factory():
         "_retry_delay_max":                     (float, 60, None, None),
         "_retry_stop_after_attempts_count":     (int, 30, None, None),
         "_retry_stop_after_attempts_duration":  (float, 900, None, None),
+        "_retry_delay_default":                 (float, 1, None, None)
     }
 
 
@@ -995,8 +996,9 @@ class ThriftBackendTestSuite(unittest.TestCase):
             443,
             "path", [],
             _retry_stop_after_attempts_count=2,
-            _retry_delay_max=0,
-            _retry_delay_min=0)
+            _retry_delay_max=4,
+            _retry_delay_min=0,
+            _retry_delay_default=3)
 
         with self.assertRaises(RequestError) as cm:
             thrift_backend.make_request(client.GetOperationStatus, req)

--- a/tests/unit/test_thrift_backend.py
+++ b/tests/unit/test_thrift_backend.py
@@ -970,41 +970,43 @@ class ThriftBackendTestSuite(unittest.TestCase):
         self.assertEqual(mock_resp.operationHandle, mock_cursor.active_op_handle)
 
     @patch("thrift.transport.THttpClient.THttpClient")
+    @patch("databricks.sql.thrift_api.TCLIService.TCLIService.Client.GetOperationStatus")
     @patch("databricks.sql.thrift_backend._retry_policy", new_callable=retry_policy_factory)
     def test_make_request_will_retry_GetOperationStatus(
-            self, mock_retry_policy, t_transport_class):
+            self, mock_retry_policy, mock_GetOperationStatus, t_transport_class):
        
         import thrift
-        from databricks.sql.thrift_api.TCLIService import TCLIService
+        from databricks.sql.thrift_api.TCLIService.TCLIService import Client
         from databricks.sql.exc import RequestError
         from databricks.sql.utils import NoRetryReason
 
-        t_transport_instance = t_transport_class.return_value
-        t_transport_instance.code = 200
-        t_transport_instance.headers = {"foo": "bar"}
+        mock_GetOperationStatus.__name__ = "GetOperationStatus"
+        mock_GetOperationStatus.side_effect = Exception("Connection timed out!")
 
         protocol = thrift.protocol.TBinaryProtocol.TBinaryProtocol(t_transport_class)
-        client = TCLIService.Client(protocol)
+        client = Client(protocol)
 
         req = ttypes.TGetOperationStatusReq(
             operationHandle=self.operation_handle,
             getProgressUpdate=False,
         )
         
+        EXPECTED_RETRIES = 2
+
         thrift_backend = ThriftBackend(
             "foobar",
             443,
             "path", [],
-            _retry_stop_after_attempts_count=2,
-            _retry_delay_max=4,
+            _retry_stop_after_attempts_count=EXPECTED_RETRIES,
+            _retry_delay_max=6,
             _retry_delay_min=0,
-            _retry_delay_default=3)
+            _retry_delay_default=0.1)
 
         with self.assertRaises(RequestError) as cm:
             thrift_backend.make_request(client.GetOperationStatus, req)
 
         self.assertEqual(NoRetryReason.OUT_OF_ATTEMPTS.value, cm.exception.context["no-retry-reason"])
-        self.assertEqual('2/2', cm.exception.context["attempt"])
+        self.assertEqual(f'{EXPECTED_RETRIES}/{EXPECTED_RETRIES}', cm.exception.context["attempt"])
     
     @patch("thrift.transport.THttpClient.THttpClient")
     def test_make_request_wont_retry_if_headers_not_present(self, t_transport_class):


### PR DESCRIPTION
## Description

Currently, we only retry attempts that returned a code 429 or 503 and include a `Retry-After` header. This pull request refactors the `extract_retry_delay` code to allow retrying of `GetOperationStatus` requests even if `Retry-After` header was not sent from the server. The configured retry policy is still honoured with regard to maximum attempts and max retry duration.

## Background

The reason we only retry 429 and 503 responses today is because retries must be idempotent. Otherwise the connector could cause unexpected or harmful consequences (data loss, excess resource utilisation etc.)

We know that 429/503 responses are idempotent because the attempt was halted before the server could execute it, regardless if the attempted operation was itself idempotent. 

By the same logic we know that `GetOperationStatus` is idempotent. No matter how many times it runs it does not change data on the server. Therefore it can be safely added to the allow list. 