### PR TITLE
Retry on connection timeout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -202,3 +202,6 @@ cython_debug/
 databricks_sql_connector.egg-info/
 dist/
 build/
+
+# vs code stuff
+.vscode


### PR DESCRIPTION
A lot of the time we see the error `[Errno 110] Connection timed out`. This happens a lot in Azure, particularly. In this PR I make it a retryable error as it is safe