### PR TITLE
Update example in docstring so query output is valid Spark SQL

### DIFF
--- a/src/databricks/sql/client.py
+++ b/src/databricks/sql/client.py
@@ -457,9 +457,9 @@ class Cursor:
         Execute a query and wait for execution to complete.
         Parameters should be given in extended param format style: %(...)<s|d|f>.
         For example:
-            operation = "SELECT * FROM %(table_name)s"
-            parameters = {"table_name": "my_table_name"}
-            Will result in the query "SELECT * FROM 'my_table_name' being sent to the server
+            operation = "SELECT * FROM table WHERE field = %(some_value)s"
+            parameters = {"some_value": "foo"}
+            Will result in the query "SELECT * FROM table WHERE field = 'foo' being sent to the server
         :returns self
         """
         if parameters is not None:


### PR DESCRIPTION
## Description

This is a no-code change. It updates the docstring for `client.execute()` to show a valid query output.

Our parameter escaper wraps all strings in single quotes (`'`) which can't be used for table names. The example prior to this commit _is how the escaper would render the input strings based on the parameter provided_, but the output is not valid Spark SQL because table names cannot be string literals.

## Related Tickets and Documents

Closes #94 