### PR TITLE
Remove unused import for SQLAlchemy 2 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fix: Revised SQLAlchemy dialect and examples for compatibility with SQLAlchemy==1.3.x (#173)
 - Fix: oauth would fail if expired credentials appeared in ~/.netrc (#122)
 - Fix: Python HTTP proxies were broken after switch to urllib3 (#158)
+- Other: remove unused import in SQLAlchemy dialect
 - Other: Relax pandas dependency constraint to allow ^2.0.0 (#164)
 - Other: Connector now logs operation handle guids as hexadecimal instead of bytes (#170)
 - Other: test_socket_timeout_user_defined e2e test was broken (#144)

--- a/src/databricks/sqlalchemy/dialect/__init__.py
+++ b/src/databricks/sqlalchemy/dialect/__init__.py
@@ -5,7 +5,7 @@ import decimal, re, datetime
 from dateutil.parser import parse
 
 import sqlalchemy
-from sqlalchemy import types, processors, event
+from sqlalchemy import types, event
 from sqlalchemy.engine import default, Engine
 from sqlalchemy.exc import DatabaseError, SQLAlchemyError
 from sqlalchemy.engine import reflection


### PR DESCRIPTION
This PR removes an unused import that was preventing the `databricks-sql-python` module from being compatible with SQLAlchemy 2.

In our company's project, we have fully migrated to SQLAlchemy 2.0.4. However, the current `databricks-sql-python` module obviously requires SQLAlchemy >=1.3.0. Despite this, I found that by simply removing a single unused import, the module could be effectively used in our SQLAlchemy 2.0.4 project.

I ran the unit tests before and after removing the import. In both cases, the results were identical with 92 tests passed and 2 skipped. This makes sense since the imported `processors` object was never used anywhere. 

While the ideal solution would be to update the entire project to be compatible with SQLAlchemy 2.0, this smaller change allows users to integrate `databricks-sql-python` into their SQLAlchemy 2 projects without any immediate breaking issues, if they're willing to use the connector out-of-spec. This serves as a temporary workaround for those users until a full migration to SQLAlchemy 2 can be achieved (I'm happy to help with that)
