### PR TITLE
Add none check on _oauth_persistence in DatabricksOAuthProvider

### DIFF
--- a/src/databricks/sql/auth/authenticators.py
+++ b/src/databricks/sql/auth/authenticators.py
@@ -88,9 +88,11 @@ class DatabricksOAuthProvider(AuthProvider):
                 )
                 self._access_token = access_token
                 self._refresh_token = refresh_token
-                self._oauth_persistence.persist(
-                    self._hostname, OAuthToken(access_token, refresh_token)
-                )
+
+                if self._oauth_persistence:
+                    self._oauth_persistence.persist(
+                        self._hostname, OAuthToken(access_token, refresh_token)
+                    )
         except Exception as e:
             logging.error(f"unexpected error in oauth initialization", e, exc_info=True)
             raise e


### PR DESCRIPTION
Add `None` check on `_oauth_persistence` in `DatabricksOAuthProvider` to avoid app crash when `_oauth_persistence` is `None`.