### PR TITLE
[ES-556959] Add pkgutil-style for the package

### DIFF
--- a/src/databricks/__init__.py
+++ b/src/databricks/__init__.py
@@ -1,0 +1,4 @@
+# https://packaging.python.org/guides/packaging-namespace-packages/#pkgutil-style-namespace-packages
+# This file should only contain the following line. Otherwise other sub-packages databricks.* namespace
+# may not be importable.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)


### PR DESCRIPTION
Since the package is under databricks namespace. pip install this package will cause issue importing other packages under the same namespace like automl and feature store.

Adding `pkgutil` style to resolve the issue.