### PR TITLE
Bump version to 2.3.0 and update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Release History
 
-## 2.2.x (Unreleased)
+## 2.3.x (Unreleased)
+
+## 2.3.0 (2023-01-10)
+
+- Support staging ingestion commands for DBR 12+
 
 ## 2.2.2 (2023-01-03)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "databricks-sql-connector"
-version = "2.2.2"
+version = "2.3.0"
 description = "Databricks SQL Connector for Python"
 authors = ["Databricks <databricks-sql-connector-maintainers@databricks.com>"]
 license = "Apache-2.0"

--- a/src/databricks/sql/__init__.py
+++ b/src/databricks/sql/__init__.py
@@ -28,7 +28,7 @@ DATETIME = DBAPITypeObject("timestamp")
 DATE = DBAPITypeObject("date")
 ROWID = DBAPITypeObject()
 
-__version__ = "2.2.2"
+__version__ = "2.3.0"
 USER_AGENT_NAME = "PyDatabricksSqlConnector"
 
 # These two functions are pyhive legacy


### PR DESCRIPTION
Per semantic versioning: 

> MINOR version when you add functionality in a backwards compatible manner

This release adds support for staging ingestion commands in a backwards compatible fashion.