### PR TITLE
[PECO-244] Make http proxies work

### DIFF
--- a/src/databricks/sql/auth/thrift_http_client.py
+++ b/src/databricks/sql/auth/thrift_http_client.py
@@ -39,7 +39,6 @@ class THttpClient(thrift.transport.THttpClient.THttpClient):
 
     @staticmethod
     def basic_proxy_auth_header(proxy):
-        logger.warning("Hey I was called!")
         if proxy is None or not proxy.username:
             return None
         ap = "%s:%s" % (

--- a/src/databricks/sql/auth/thrift_http_client.py
+++ b/src/databricks/sql/auth/thrift_http_client.py
@@ -1,7 +1,10 @@
 import logging
 from typing import Dict
 
+
 import thrift
+
+import urllib.parse, six, base64
 
 logger = logging.getLogger(__name__)
 
@@ -33,3 +36,15 @@ class THttpClient(thrift.transport.THttpClient.THttpClient):
         self._headers = headers
         self.setCustomHeaders(self._headers)
         super().flush()
+
+    @staticmethod
+    def basic_proxy_auth_header(proxy):
+        logger.warning("Hey I was called!")
+        if proxy is None or not proxy.username:
+            return None
+        ap = "%s:%s" % (
+            urllib.parse.unquote(proxy.username),
+            urllib.parse.unquote(proxy.password),
+        )
+        cr = base64.b64encode(ap.encode()).strip()
+        return "Basic " + six.ensure_str(cr)

--- a/tests/unit/test_thrift_backend.py
+++ b/tests/unit/test_thrift_backend.py
@@ -143,6 +143,21 @@ class ThriftBackendTestSuite(unittest.TestCase):
         ThriftBackend("foo", 123, "bar", [("header", "value")], auth_provider=AuthProvider())
         t_http_client_class.return_value.setCustomHeaders.assert_called_with({"header": "value"})
 
+    def test_proxy_headers_are_set(self):
+
+        from databricks.sql.auth.thrift_http_client import THttpClient
+        from urllib.parse import urlparse
+
+        fake_proxy_spec = "https://someuser:somepassword@8.8.8.8:12340"
+        parsed_proxy = urlparse(fake_proxy_spec)
+        
+        try:
+            result = THttpClient.basic_proxy_auth_header(parsed_proxy)
+        except TypeError as e:
+            assert False
+
+        assert isinstance(result, type(str()))
+
     @patch("databricks.sql.auth.thrift_http_client.THttpClient")
     @patch("databricks.sql.thrift_backend.create_default_context")
     def test_tls_cert_args_are_propagated(self, mock_create_default_context, t_http_client_class):


### PR DESCRIPTION
## Description

This fix makes the connector work with standard proxies using Python's [environment variable configuration spec](https://docs.python.org/3/library/urllib.request.html#urllib.request.getproxies). This fix is taken directly from @pspeter's pull request against the `thrift` library here: https://github.com/apache/thrift/pull/2565

Since we are already overriding the `THttpClient`, we don't need to wait for the fix to merge into `thrift` upstream to implement it locally.


## Related Tickets & Documents

Closes https://github.com/databricks/databricks-sql-python/issues/22
