### PR TITLE
sqlalchemy: support TINYINT type

### DIFF
--- a/src/databricks/sqlalchemy/dialect/__init__.py
+++ b/src/databricks/sqlalchemy/dialect/__init__.py
@@ -73,7 +73,10 @@ class TINYINT(types.Integer):
 
     Details about this type: https://docs.databricks.com/sql/language-manual/data-types/tinyint-type.html
     """
+
     __visit_name__ = "TINYINT"
+
+
 class DatabricksDialect(default.DefaultDialect):
     """This dialect implements only those methods required to pass our e2e tests"""
 

--- a/src/databricks/sqlalchemy/dialect/__init__.py
+++ b/src/databricks/sqlalchemy/dialect/__init__.py
@@ -65,6 +65,15 @@ class DatabricksDate(types.TypeDecorator):
         return self.impl
 
 
+class TINYINT(types.Integer):
+    """
+    A one-byte signed integer. Can represent any integer number in the range from -128 to 127.
+
+    Implementation copied from mssql dialect
+
+    Details about this type: https://docs.databricks.com/sql/language-manual/data-types/tinyint-type.html
+    """
+    __visit_name__ = "TINYINT"
 class DatabricksDialect(default.DefaultDialect):
     """This dialect implements only those methods required to pass our e2e tests"""
 
@@ -136,6 +145,7 @@ class DatabricksDialect(default.DefaultDialect):
         _type_map = {
             "boolean": types.Boolean,
             "smallint": types.SmallInteger,
+            "tinyint": TINYINT,
             "int": types.Integer,
             "bigint": types.BigInteger,
             "float": types.Float,

--- a/src/databricks/sqlalchemy/dialect/__init__.py
+++ b/src/databricks/sqlalchemy/dialect/__init__.py
@@ -74,6 +74,12 @@ class TINYINT(types.Integer):
     Details about this type: https://docs.databricks.com/sql/language-manual/data-types/tinyint-type.html
     """
     __visit_name__ = "TINYINT"
+
+from sqlalchemy.ext.compiler import compiles
+@compiles(TINYINT, "databricks")
+def compile_tinyint_databricks(type_, compiler, **kw):
+    return "TINYINT"
+
 class DatabricksDialect(default.DefaultDialect):
     """This dialect implements only those methods required to pass our e2e tests"""
 

--- a/src/databricks/sqlalchemy/dialect/__init__.py
+++ b/src/databricks/sqlalchemy/dialect/__init__.py
@@ -74,12 +74,6 @@ class TINYINT(types.Integer):
     Details about this type: https://docs.databricks.com/sql/language-manual/data-types/tinyint-type.html
     """
     __visit_name__ = "TINYINT"
-
-from sqlalchemy.ext.compiler import compiles
-@compiles(TINYINT, "databricks")
-def compile_tinyint_databricks(type_, compiler, **kw):
-    return "TINYINT"
-
 class DatabricksDialect(default.DefaultDialect):
     """This dialect implements only those methods required to pass our e2e tests"""
 

--- a/src/databricks/sqlalchemy/dialect/compiler.py
+++ b/src/databricks/sqlalchemy/dialect/compiler.py
@@ -1,6 +1,7 @@
 from sqlalchemy.sql import compiler
 
 
+
 class DatabricksTypeCompiler(compiler.GenericTypeCompiler):
     """Originally forked from pyhive"""
 
@@ -36,3 +37,6 @@ class DatabricksTypeCompiler(compiler.GenericTypeCompiler):
 
     def visit_DATETIME(self, type_):
         return "TIMESTAMP"
+    
+    def visit_TINYINT(self, type_):
+        return "TINYINT"

--- a/src/databricks/sqlalchemy/dialect/compiler.py
+++ b/src/databricks/sqlalchemy/dialect/compiler.py
@@ -1,7 +1,6 @@
 from sqlalchemy.sql import compiler
 
 
-
 class DatabricksTypeCompiler(compiler.GenericTypeCompiler):
     """Originally forked from pyhive"""
 
@@ -37,6 +36,6 @@ class DatabricksTypeCompiler(compiler.GenericTypeCompiler):
 
     def visit_DATETIME(self, type_):
         return "TIMESTAMP"
-    
+
     def visit_TINYINT(self, type_):
         return "TINYINT"

--- a/tests/e2e/sqlalchemy/test_basic.py
+++ b/tests/e2e/sqlalchemy/test_basic.py
@@ -157,7 +157,7 @@ def test_create_insert_drop_table_core(base, db_engine, metadata_obj: MetaData):
     metadata_obj.create_all()
 
     insert_stmt = insert(SampleTable).values(
-        name="Bim Adewunmi", episodes=6, some_bool=True, dollars=decimal.Decimal(125)
+        name="Bim Adewunmi", episodes=6, some_bool=True, dollars=decimal.Decimal(125), tiny_int=25
     )
 
     with db_engine.connect() as conn:

--- a/tests/e2e/sqlalchemy/test_basic.py
+++ b/tests/e2e/sqlalchemy/test_basic.py
@@ -4,6 +4,7 @@ from unittest import skipIf
 from sqlalchemy import create_engine, select, insert, Column, MetaData, Table
 from sqlalchemy.orm import declarative_base, Session
 from sqlalchemy.types import SMALLINT, Integer, BOOLEAN, String, DECIMAL, Date
+from databricks.sqlalchemy.dialect import TINYINT
 
 
 USER_AGENT_TOKEN = "PySQL e2e Tests"
@@ -150,6 +151,7 @@ def test_create_insert_drop_table_core(base, db_engine, metadata_obj: MetaData):
         Column("episodes", Integer),
         Column("some_bool", BOOLEAN),
         Column("dollars", DECIMAL(10, 2)),
+        Column("tiny_int", TINYINT)
     )
 
     metadata_obj.create_all()


### PR DESCRIPTION
## Description

Adds support for the Databricks `TINYINT` type.

To use the `TINYINT` users can:

```python
from databricks.sqlalchemy.dialect import TINYINT

SampleTable = Table(
    "some_table_name",
    metadata_obj,
    Column("small_number",TINYINT),
)
```

## Related Tickets & Documents

Closes #123

Related to #108 since we'll need to implement BINARY in a similar fashion.