### PR TITLE
Fix SQLAlchemy timestamp converter + docs

### DIFF
--- a/examples/sqlalchemy.py
+++ b/examples/sqlalchemy.py
@@ -4,6 +4,8 @@ It aims to be a drop-in replacement for the crflynn/sqlalchemy-databricks projec
 more of the Databricks API, particularly around table reflection, Alembic usage, and data
 ingestion with pandas.
 
+Expected URI format is: databricks+thrift://token:dapi***@***.cloud.databricks.com?http_path=/sql/***
+
 Because of the extent of SQLAlchemy's capabilities it isn't feasible to provide examples of every
 usage in a single script, so we only provide a basic one here. More examples are found in our test
 suite at tests/e2e/sqlalchemy/test_basic.py and in the PR that implements this change: 

--- a/src/databricks/sqlalchemy/dialect/__init__.py
+++ b/src/databricks/sqlalchemy/dialect/__init__.py
@@ -59,7 +59,7 @@ class DatabricksDate(types.TypeDecorator):
     impl = types.DATE
 
     def process_result_value(self, value, dialect):
-        return processors.str_to_date(value)
+        return value
 
     def adapt(self, impltype, **kwargs):
         return self.impl

--- a/src/databricks/sqlalchemy/dialect/__init__.py
+++ b/src/databricks/sqlalchemy/dialect/__init__.py
@@ -47,7 +47,7 @@ class DatabricksTimestamp(types.TypeDecorator):
     impl = types.TIMESTAMP
 
     def process_result_value(self, value, dialect):
-        return processors.str_to_datetime(value)
+        return value
 
     def adapt(self, impltype, **kwargs):
         return self.impl


### PR DESCRIPTION
This is to unblock langchain work. Tests coming in subsequent PR.

Resolves the case of reading a table with a snippet like this:

```python
tables = Table("system.information_schema.tables", metadata_obj, autoload_with=db_engine)
cursor = db_engine.execute(select(tables))
cursor.fetchone()
```

Which would fail with this error:

```
ValueError: Couldn't parse datetime string 'datetime.datetime(2023, 1, 5, 19, 8, 2, 16000)' - value is not a string.
```

This happened because DatabricksTimestamp assumed that TIMESTAMP types were returned as strings from the thrift connector. However TIMESTAMPS are actually returned as `DateTime` objects, so calling `str_to_datetime` was superfluous and unecessary.

We missed this in the initial development because we didn't test for it. I will make a follow-up PR that adds proper type mapping tests that we can build-on as we continue development of the SQLA dialect.