### PR TITLE
Bump version to 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Release History
 
-## 2.0.x (Unreleased)
+## 2.1.x (Unreleased)
+
+## 2.1.0 (2022-09-30)
+
+- Introduce experimental OAuth support while Bring Your Own IDP is in Public Preview on AWS
+- Add functional examples
 
 ## 2.0.5 (2022-08-23)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "databricks-sql-connector"
-version = "2.0.5"
+version = "2.1.0"
 description = "Databricks SQL Connector for Python"
 authors = ["Databricks <databricks-sql-connector-maintainers@databricks.com>"]
 license = "Apache-2.0"

--- a/src/databricks/sql/__init__.py
+++ b/src/databricks/sql/__init__.py
@@ -28,7 +28,7 @@ DATETIME = DBAPITypeObject("timestamp")
 DATE = DBAPITypeObject("date")
 ROWID = DBAPITypeObject()
 
-__version__ = "2.0.5"
+__version__ = "2.1.0"
 USER_AGENT_NAME = "PyDatabricksSqlConnector"
 
 # These two functions are pyhive legacy


### PR DESCRIPTION
Incorporates the new examples directory and experimental OAuth support.