### PR TITLE
On Pypi, display the "Project Links" sidebar.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,10 @@ pytest = "^7.1.2"
 mypy = "^0.950"
 black = "^22.3.0"
 
+[tool.poetry.urls]
+"Homepage" = "https://github.com/databricks/databricks-sql-python"
+"Bug Tracker" = "https://github.com/databricks/databricks-sql-python/issues"
+
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
This PR makes it so our bug tracker and homepage are explicitly called out on the Pypi listing. I tested by pushing to test.pypi.org. It looks like this:

<img width="328" alt="CleanShot 2022-08-17 at 14 47 28@2x" src="https://user-images.githubusercontent.com/17067911/185229355-6521e8e9-6841-4d06-b80f-7fcf0c2c27a2.png">

You can see the sample here: https://test.pypi.org/project/databricks-sql-connector/2.0.5.dev1/

**note**: test.pypi.org is periodically erased and rebuilt so the above link may break in the future.