### PR TITLE
fix dco issue

### DIFF
--- a/.github/workflows/dco-check.yml
+++ b/.github/workflows/dco-check.yml
@@ -2,6 +2,14 @@ name: DCO Check
 
 on: [pull_request]
 
+require:
+  members: false
+
+allowRemediationCommits:
+  individual: true
+  thirdParty: true
+
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/dco-check.yml
+++ b/.github/workflows/dco-check.yml
@@ -9,7 +9,6 @@ allowRemediationCommits:
   individual: true
   thirdParty: true
 
-
 jobs:
   check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Signed-off-by: Moe Derakhshani <moe.derakhshani@databricks.com>

my [OAuth PR](https://github.com/databricks/databricks-sql-python/runs/8005844758?check_suite_focus=true) is blocked due to dco validation (following error):
<img width="1202" alt="Screen Shot 2022-08-25 at 12 05 40 PM" src="https://user-images.githubusercontent.com/22279672/186747897-c9d57586-366f-41f9-aa66-609f2bf3911f.png">



We should try to avoid running dco for internal databricks employees:
I am trying to relax the validation based on this guideline:
https://github.com/dcoapp/app/blob/main/README.md#skipping-sign-off-for-organization-members

and here:
https://stackoverflow.com/questions/62969381/is-it-in-line-with-the-dco-that-a-github-sign-off-needs-and-publishes-full-name