### PR TITLE
Default socket timeout to 15 min

### DIFF
--- a/src/databricks/sql/thrift_backend.py
+++ b/src/databricks/sql/thrift_backend.py
@@ -152,7 +152,11 @@ class ThriftBackend:
             ssl_context=ssl_context,
         )
 
-        timeout = 60 if kwargs.get("_socket_timeout") is None else kwargs.get("_socket_timeout")
+        timeout = (
+            60
+            if kwargs.get("_socket_timeout") is None
+            else kwargs.get("_socket_timeout")
+        )
         # setTimeout defaults to 60 seconds and is expected in ms
         self._transport.setTimeout(timeout and (float(timeout) * 1000.0))
 

--- a/src/databricks/sql/thrift_backend.py
+++ b/src/databricks/sql/thrift_backend.py
@@ -37,6 +37,7 @@ DATABRICKS_ERROR_OR_REDIRECT_HEADER = "x-databricks-error-or-redirect-message"
 DATABRICKS_REASON_HEADER = "x-databricks-reason-phrase"
 
 TIMESTAMP_AS_STRING_CONFIG = "spark.thriftserver.arrowBasedRowSet.timestampAsString"
+DEFAULT_SOCKET_TIMEOUT = float(900)
 
 # see Connection.__init__ for parameter descriptions.
 # - Min/Max avoids unsustainable configs (sane values are far more constrained)
@@ -100,7 +101,7 @@ class ThriftBackend:
         #  The maximum number of times we should retry retryable requests (defaults to 24)
         # _socket_timeout
         #  The timeout in seconds for socket send, recv and connect operations. Should be a positive float or integer.
-        #  (defaults to 60)
+        #  (defaults to 900)
 
         port = port or 443
         if kwargs.get("_connection_uri"):
@@ -152,11 +153,7 @@ class ThriftBackend:
             ssl_context=ssl_context,
         )
 
-        timeout = (
-            900
-            if kwargs.get("_socket_timeout") is None
-            else kwargs.get("_socket_timeout")
-        )
+        timeout = kwargs.get("_socket_timeout", DEFAULT_SOCKET_TIMEOUT)
         # setTimeout defaults to 60 seconds and is expected in ms
         self._transport.setTimeout(timeout and (float(timeout) * 1000.0))
 

--- a/src/databricks/sql/thrift_backend.py
+++ b/src/databricks/sql/thrift_backend.py
@@ -154,7 +154,7 @@ class ThriftBackend:
 
         timeout = 60 if kwargs.get("_socket_timeout") is None else kwargs.get("_socket_timeout")
         # setTimeout defaults to 60 seconds and is expected in ms
-        self._transport.setTimeout(float(timeout) * 1000.0)
+        self._transport.setTimeout(timeout and (float(timeout) * 1000.0))
 
         self._transport.setCustomHeaders(dict(http_headers))
         protocol = thrift.protocol.TBinaryProtocol.TBinaryProtocol(self._transport)

--- a/src/databricks/sql/thrift_backend.py
+++ b/src/databricks/sql/thrift_backend.py
@@ -153,7 +153,7 @@ class ThriftBackend:
         )
 
         timeout = (
-            60
+            900
             if kwargs.get("_socket_timeout") is None
             else kwargs.get("_socket_timeout")
         )

--- a/src/databricks/sql/thrift_backend.py
+++ b/src/databricks/sql/thrift_backend.py
@@ -154,7 +154,7 @@ class ThriftBackend:
         )
 
         timeout = kwargs.get("_socket_timeout", DEFAULT_SOCKET_TIMEOUT)
-        # setTimeout defaults to 60 seconds and is expected in ms
+        # setTimeout defaults to 15 minutes and is expected in ms
         self._transport.setTimeout(timeout and (float(timeout) * 1000.0))
 
         self._transport.setCustomHeaders(dict(http_headers))

--- a/src/databricks/sql/thrift_backend.py
+++ b/src/databricks/sql/thrift_backend.py
@@ -99,8 +99,8 @@ class ThriftBackend:
         # _retry_stop_after_attempts_count
         #  The maximum number of times we should retry retryable requests (defaults to 24)
         # _socket_timeout
-        #  The timeout in seconds for socket send, recv and connect operations. Defaults to None for
-        #  no timeout. Should be a positive float or integer.
+        #  The timeout in seconds for socket send, recv and connect operations. Should be a positive float or integer.
+        #  (defaults to 60)
 
         port = port or 443
         if kwargs.get("_connection_uri"):
@@ -152,9 +152,9 @@ class ThriftBackend:
             ssl_context=ssl_context,
         )
 
-        timeout = kwargs.get("_socket_timeout")
-        # setTimeout defaults to None (i.e. no timeout), and is expected in ms
-        self._transport.setTimeout(timeout and (float(timeout) * 1000.0))
+        timeout = 60 if kwargs.get("_socket_timeout") is None else kwargs.get("_socket_timeout")
+        # setTimeout defaults to 60 seconds and is expected in ms
+        self._transport.setTimeout(float(timeout) * 1000.0)
 
         self._transport.setCustomHeaders(dict(http_headers))
         protocol = thrift.protocol.TBinaryProtocol.TBinaryProtocol(self._transport)

--- a/tests/e2e/driver_tests.py
+++ b/tests/e2e/driver_tests.py
@@ -469,8 +469,8 @@ class PySQLCoreTestSuite(SmokeTestMixin, CoreTestMixin, DecimalTestsMixin, Times
 
     @skipIf(pysql_has_version('<', '2'), 'requires pysql v2')
     def test_socket_timeout_user_defined(self):
-        #  We expect to see a BlockingIO error when the socket is opened
-        #  in non-blocking mode, since no poll is done before the read
+        #  We expect to see a TimeoutError when the socket timeout is only
+        #  1 sec for a query that takes longer than that to process
         with self.assertRaises(RequestError) as cm:
             with self.cursor({"_socket_timeout": 1}) as cursor:
                 query = "select * from range(10000000)"

--- a/tests/e2e/driver_tests.py
+++ b/tests/e2e/driver_tests.py
@@ -459,7 +459,7 @@ class PySQLCoreTestSuite(SmokeTestMixin, CoreTestMixin, DecimalTestsMixin, Times
 
     @skipIf(pysql_has_version('<', '2'), 'requires pysql v2')
     def test_socket_timeout(self):
-        #  We we expect to see a BlockingIO error when the socket is opened
+        #  We expect to see a BlockingIO error when the socket is opened
         #  in non-blocking mode, since no poll is done before the read
         with self.assertRaises(OperationalError) as cm:
             with self.cursor({"_socket_timeout": 0}):

--- a/tests/unit/test_thrift_backend.py
+++ b/tests/unit/test_thrift_backend.py
@@ -218,7 +218,7 @@ class ThriftBackendTestSuite(unittest.TestCase):
         ThriftBackend("hostname", 123, "path_value", [], auth_provider=AuthProvider(), _socket_timeout=0)
         self.assertEqual(t_http_client_class.return_value.setTimeout.call_args[0][0], 0)
         ThriftBackend("hostname", 123, "path_value", [], auth_provider=AuthProvider(), _socket_timeout=None)
-        self.assertEqual(t_http_client_class.return_value.setTimeout.call_args[0][0], None)
+        self.assertEqual(t_http_client_class.return_value.setTimeout.call_args[0][0], 60 * 1000)
 
     def test_non_primitive_types_raise_error(self):
         columns = [

--- a/tests/unit/test_thrift_backend.py
+++ b/tests/unit/test_thrift_backend.py
@@ -217,8 +217,10 @@ class ThriftBackendTestSuite(unittest.TestCase):
         self.assertEqual(t_http_client_class.return_value.setTimeout.call_args[0][0], 129 * 1000)
         ThriftBackend("hostname", 123, "path_value", [], auth_provider=AuthProvider(), _socket_timeout=0)
         self.assertEqual(t_http_client_class.return_value.setTimeout.call_args[0][0], 0)
-        ThriftBackend("hostname", 123, "path_value", [], auth_provider=AuthProvider(), _socket_timeout=None)
+        ThriftBackend("hostname", 123, "path_value", [], auth_provider=AuthProvider())
         self.assertEqual(t_http_client_class.return_value.setTimeout.call_args[0][0], 900 * 1000)
+        ThriftBackend("hostname", 123, "path_value", [], auth_provider=AuthProvider(), _socket_timeout=None)
+        self.assertEqual(t_http_client_class.return_value.setTimeout.call_args[0][0], None)
 
     def test_non_primitive_types_raise_error(self):
         columns = [

--- a/tests/unit/test_thrift_backend.py
+++ b/tests/unit/test_thrift_backend.py
@@ -218,7 +218,7 @@ class ThriftBackendTestSuite(unittest.TestCase):
         ThriftBackend("hostname", 123, "path_value", [], auth_provider=AuthProvider(), _socket_timeout=0)
         self.assertEqual(t_http_client_class.return_value.setTimeout.call_args[0][0], 0)
         ThriftBackend("hostname", 123, "path_value", [], auth_provider=AuthProvider(), _socket_timeout=None)
-        self.assertEqual(t_http_client_class.return_value.setTimeout.call_args[0][0], 60 * 1000)
+        self.assertEqual(t_http_client_class.return_value.setTimeout.call_args[0][0], 900 * 1000)
 
     def test_non_primitive_types_raise_error(self):
         columns = [


### PR DESCRIPTION
Currently, if socket timeout is not specified in the kwargs, there will be no socket timeout. As per PECO-742, a single request should not block indefinitely. If the server side does not respond within one minute, we should timeout. We'll set the timeout conservatively to 15 min