### PR TITLE
Bump version to 2.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## 2.4.x (Unreleased)
 
+## 2.4.1 (2023-03-21)
+
+- Less strict numpy and pyarrow dependencies
+- Update examples in README to use security best practices
+- Update docstring for client.execute() for clarity
+
 ## 2.4.0 (2023-02-21)
 
 - Improve compatibility when installed alongside other Databricks namespace Python packages

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "databricks-sql-connector"
-version = "2.4.0"
+version = "2.4.1"
 description = "Databricks SQL Connector for Python"
 authors = ["Databricks <databricks-sql-connector-maintainers@databricks.com>"]
 license = "Apache-2.0"

--- a/src/databricks/sql/__init__.py
+++ b/src/databricks/sql/__init__.py
@@ -28,7 +28,7 @@ DATETIME = DBAPITypeObject("timestamp")
 DATE = DBAPITypeObject("date")
 ROWID = DBAPITypeObject()
 
-__version__ = "2.4.0"
+__version__ = "2.4.1"
 USER_AGENT_NAME = "PyDatabricksSqlConnector"
 
 # These two functions are pyhive legacy


### PR DESCRIPTION
Per the sermver.org spec, updating the projects dependencies is considered a backwards-compatible change.

https: //semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api