### PR TITLE
arrow table to pandas util api

### DIFF
--- a/src/databricks/sql/utils.py
+++ b/src/databricks/sql/utils.py
@@ -205,10 +205,7 @@ def convert_arrow_table_to_pandas(table: pyarrow.Table) -> pandas.DataFrame:
         pyarrow.string(): pandas.StringDtype(),
     }
 
-    # Need to rename columns, as the to_pandas function cannot handle duplicate column names
-    table_renamed = table.rename_columns([str(c) for c in range(table.num_columns)])
-
-    return table_renamed.to_pandas(
+    return table.to_pandas(
         types_mapper=dtype_mapping.get,
         date_as_object=True,
         timestamp_as_object=True,


### PR DESCRIPTION
While working with databricks-sql-python API, a question appears - how to get pandas dataframe using databricks connection and execute sql API.
At least a handy util api is necessary in order to provide conversion from arrow table to pandas dataframe, moreover it has already been implemented, I just separated the logic from fetchall API.