### PR TITLE
Test parameter escaping

### DIFF
--- a/src/databricks/sql/client.py
+++ b/src/databricks/sql/client.py
@@ -7,7 +7,7 @@ from databricks.sql import __version__
 from databricks.sql import *
 from databricks.sql.exc import OperationalError
 from databricks.sql.thrift_backend import ThriftBackend
-from databricks.sql.utils import ExecuteResponse, ParamEscaper
+from databricks.sql.utils import ExecuteResponse, ParamEscaper, inject_parameters
 from databricks.sql.types import Row
 from databricks.sql.auth.auth import get_python_sql_connector_auth_provider
 from databricks.sql.experimental.oauth_persistence import OAuthPersistence
@@ -309,7 +309,9 @@ class Cursor:
         :returns self
         """
         if parameters is not None:
-            operation = operation % self.escaper.escape_args(parameters)
+            operation = inject_parameters(
+                operation, self.escaper.escape_args(parameters)
+            )
 
         self._check_not_closed()
         self._close_and_clear_active_result_set()

--- a/src/databricks/sql/utils.py
+++ b/src/databricks/sql/utils.py
@@ -146,7 +146,7 @@ class ParamEscaper:
         # This is good enough when backslashes are literal, newlines are just followed, and the way
         # to escape a single quote is to put two single quotes.
         # (i.e. only special character is single quote)
-        return "'{}'".format(item.replace("'", "\'"))
+        return "'{}'".format(item.replace("'", "\\'"))
 
     def escape_sequence(self, item):
         l = map(str, map(self.escape_item, item))

--- a/src/databricks/sql/utils.py
+++ b/src/databricks/sql/utils.py
@@ -2,7 +2,7 @@ from collections import namedtuple, OrderedDict
 from collections.abc import Iterable
 import datetime
 from enum import Enum
-
+from typing import Dict
 import pyarrow
 
 
@@ -172,3 +172,7 @@ class ParamEscaper:
             return self.escape_datetime(item, self._DATE_FORMAT)
         else:
             raise exc.ProgrammingError("Unsupported object {}".format(item))
+
+
+def inject_parameters(operation: str, parameters: Dict[str, str]):
+    return operation % parameters

--- a/src/databricks/sql/utils.py
+++ b/src/databricks/sql/utils.py
@@ -146,7 +146,7 @@ class ParamEscaper:
         # This is good enough when backslashes are literal, newlines are just followed, and the way
         # to escape a single quote is to put two single quotes.
         # (i.e. only special character is single quote)
-        return "'{}'".format(item.replace('\\','\\\\' ).replace("'", "\\'"))
+        return "'{}'".format(item.replace("\\", "\\\\").replace("'", "\\'"))
 
     def escape_sequence(self, item):
         l = map(str, map(self.escape_item, item))

--- a/src/databricks/sql/utils.py
+++ b/src/databricks/sql/utils.py
@@ -146,7 +146,7 @@ class ParamEscaper:
         # This is good enough when backslashes are literal, newlines are just followed, and the way
         # to escape a single quote is to put two single quotes.
         # (i.e. only special character is single quote)
-        return "'{}'".format(item.replace("'", "\\'"))
+        return "'{}'".format(item.replace('\\','\\\\' ).replace("'", "\\'"))
 
     def escape_sequence(self, item):
         l = map(str, map(self.escape_item, item))

--- a/src/databricks/sql/utils.py
+++ b/src/databricks/sql/utils.py
@@ -146,7 +146,7 @@ class ParamEscaper:
         # This is good enough when backslashes are literal, newlines are just followed, and the way
         # to escape a single quote is to put two single quotes.
         # (i.e. only special character is single quote)
-        return "'{}'".format(item.replace("'", "''"))
+        return "'{}'".format(item.replace("'", "\'"))
 
     def escape_sequence(self, item):
         l = map(str, map(self.escape_item, item))

--- a/tests/unit/test_param_escaper.py
+++ b/tests/unit/test_param_escaper.py
@@ -24,11 +24,13 @@ class TestIndividualFormatters(object):
 
         assert pe.escape_string("golly bob howdy") == "'golly bob howdy'"
 
-    def test_escape_string_that_includes_quotes(self):
-        # Databricks queries support just one special character: a single quote mark
-        # These are escaped by doubling: 
+    def test_escape_string_that_includes_single_quotes(self):
         # e.g. INPUT: his name was 'robert palmer'
         # e.g. OUTPUT: 'his name was ''robert palmer'''
+
+        assert pe.escape_string("his name was 'robert palmer'") == "'his name was ''robert palmer'''"
+
+    def test_escape_string_that_includes_special_characters(self):
 
         assert pe.escape_string("his name was 'robert palmer'") == "'his name was ''robert palmer'''"
 

--- a/tests/unit/test_param_escaper.py
+++ b/tests/unit/test_param_escaper.py
@@ -1,0 +1,108 @@
+from datetime import date, datetime
+import unittest, pytest
+
+from databricks.sql.utils import ParamEscaper, inject_parameters
+
+pe = ParamEscaper()
+
+class TestIndividualFormatters(object):
+
+    # Test individual type escapers
+    def test_escape_number_integer(self):
+        """This behaviour falls back to Python's default string formatting of numbers
+        """
+        assert pe.escape_number(100) == 100
+
+    def test_escape_number_float(self):
+        """This behaviour falls back to Python's default string formatting of numbers
+        """
+        assert pe.escape_number(100.1234) == 100.1234
+
+    def test_escape_string_normal(self):
+        """
+        """
+
+        assert pe.escape_string("golly bob howdy") == "'golly bob howdy'"
+
+    def test_escape_string_that_includes_quotes(self):
+        # Databricks queries support just one special character: a single quote mark
+        # These are escaped by doubling: 
+        # e.g. INPUT: his name was 'robert palmer'
+        # e.g. OUTPUT: 'his name was ''robert palmer'''
+
+        assert pe.escape_string("his name was 'robert palmer'") == "'his name was ''robert palmer'''"
+
+    def test_escape_date_time(self):
+        INPUT = datetime(1991,8,3,21,55)
+        OUTPUT = "1991-08-03 21:55:00"
+        assert pe.escape_datetime(INPUT, OUTPUT)
+
+    def test_escape_date(self):
+        INPUT = date(1991,8,3)
+        OUTPUT = "1991-08-03"
+        assert pe.escape_datetime(INPUT, OUTPUT)
+
+    def test_escape_sequence_integer(self):
+        assert pe.escape_sequence([1,2,3,4]) == "(1,2,3,4)"
+
+    def test_escape_sequence_float(self):
+        assert pe.escape_sequence([1.1,2.2,3.3,4.4]) == "(1.1,2.2,3.3,4.4)"
+
+    def test_escape_sequence_string(self):
+        assert pe.escape_sequence(
+            ["his", "name", "was", "robert", "palmer"]) == \
+            "('his','name','was','robert','palmer')"
+
+    def test_escape_sequence_sequence_of_strings(self):
+        # This is not valid SQL.
+        INPUT = [["his", "name"], ["was", "robert"], ["palmer"]]
+        OUTPUT = "(('his','name'),('was','robert'),('palmer'))"
+
+        assert pe.escape_sequence(INPUT) == OUTPUT
+
+
+class TestFullQueryEscaping(object):
+
+    def test_simple(self):
+
+        INPUT = """
+        SELECT
+          field1,
+          field2,
+          field3
+        FROM
+          table
+        WHERE
+          field1 = %(param1)s
+        """
+
+        OUTPUT = """
+        SELECT
+          field1,
+          field2,
+          field3
+        FROM
+          table
+        WHERE
+          field1 = ';DROP ALL TABLES'
+        """
+
+        args = {"param1": ";DROP ALL TABLES"}
+
+        assert inject_parameters(INPUT, pe.escape_args(args)) == OUTPUT
+
+    @unittest.skipUnless(False, "Thrift server supports native parameter binding.")
+    def test_only_bind_in_where_clause(self):
+
+        INPUT = """
+        SELECT
+          %(field)s,
+          field2,
+          field3
+        FROM table
+        """
+
+        args = {"field": "Some Value"}
+
+        with pytest.raises(Exception):
+            inject_parameters(INPUT, pe.escape_args(args))

--- a/tests/unit/test_param_escaper.py
+++ b/tests/unit/test_param_escaper.py
@@ -74,13 +74,15 @@ class TestIndividualFormatters(object):
 
     def test_escape_date_time(self):
         INPUT = datetime(1991,8,3,21,55)
-        OUTPUT = "1991-08-03 21:55:00"
-        assert pe.escape_datetime(INPUT, OUTPUT)
+        FORMAT = "%Y-%m-%d %H:%M:%S"
+        OUTPUT = "'1991-08-03 21:55:00'"
+        assert pe.escape_datetime(INPUT, FORMAT) == OUTPUT
 
     def test_escape_date(self):
         INPUT = date(1991,8,3)
-        OUTPUT = "1991-08-03"
-        assert pe.escape_datetime(INPUT, OUTPUT)
+        FORMAT = "%Y-%m-%d"
+        OUTPUT = "'1991-08-03'"
+        assert pe.escape_datetime(INPUT, FORMAT) == OUTPUT
 
     def test_escape_sequence_integer(self):
         assert pe.escape_sequence([1,2,3,4]) == "(1,2,3,4)"

--- a/tests/unit/test_param_escaper.py
+++ b/tests/unit/test_param_escaper.py
@@ -24,15 +24,41 @@ class TestIndividualFormatters(object):
 
         assert pe.escape_string("golly bob howdy") == "'golly bob howdy'"
 
-    def test_escape_string_that_includes_single_quotes(self):
-        # e.g. INPUT: his name was 'robert palmer'
-        # e.g. OUTPUT: 'his name was ''robert palmer'''
-
-        assert pe.escape_string("his name was 'robert palmer'") == "'his name was ''robert palmer'''"
-
     def test_escape_string_that_includes_special_characters(self):
+      """Tests for how special characters are treated.
 
-        assert pe.escape_string("his name was 'robert palmer'") == "'his name was ''robert palmer'''"
+      When passed a string, the `escape_string` method wraps it in single quotes
+      and escapes any special characters with a back stroke (\)
+
+      Example:
+
+      IN : his name was 'robert palmer'
+      OUT: 'his name was \'robert palmer\''
+      """
+
+      # Testing for the presence of these characters: '"/\😂
+
+      assert pe.escape_string("his name was 'robert palmer'") == "'his name was \'robert palmer\''"
+
+      # These two tests represent the same user input in the several ways it can be written in Python
+      # Each argument to `escape_string` evaluates to the same bytes. But Python lets us write it differently.
+      assert pe.escape_string("his name was \"robert palmer\"") == "'his name was \"robert palmer\"'"
+      assert pe.escape_string('his name was "robert palmer"') == "'his name was \"robert palmer\"'"
+      assert pe.escape_string('his name was {}'.format('"robert palmer"')) == "'his name was \"robert palmer\"'"
+
+      assert pe.escape_string("his name was robert / palmer") == "'his name was robert / palmer'"
+
+      # If you need to include a single backslash, use an r-string to prevent Python from raising a
+      # DeprecationWarning for an invalid escape sequence
+      assert pe.escape_string(r"his name was robert \/ palmer") == "'his name was robert \\/ palmer'"
+      assert pe.escape_string("his name was robert \\ palmer") == "'his name was robert \\ palmer'"
+      assert pe.escape_string("his name was robert \\\\ palmer") == "'his name was robert \\\\ palmer'"
+
+      assert pe.escape_string("his name was robert palmer 😂") == "'his name was robert palmer 😂'"
+
+      # Adding the test from PR #56 to prove escape behaviour
+
+      assert pe.escape_string("you're") == "'you\'re'"
 
     def test_escape_date_time(self):
         INPUT = datetime(1991,8,3,21,55)

--- a/tests/unit/test_param_escaper.py
+++ b/tests/unit/test_param_escaper.py
@@ -40,7 +40,7 @@ class TestIndividualFormatters(object):
 
       assert pe.escape_string("his name was 'robert palmer'") == r"'his name was \'robert palmer\''"
 
-      # These two tests represent the same user input in the several ways it can be written in Python
+      # These tests represent the same user input in the several ways it can be written in Python
       # Each argument to `escape_string` evaluates to the same bytes. But Python lets us write it differently.
       assert pe.escape_string("his name was \"robert palmer\"") == "'his name was \"robert palmer\"'"
       assert pe.escape_string('his name was "robert palmer"') == "'his name was \"robert palmer\"'"

--- a/tests/unit/test_param_escaper.py
+++ b/tests/unit/test_param_escaper.py
@@ -38,7 +38,7 @@ class TestIndividualFormatters(object):
 
       # Testing for the presence of these characters: '"/\😂
 
-      assert pe.escape_string("his name was 'robert palmer'") == "'his name was \'robert palmer\''"
+      assert pe.escape_string("his name was 'robert palmer'") == r"'his name was \'robert palmer\''"
 
       # These two tests represent the same user input in the several ways it can be written in Python
       # Each argument to `escape_string` evaluates to the same bytes. But Python lets us write it differently.
@@ -46,19 +46,31 @@ class TestIndividualFormatters(object):
       assert pe.escape_string('his name was "robert palmer"') == "'his name was \"robert palmer\"'"
       assert pe.escape_string('his name was {}'.format('"robert palmer"')) == "'his name was \"robert palmer\"'"
 
-      assert pe.escape_string("his name was robert / palmer") == "'his name was robert / palmer'"
+      assert pe.escape_string("his name was robert / palmer") == r"'his name was robert / palmer'"
 
       # If you need to include a single backslash, use an r-string to prevent Python from raising a
       # DeprecationWarning for an invalid escape sequence
-      assert pe.escape_string(r"his name was robert \/ palmer") == "'his name was robert \\/ palmer'"
-      assert pe.escape_string("his name was robert \\ palmer") == "'his name was robert \\ palmer'"
-      assert pe.escape_string("his name was robert \\\\ palmer") == "'his name was robert \\\\ palmer'"
+      assert pe.escape_string("his name was robert \\/ palmer") == r"'his name was robert \\/ palmer'"
+      assert pe.escape_string("his name was robert \\ palmer") == r"'his name was robert \\ palmer'"
+      assert pe.escape_string("his name was robert \\\\ palmer") == r"'his name was robert \\\\ palmer'"
 
-      assert pe.escape_string("his name was robert palmer 😂") == "'his name was robert palmer 😂'"
+      assert pe.escape_string("his name was robert palmer 😂") == r"'his name was robert palmer 😂'"
 
       # Adding the test from PR #56 to prove escape behaviour
 
-      assert pe.escape_string("you're") == "'you\'re'"
+      assert pe.escape_string("you're") == r"'you\'re'"
+
+      # Adding this test from #51 to prove escape behaviour when the target string involves repeated SQL escape chars
+      assert pe.escape_string("cat\\'s meow") == r"'cat\\\'s meow'"
+
+      # Tests from the docs: https://docs.databricks.com/sql/language-manual/data-types/string-type.html
+
+      assert pe.escape_string('Spark') == "'Spark'"
+      assert pe.escape_string("O'Connell") == r"'O\'Connell'"
+      assert pe.escape_string("Some\\nText") == r"'Some\\nText'"
+      assert pe.escape_string("Some\\\\nText") == r"'Some\\\\nText'"
+      assert pe.escape_string("서울시") == "'서울시'"
+      assert pe.escape_string("\\\\") == r"'\\\\'"
 
     def test_escape_date_time(self):
         INPUT = datetime(1991,8,3,21,55)


### PR DESCRIPTION
## Background

`databricks-sql-connector` adheres to PEP-249 which defines a parameter binding API. For supported databases, parameter binding avoids SQL-injection vulnerabilities because parameter values are always escaped at runtime. The hive thrift server doesn't support safe parameter binding (yet!). This means that all queries are passed as strings and are therefore vulnerable to SQL-injection. It's the client's responsibility to safely handle parameterised input before calling `cursor.execute(<some query text>)`.

`databricks-sql-connector` automatically sanitises inputs that follow the PEP-249 calling convention. This pull request adds unit tests to demonstrate the sanitisation behaviour. It also sets a baseline we can use for testing server-side parameter binding once it's supported by the Databricks runtime.

In a follow-up PR, I will add examples that use the PEP-249 parameter binding interface. Once Databricks runtime supports proper server-side binding, users of `databricks-sql-connector` will benefit from its enhanced safety "for free", without needing to rewrite their client code.