### PR TITLE
Automate deploys to Pypi

### DIFF
--- a/.github/workflows/publish-test.yml
+++ b/.github/workflows/publish-test.yml
@@ -1,0 +1,64 @@
+name: Publish to PyPI [Test]
+on: [push]
+jobs:
+  test-pypi:
+    name: Create patch version number and push to test-pypi
+    runs-on: ubuntu-latest
+    steps:
+      #----------------------------------------------
+      #       check-out repo and set-up python
+      #----------------------------------------------
+      - name: Check out repository
+        uses: actions/checkout@v2
+      - name: Set up python
+        id: setup-python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      #----------------------------------------------
+      #  -----  install & configure poetry  -----
+      #----------------------------------------------
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+        with:
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+          installer-parallel: true
+      #----------------------------------------------
+      #       load cached venv if cache exists
+      #----------------------------------------------
+      - name: Load cached venv
+        id: cached-poetry-dependencies
+        uses: actions/cache@v2
+        with:
+          path: .venv
+          key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ github.event.repository.name }}-${{ hashFiles('**/poetry.lock') }}
+      #----------------------------------------------
+      # install dependencies if cache does not exist
+      #----------------------------------------------
+      - name: Install dependencies
+        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
+        run: poetry install --no-interaction --no-root
+      #----------------------------------------------
+      # Get the current version and increment it (test-pypi requires a unique version number)
+      #----------------------------------------------
+      - name: Get next version
+        uses: reecetech/version-increment@2022.2.4
+        id: version
+        with:
+          scheme: semver
+          increment: patch
+      #----------------------------------------------
+      # Tell poetry to update the version number
+      #----------------------------------------------
+      - name: Update pyproject.toml
+        run: poetry version ${{ steps.version.outputs.major-version }}.${{ steps.version.outputs.minor-version }}.dev$(date +%s)
+      #----------------------------------------------
+      # Attempt push to test-pypi
+      #----------------------------------------------
+      - name: Build and publish to pypi
+        uses: JRubics/poetry-publish@v1.10
+        with:
+          pypi_token: ${{ secrets.TEST_PYPI_TOKEN }}
+          repository_name: "testpypi"
+          repository_url: "https://test.pypi.org/legacy/"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,64 @@
+name: Publish to PyPI [Production]
+on:
+  release:
+    types: [published]
+jobs:
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+    steps:
+      #----------------------------------------------
+      #       check-out repo and set-up python
+      #----------------------------------------------
+      - name: Check out repository
+        uses: actions/checkout@v2
+      - name: Set up python
+        id: setup-python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      #----------------------------------------------
+      #  -----  install & configure poetry  -----
+      #----------------------------------------------
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+        with:
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+          installer-parallel: true
+      #----------------------------------------------
+      #       load cached venv if cache exists
+      #----------------------------------------------
+      - name: Load cached venv
+        id: cached-poetry-dependencies
+        uses: actions/cache@v2
+        with:
+          path: .venv
+          key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ github.event.repository.name }}-${{ hashFiles('**/poetry.lock') }}
+      #----------------------------------------------
+      # install dependencies if cache does not exist
+      #----------------------------------------------
+      - name: Install dependencies
+        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
+        run: poetry install --no-interaction --no-root
+      #------------------------------------------------------------------------------------------------
+      # Here we use version-increment to fetch the latest tagged version (we won't increment it though)
+      #------------------------------------------------------------------------------------------------
+      - name: Get next version
+        uses: reecetech/version-increment@2022.2.4
+        id: version
+        with:
+          scheme: semver
+          increment: patch
+      #-----------------------------------------------------------------------------
+      # Tell poetry to use the `current-version` that was found by the previous step
+      #-----------------------------------------------------------------------------
+      - name: Update pyproject.toml
+        run: poetry version ${{ steps.version.outputs.current-version }}
+      #----------------------------------------------
+      # Attempt push to test-pypi
+      #----------------------------------------------
+      - name: Build and publish to pypi
+        uses: JRubics/poetry-publish@v1.10
+        with:
+          pypi_token: ${{ secrets.PROD_PYPI_TOKEN }}


### PR DESCRIPTION
Borrowing the github actions from databricks/databricks-sql-cli.

This introduces two GitHub actions:
- test publish will push a new experimental version to test.pypi.org for every pull request. This verifies that a successful publish is possible as of the tip of that branch.
- publish will new push a new version to pypi.org whenever we cut a new GitHub release (using the /releases sub-path of this repository). The version number will be the highest tagged version.