### PR TITLE
Github workflows: run checks on pull requests from forks

### DIFF
--- a/.github/workflows/code-quality-checks.yml
+++ b/.github/workflows/code-quality-checks.yml
@@ -1,5 +1,5 @@
 name: Code Quality Checks
-on: [push]
+on: [pull_request, push]
 jobs:
   run-unit-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

Prior to this change, the unit test workflow only runs when changes were `push`'d to a branch of the main repository. What we want instead is to run the unit tests for any pull request, including from forks.