### PR TITLE
Bump version to 2.0.5 and update CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 2.0.x (Unreleased)
 
+## 2.0.5 (2022-08-23)
+
+- Fix: closing a connection now closes any open cursors from that connection at the server
+- Other: Add project links to pyproject.toml (helpful for visitors from PyPi)
+
 ## 2.0.4 (2022-08-17)
 
 - Add support for Python 3.10

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "databricks-sql-connector"
-version = "2.0.5-dev"
+version = "2.0.5"
 description = "Databricks SQL Connector for Python"
 authors = ["Databricks <databricks-sql-connector-maintainers@databricks.com>"]
 license = "Apache-2.0"

--- a/src/databricks/sql/__init__.py
+++ b/src/databricks/sql/__init__.py
@@ -28,7 +28,7 @@ DATETIME = DBAPITypeObject("timestamp")
 DATE = DBAPITypeObject("date")
 ROWID = DBAPITypeObject()
 
-__version__ = "2.0.5-dev"
+__version__ = "2.0.5"
 USER_AGENT_NAME = "PyDatabricksSqlConnector"
 
 # These two functions are pyhive legacy


### PR DESCRIPTION
## Description

This prepares for the `2.0.5` release. You can see an example of this release on test.pypi.org here:

https://test.pypi.org/project/databricks-sql-connector/2.0.5/