### PR TITLE
Fix socket timeout test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fix: oauth would fail if expired credentials appeared in ~/.netrc (#122)
 - Fix: Python HTTP proxies were broken after switch to urllib3 (#158)
 - Other: Relax pandas dependency constraint to allow ^2.0.0 (#164)
+- Other: test_socket_timeout_user_defined e2e test was broken (#144)
 
 ## 2.7.0 (2023-06-26)
 

--- a/tests/e2e/test_driver.py
+++ b/tests/e2e/test_driver.py
@@ -16,6 +16,7 @@ import pyarrow
 import pytz
 import thrift
 import pytest
+from urllib3.connectionpool import ReadTimeoutError
 
 import databricks.sql as sql
 from databricks.sql import STRING, BINARY, NUMBER, DATETIME, DATE, DatabaseError, Error, OperationalError, RequestError
@@ -509,12 +510,11 @@ class PySQLCoreTestSuite(SmokeTestMixin, CoreTestMixin, DecimalTestsMixin, Times
     def test_socket_timeout_user_defined(self):
         #  We expect to see a TimeoutError when the socket timeout is only
         #  1 sec for a query that takes longer than that to process
-        with self.assertRaises(RequestError) as cm:
+        with self.assertRaises(ReadTimeoutError) as cm:
             with self.cursor({"_socket_timeout": 1}) as cursor:
-                query = "select * from range(10000000)"
+                query = "select * from range(1000000000)"
                 cursor.execute(query)
 
-        self.assertIsInstance(cm.exception.args[1], TimeoutError)
 
     def test_ssp_passthrough(self):
         for enable_ansi in (True, False):


### PR DESCRIPTION
`test_socket_timeout_user_defined` e2e test worked for the previous version of the driver before we introduced the urllib3.connectionpool to reuse http connection. The error that is thrown is now `urllib3.connnectionpool.ReadTimeoutError`