### PR TITLE
Update changelog and bump to v2.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 2.0.x (Unreleased)
 
+## 2.0.4 (2022-08-17)
+
+- Add support for Python 3.10
+- Add unit test matrix for supported Python versions
+
 ## 2.0.3 (2022-08-05)
 
 - Add retry logic for `GetOperationStatus` requests that fail with an `OSError`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Add support for Python 3.10
 - Add unit test matrix for supported Python versions
 
+Huge thanks to @dbaxa for contributing this change!
+
 ## 2.0.3 (2022-08-05)
 
 - Add retry logic for `GetOperationStatus` requests that fail with an `OSError`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "databricks-sql-connector"
-version = "2.0.4-dev"
+version = "2.0.4"
 description = "Databricks SQL Connector for Python"
 authors = ["Databricks <databricks-sql-connector-maintainers@databricks.com>"]
 license = "Apache-2.0"

--- a/src/databricks/sql/__init__.py
+++ b/src/databricks/sql/__init__.py
@@ -28,7 +28,7 @@ DATETIME = DBAPITypeObject("timestamp")
 DATE = DBAPITypeObject("date")
 ROWID = DBAPITypeObject()
 
-__version__ = "2.0.4-dev"
+__version__ = "2.0.4"
 USER_AGENT_NAME = "PyDatabricksSqlConnector"
 
 # These two functions are pyhive legacy


### PR DESCRIPTION
Preparing to release `v2.0.4` with Python 3.10 support to pypi.