### PR TITLE
Indicate that Python 3.10 is not supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ You are welcome to file an issue here for general use cases. You can also contac
 
 ## Requirements
 
-Python 3.7 or above is required.
+A development machine running Python >=3.7, <3.10.
 
 ## Documentation
 


### PR DESCRIPTION
Alert users about needing Python 3.7, 3.8, or 3.9 until https://github.com/databricks/databricks-sql-python/issues/26 is fixed.