### PR TITLE
Cloud fetch queue and integration

### DIFF
--- a/src/databricks/sql/client.py
+++ b/src/databricks/sql/client.py
@@ -17,7 +17,7 @@ from databricks.sql.experimental.oauth_persistence import OAuthPersistence
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_RESULT_BUFFER_SIZE_BYTES = 10485760
+DEFAULT_RESULT_BUFFER_SIZE_BYTES = 104857600
 DEFAULT_ARRAY_SIZE = 100000
 
 

--- a/src/databricks/sql/client.py
+++ b/src/databricks/sql/client.py
@@ -839,6 +839,7 @@ class ResultSet:
             lz4_compressed=self.lz4_compressed,
             arrow_schema_bytes=self._arrow_schema_bytes,
             description=self.description,
+            max_download_threads=self.connection.max_download_threads,
         )
         self.results = results
         self.has_more_rows = has_more_rows

--- a/src/databricks/sql/client.py
+++ b/src/databricks/sql/client.py
@@ -155,8 +155,6 @@ class Connection:
         # (True by default)
         # use_cloud_fetch
         # Enable use of cloud fetch to extract large query results in parallel via cloud storage
-        # max_download_threads
-        # Number of threads for handling cloud fetch downloads. Defaults to 10
 
         if access_token:
             access_token_kv = {"access_token": access_token}
@@ -194,7 +192,6 @@ class Connection:
             session_configuration, catalog, schema
         )
         self.use_cloud_fetch = kwargs.get("use_cloud_fetch", False)
-        self.max_download_threads = kwargs.get("max_download_threads", 10)
         self.open = True
         logger.info("Successfully opened session " + str(self.get_session_id_hex()))
         self._cursors = []  # type: List[Cursor]
@@ -811,7 +808,6 @@ class ResultSet:
         self.description = execute_response.description
         self._arrow_schema_bytes = execute_response.arrow_schema_bytes
         self._next_row_index = 0
-        self.results = None
 
         if execute_response.arrow_queue:
             # In this case the server has taken the fast path and returned an initial batch of
@@ -839,7 +835,6 @@ class ResultSet:
             lz4_compressed=self.lz4_compressed,
             arrow_schema_bytes=self._arrow_schema_bytes,
             description=self.description,
-            max_download_threads=self.connection.max_download_threads,
         )
         self.results = results
         self.has_more_rows = has_more_rows

--- a/src/databricks/sql/cloudfetch/download_manager.py
+++ b/src/databricks/sql/cloudfetch/download_manager.py
@@ -161,6 +161,6 @@ class ResultFileDownloadManager:
         return True
 
     def _shutdown_manager(self):
-        # Clear download handlers and shutdown the thread pool to cancel pending futures
+        # Clear download handlers and shutdown the thread pool
         self.download_handlers = []
-        self.thread_pool.shutdown(wait=False, cancel_futures=True)
+        self.thread_pool.shutdown(wait=False)

--- a/src/databricks/sql/thrift_backend.py
+++ b/src/databricks/sql/thrift_backend.py
@@ -5,7 +5,6 @@ import math
 import time
 import uuid
 import threading
-import lz4.frame
 from ssl import CERT_NONE, CERT_REQUIRED, create_default_context
 from typing import List, Union
 
@@ -31,6 +30,10 @@ from databricks.sql.utils import (
     _bound,
     RequestErrorInfo,
     NoRetryReason,
+    ResultSetQueueFactory,
+    convert_arrow_based_set_to_arrow_table,
+    convert_decimals_in_arrow_table,
+    convert_column_based_set_to_arrow_table,
 )
 
 logger = logging.getLogger(__name__)
@@ -67,7 +70,6 @@ _retry_policy = {  # (type, default, min, max)
 class ThriftBackend:
     CLOSED_OP_STATE = ttypes.TOperationState.CLOSED_STATE
     ERROR_OP_STATE = ttypes.TOperationState.ERROR_STATE
-    BIT_MASKS = [1, 2, 4, 8, 16, 32, 64, 128]
 
     def __init__(
         self,
@@ -558,108 +560,19 @@ class ThriftBackend:
             (
                 arrow_table,
                 num_rows,
-            ) = ThriftBackend._convert_column_based_set_to_arrow_table(
+            ) = convert_column_based_set_to_arrow_table(
                 t_row_set.columns, description
             )
         elif t_row_set.arrowBatches is not None:
             (
                 arrow_table,
                 num_rows,
-            ) = ThriftBackend._convert_arrow_based_set_to_arrow_table(
+            ) = convert_arrow_based_set_to_arrow_table(
                 t_row_set.arrowBatches, lz4_compressed, schema_bytes
             )
         else:
             raise OperationalError("Unsupported TRowSet instance {}".format(t_row_set))
-        return self._convert_decimals_in_arrow_table(arrow_table, description), num_rows
-
-    @staticmethod
-    def _convert_decimals_in_arrow_table(table, description):
-        for (i, col) in enumerate(table.itercolumns()):
-            if description[i][1] == "decimal":
-                decimal_col = col.to_pandas().apply(
-                    lambda v: v if v is None else Decimal(v)
-                )
-                precision, scale = description[i][4], description[i][5]
-                assert scale is not None
-                assert precision is not None
-                # Spark limits decimal to a maximum scale of 38,
-                # so 128 is guaranteed to be big enough
-                dtype = pyarrow.decimal128(precision, scale)
-                col_data = pyarrow.array(decimal_col, type=dtype)
-                field = table.field(i).with_type(dtype)
-                table = table.set_column(i, field, col_data)
-        return table
-
-    @staticmethod
-    def _convert_arrow_based_set_to_arrow_table(
-        arrow_batches, lz4_compressed, schema_bytes
-    ):
-        ba = bytearray()
-        ba += schema_bytes
-        n_rows = 0
-        if lz4_compressed:
-            for arrow_batch in arrow_batches:
-                n_rows += arrow_batch.rowCount
-                ba += lz4.frame.decompress(arrow_batch.batch)
-        else:
-            for arrow_batch in arrow_batches:
-                n_rows += arrow_batch.rowCount
-                ba += arrow_batch.batch
-        arrow_table = pyarrow.ipc.open_stream(ba).read_all()
-        return arrow_table, n_rows
-
-    @staticmethod
-    def _convert_column_based_set_to_arrow_table(columns, description):
-        arrow_table = pyarrow.Table.from_arrays(
-            [ThriftBackend._convert_column_to_arrow_array(c) for c in columns],
-            # Only use the column names from the schema, the types are determined by the
-            # physical types used in column based set, as they can differ from the
-            # mapping used in _hive_schema_to_arrow_schema.
-            names=[c[0] for c in description],
-        )
-        return arrow_table, arrow_table.num_rows
-
-    @staticmethod
-    def _convert_column_to_arrow_array(t_col):
-        """
-        Return a pyarrow array from the values in a TColumn instance.
-        Note that ColumnBasedSet has no native support for complex types, so they will be converted
-        to strings server-side.
-        """
-        field_name_to_arrow_type = {
-            "boolVal": pyarrow.bool_(),
-            "byteVal": pyarrow.int8(),
-            "i16Val": pyarrow.int16(),
-            "i32Val": pyarrow.int32(),
-            "i64Val": pyarrow.int64(),
-            "doubleVal": pyarrow.float64(),
-            "stringVal": pyarrow.string(),
-            "binaryVal": pyarrow.binary(),
-        }
-        for field in field_name_to_arrow_type.keys():
-            wrapper = getattr(t_col, field)
-            if wrapper:
-                return ThriftBackend._create_arrow_array(
-                    wrapper, field_name_to_arrow_type[field]
-                )
-
-        raise OperationalError("Empty TColumn instance {}".format(t_col))
-
-    @staticmethod
-    def _create_arrow_array(t_col_value_wrapper, arrow_type):
-        result = t_col_value_wrapper.values
-        nulls = t_col_value_wrapper.nulls  # bitfield describing which values are null
-        assert isinstance(nulls, bytes)
-
-        # The number of bits in nulls can be both larger or smaller than the number of
-        # elements in result, so take the minimum of both to iterate over.
-        length = min(len(result), len(nulls) * 8)
-
-        for i in range(length):
-            if nulls[i >> 3] & ThriftBackend.BIT_MASKS[i & 0x7]:
-                result[i] = None
-
-        return pyarrow.array(result, type=arrow_type)
+        return convert_decimals_in_arrow_table(arrow_table, description), num_rows
 
     def _get_metadata_resp(self, op_handle):
         req = ttypes.TGetResultSetMetadataReq(operationHandle=op_handle)
@@ -752,6 +665,7 @@ class ThriftBackend:
         if t_result_set_metadata_resp.resultFormat not in [
             ttypes.TSparkRowSetType.ARROW_BASED_SET,
             ttypes.TSparkRowSetType.COLUMN_BASED_SET,
+            ttypes.TSparkRowSetType.URL_BASED_SET,
         ]:
             raise OperationalError(
                 "Expected results to be in Arrow or column based format, "
@@ -783,13 +697,16 @@ class ThriftBackend:
             assert direct_results.resultSet.results.startRowOffset == 0
             assert direct_results.resultSetMetadata
 
-            arrow_results, n_rows = self._create_arrow_table(
-                direct_results.resultSet.results,
-                lz4_compressed,
-                schema_bytes,
-                description,
-            )
-            arrow_queue_opt = ArrowQueue(arrow_results, n_rows, 0)
+            if direct_results.resultSet.results.resultLinks is None:
+                arrow_results, n_rows = self._create_arrow_table(
+                    direct_results.resultSet.results,
+                    lz4_compressed,
+                    schema_bytes,
+                    description,
+                )
+                arrow_queue_opt = ArrowQueue(arrow_results, n_rows, 0)
+            else:
+                arrow_queue_opt = None
         else:
             arrow_queue_opt = None
         return ExecuteResponse(
@@ -843,7 +760,7 @@ class ThriftBackend:
                 )
 
     def execute_command(
-        self, operation, session_handle, max_rows, max_bytes, lz4_compression, cursor
+        self, operation, session_handle, max_rows, max_bytes, lz4_compression, cursor, use_cloud_fetch=False
     ):
         assert session_handle is not None
 
@@ -864,7 +781,7 @@ class ThriftBackend:
             ),
             canReadArrowResult=True,
             canDecompressLZ4Result=lz4_compression,
-            canDownloadResult=False,
+            canDownloadResult=use_cloud_fetch,
             confOverlay={
                 # We want to receive proper Timestamp arrow types.
                 "spark.thriftserver.arrowBasedRowSet.timestampAsString": "false"
@@ -993,6 +910,7 @@ class ThriftBackend:
             maxRows=max_rows,
             maxBytes=max_bytes,
             orientation=ttypes.TFetchOrientation.FETCH_NEXT,
+            includeResultSetMetadata=True,
         )
 
         resp = self.make_request(self._client.FetchResults, req)
@@ -1002,12 +920,16 @@ class ThriftBackend:
                     expected_row_start_offset, resp.results.startRowOffset
                 )
             )
-        arrow_results, n_rows = self._create_arrow_table(
-            resp.results, lz4_compressed, arrow_schema_bytes, description
-        )
-        arrow_queue = ArrowQueue(arrow_results, n_rows)
 
-        return arrow_queue, resp.hasMoreRows
+        queue = ResultSetQueueFactory.build_queue(
+            row_set_type=resp.resultSetMetadata.resultFormat,
+            t_row_set=resp.results,
+            arrow_schema_bytes=arrow_schema_bytes,
+            lz4_compressed=lz4_compressed,
+            description=description,
+        )
+
+        return queue, resp.hasMoreRows
 
     def close_command(self, op_handle):
         req = ttypes.TCloseOperationReq(operationHandle=op_handle)

--- a/src/databricks/sql/thrift_backend.py
+++ b/src/databricks/sql/thrift_backend.py
@@ -697,16 +697,13 @@ class ThriftBackend:
             assert direct_results.resultSet.results.startRowOffset == 0
             assert direct_results.resultSetMetadata
 
-            if direct_results.resultSet.results.resultLinks is None:
-                arrow_results, n_rows = self._create_arrow_table(
-                    direct_results.resultSet.results,
-                    lz4_compressed,
-                    schema_bytes,
-                    description,
-                )
-                arrow_queue_opt = ArrowQueue(arrow_results, n_rows, 0)
-            else:
-                arrow_queue_opt = None
+            arrow_queue_opt = ResultSetQueueFactory.build_queue(
+                row_set_type=t_result_set_metadata_resp.resultFormat,
+                t_row_set=direct_results.resultSet.results,
+                arrow_schema_bytes=schema_bytes,
+                lz4_compressed=lz4_compressed,
+                description=description,
+            )
         else:
             arrow_queue_opt = None
         return ExecuteResponse(

--- a/src/databricks/sql/thrift_backend.py
+++ b/src/databricks/sql/thrift_backend.py
@@ -656,7 +656,7 @@ class ThriftBackend:
             ThriftBackend._col_to_description(col) for col in t_table_schema.columns
         ]
 
-    def _results_message_to_execute_response(self, resp, operation_state):
+    def _results_message_to_execute_response(self, resp, operation_state, max_download_threads):
         if resp.directResults and resp.directResults.resultSetMetadata:
             t_result_set_metadata_resp = resp.directResults.resultSetMetadata
         else:
@@ -703,6 +703,7 @@ class ThriftBackend:
                 arrow_schema_bytes=schema_bytes,
                 lz4_compressed=lz4_compressed,
                 description=description,
+                max_download_threads=max_download_threads,
             )
         else:
             arrow_queue_opt = None
@@ -883,7 +884,9 @@ class ThriftBackend:
             resp.directResults and resp.directResults.operationStatus,
         )
 
-        return self._results_message_to_execute_response(resp, final_operation_state)
+        max_download_threads = cursor.connection.max_download_threads
+
+        return self._results_message_to_execute_response(resp, final_operation_state, max_download_threads)
 
     def fetch_results(
         self,
@@ -894,6 +897,7 @@ class ThriftBackend:
         lz4_compressed,
         arrow_schema_bytes,
         description,
+        max_download_threads,
     ):
         assert op_handle is not None
 
@@ -924,6 +928,7 @@ class ThriftBackend:
             arrow_schema_bytes=arrow_schema_bytes,
             lz4_compressed=lz4_compressed,
             description=description,
+            max_download_threads=max_download_threads,
         )
 
         return queue, resp.hasMoreRows

--- a/src/databricks/sql/thrift_backend.py
+++ b/src/databricks/sql/thrift_backend.py
@@ -655,9 +655,7 @@ class ThriftBackend:
             ThriftBackend._col_to_description(col) for col in t_table_schema.columns
         ]
 
-    def _results_message_to_execute_response(
-        self, resp, operation_state
-    ):
+    def _results_message_to_execute_response(self, resp, operation_state):
         if resp.directResults and resp.directResults.resultSetMetadata:
             t_result_set_metadata_resp = resp.directResults.resultSetMetadata
         else:
@@ -892,9 +890,7 @@ class ThriftBackend:
             resp.directResults and resp.directResults.operationStatus,
         )
 
-        return self._results_message_to_execute_response(
-            resp, final_operation_state
-        )
+        return self._results_message_to_execute_response(resp, final_operation_state)
 
     def fetch_results(
         self,

--- a/src/databricks/sql/thrift_backend.py
+++ b/src/databricks/sql/thrift_backend.py
@@ -25,7 +25,6 @@ from databricks.sql.thrift_api.TCLIService.TCLIService import (
 )
 
 from databricks.sql.utils import (
-    ArrowQueue,
     ExecuteResponse,
     _bound,
     RequestErrorInfo,
@@ -560,14 +559,9 @@ class ThriftBackend:
             (
                 arrow_table,
                 num_rows,
-            ) = convert_column_based_set_to_arrow_table(
-                t_row_set.columns, description
-            )
+            ) = convert_column_based_set_to_arrow_table(t_row_set.columns, description)
         elif t_row_set.arrowBatches is not None:
-            (
-                arrow_table,
-                num_rows,
-            ) = convert_arrow_based_set_to_arrow_table(
+            (arrow_table, num_rows,) = convert_arrow_based_set_to_arrow_table(
                 t_row_set.arrowBatches, lz4_compressed, schema_bytes
             )
         else:
@@ -656,7 +650,9 @@ class ThriftBackend:
             ThriftBackend._col_to_description(col) for col in t_table_schema.columns
         ]
 
-    def _results_message_to_execute_response(self, resp, operation_state, max_download_threads):
+    def _results_message_to_execute_response(
+        self, resp, operation_state, max_download_threads
+    ):
         if resp.directResults and resp.directResults.resultSetMetadata:
             t_result_set_metadata_resp = resp.directResults.resultSetMetadata
         else:
@@ -758,7 +754,14 @@ class ThriftBackend:
                 )
 
     def execute_command(
-        self, operation, session_handle, max_rows, max_bytes, lz4_compression, cursor, use_cloud_fetch=False
+        self,
+        operation,
+        session_handle,
+        max_rows,
+        max_bytes,
+        lz4_compression,
+        cursor,
+        use_cloud_fetch=False,
     ):
         assert session_handle is not None
 
@@ -886,7 +889,9 @@ class ThriftBackend:
 
         max_download_threads = cursor.connection.max_download_threads
 
-        return self._results_message_to_execute_response(resp, final_operation_state, max_download_threads)
+        return self._results_message_to_execute_response(
+            resp, final_operation_state, max_download_threads
+        )
 
     def fetch_results(
         self,

--- a/src/databricks/sql/utils.py
+++ b/src/databricks/sql/utils.py
@@ -6,7 +6,7 @@ import datetime
 import decimal
 from enum import Enum
 import lz4.frame
-from typing import Dict, List, Union
+from typing import Dict, List, Union, Any
 import pyarrow
 
 from databricks.sql import exc, OperationalError
@@ -38,7 +38,7 @@ class ResultSetQueueFactory(ABC):
         arrow_schema_bytes: bytes,
         max_download_threads: int,
         lz4_compressed: bool = True,
-        description: List[List[any]] = None,
+        description: List[List[Any]] = None,
     ) -> ResultSetQueue:
         """
         Factory method to build a result set queue.
@@ -48,7 +48,7 @@ class ResultSetQueueFactory(ABC):
             t_row_set (TRowSet): Result containing arrow batches, columns, or cloud fetch links.
             arrow_schema_bytes (bytes): Bytes representing the arrow schema.
             lz4_compressed (bool): Whether result data has been lz4 compressed.
-            description (List[List[any]]): Hive table schema description.
+            description (List[List[Any]]): Hive table schema description.
             max_download_threads (int): Maximum number of downloader thread pool threads.
 
         Returns:
@@ -126,7 +126,7 @@ class CloudFetchQueue(ResultSetQueue):
         start_row_offset: int = 0,
         result_links: List[TSparkArrowResultLink] = None,
         lz4_compressed: bool = True,
-        description: List[List[any]] = None,
+        description: List[List[Any]] = None,
     ):
         """
         A queue-like wrapper over CloudFetch arrow batches.
@@ -137,7 +137,7 @@ class CloudFetchQueue(ResultSetQueue):
             start_row_offset (int): The offset of the first row of the cloud fetch links.
             result_links (List[TSparkArrowResultLink]): Links containing the downloadable URL and metadata.
             lz4_compressed (bool): Whether the files are lz4 compressed.
-            description (List[List[any]]): Hive table schema description.
+            description (List[List[Any]]): Hive table schema description.
         """
         self.schema_bytes = schema_bytes
         self.max_download_threads = max_download_threads
@@ -376,9 +376,7 @@ def inject_parameters(operation: str, parameters: Dict[str, str]):
     return operation % parameters
 
 
-def create_arrow_table_from_arrow_file(
-    file_bytes: bytes, description
-) -> (pyarrow.Table, int):
+def create_arrow_table_from_arrow_file(file_bytes: bytes, description) -> pyarrow.Table:
     arrow_table = convert_arrow_based_file_to_arrow_table(file_bytes)
     return convert_decimals_in_arrow_table(arrow_table, description)
 

--- a/src/databricks/sql/utils.py
+++ b/src/databricks/sql/utils.py
@@ -17,7 +17,6 @@ from databricks.sql.thrift_api.TCLIService.ttypes import (
     TRowSet,
 )
 
-DEFAULT_MAX_DOWNLOAD_THREADS = 10
 BIT_MASKS = [1, 2, 4, 8, 16, 32, 64, 128]
 
 
@@ -37,9 +36,9 @@ class ResultSetQueueFactory(ABC):
         row_set_type: TSparkRowSetType,
         t_row_set: TRowSet,
         arrow_schema_bytes: bytes,
+        max_download_threads: int,
         lz4_compressed: bool = True,
         description: List[List[any]] = None,
-        max_download_threads: int = DEFAULT_MAX_DOWNLOAD_THREADS,
     ) -> ResultSetQueue:
         """
         Factory method to build a result set queue.

--- a/tests/unit/test_cloud_fetch_queue.py
+++ b/tests/unit/test_cloud_fetch_queue.py
@@ -1,0 +1,223 @@
+import pyarrow
+import unittest
+from unittest.mock import MagicMock, patch
+
+from databricks.sql.thrift_api.TCLIService.ttypes import TSparkArrowResultLink
+import databricks.sql.utils as utils
+
+
+class CloudFetchQueueSuite(unittest.TestCase):
+
+    def create_result_link(
+            self,
+            file_link: str = "fileLink",
+            start_row_offset: int = 0,
+            row_count: int = 8000,
+            bytes_num: int = 20971520
+    ):
+        return TSparkArrowResultLink(file_link, None, start_row_offset, row_count, bytes_num)
+
+    def create_result_links(self, num_files: int, start_row_offset: int = 0):
+        result_links = []
+        for i in range(num_files):
+            file_link = "fileLink_" + str(i)
+            result_link = self.create_result_link(file_link=file_link, start_row_offset=start_row_offset)
+            result_links.append(result_link)
+            start_row_offset += result_link.rowCount
+        return result_links
+
+    @staticmethod
+    def make_arrow_table():
+        batch = [[0, 1, 2], [3, 4, 5], [6, 7, 8], [9, 10, 11]]
+        n_cols = len(batch[0]) if batch else 0
+        schema = pyarrow.schema({"col%s" % i: pyarrow.uint32() for i in range(n_cols)})
+        cols = [[batch[row][col] for row in range(len(batch))] for col in range(n_cols)]
+        return pyarrow.Table.from_pydict(dict(zip(schema.names, cols)), schema=schema)
+
+    @staticmethod
+    def get_schema_bytes():
+        schema = pyarrow.schema({"col%s" % i: pyarrow.uint32() for i in range(4)})
+        sink = pyarrow.BufferOutputStream()
+        writer = pyarrow.ipc.RecordBatchStreamWriter(sink, schema)
+        writer.close()
+        return sink.getvalue().to_pybytes()
+
+
+    @patch("databricks.sql.utils.CloudFetchQueue._create_next_table", return_value=[None, None])
+    def test_initializer_adds_links(self, mock_create_next_table):
+        schema_bytes = MagicMock()
+        result_links = self.create_result_links(10)
+        queue = utils.CloudFetchQueue(schema_bytes, result_links=result_links)
+
+        assert len(queue.download_manager.download_handlers) == 10
+        mock_create_next_table.assert_called()
+
+    def test_initializer_no_links_to_add(self):
+        schema_bytes = MagicMock()
+        result_links = []
+        queue = utils.CloudFetchQueue(schema_bytes, result_links=result_links)
+
+        assert len(queue.download_manager.download_handlers) == 0
+        assert queue.table is None
+        assert queue.table_num_rows == 0
+
+    @patch("databricks.sql.cloudfetch.download_manager.ResultFileDownloadManager.get_next_downloaded_file", return_value=None)
+    def test_create_next_table_no_download(self, mock_get_next_downloaded_file):
+        queue = utils.CloudFetchQueue(MagicMock(), result_links=[])
+
+        assert queue._create_next_table() == (None, 0)
+        assert mock_get_next_downloaded_file.called_with(0)
+
+    @patch("databricks.sql.utils.create_arrow_table_from_arrow_file", return_value=make_arrow_table())
+    @patch("databricks.sql.cloudfetch.download_manager.ResultFileDownloadManager.get_next_downloaded_file",
+           return_value=MagicMock(file_bytes=b"1234567890", row_count=4))
+    def test_initializer_create_next_table_success(self, mock_get_next_downloaded_file, mock_create_arrow_table):
+        schema_bytes, description = MagicMock(), MagicMock()
+        queue = utils.CloudFetchQueue(schema_bytes, result_links=[], description=description)
+        expected_result = self.make_arrow_table()
+
+        assert mock_create_arrow_table.called_with(b"1234567890", True, schema_bytes, description)
+        assert mock_get_next_downloaded_file.called_with(0)
+        assert queue.table == expected_result
+        assert queue.table_num_rows == 4
+        assert queue.table_row_index == 0
+        assert queue.start_row_index == 4
+
+        table, row_count = queue._create_next_table()
+        assert table == expected_result
+        assert row_count == 4
+        assert queue.start_row_index == 8
+
+    @patch("databricks.sql.utils.CloudFetchQueue._create_next_table", return_value=(make_arrow_table(), 4))
+    def test_next_n_rows_0_rows(self, mock_create_next_table):
+        schema_bytes, description = MagicMock(), MagicMock()
+        queue = utils.CloudFetchQueue(schema_bytes, result_links=[], description=description)
+        assert queue.table == self.make_arrow_table()
+        assert queue.table_num_rows == 4
+        assert queue.table_row_index == 0
+
+        result = queue.next_n_rows(0)
+        assert result.num_rows == 0
+        assert queue.table_row_index == 0
+        assert result == self.make_arrow_table()[0:0]
+
+    @patch("databricks.sql.utils.CloudFetchQueue._create_next_table", return_value=(make_arrow_table(), 4))
+    def test_next_n_rows_partial_table(self, mock_create_next_table):
+        schema_bytes, description = MagicMock(), MagicMock()
+        queue = utils.CloudFetchQueue(schema_bytes, result_links=[], description=description)
+        assert queue.table == self.make_arrow_table()
+        assert queue.table_num_rows == 4
+        assert queue.table_row_index == 0
+
+        result = queue.next_n_rows(3)
+        assert result.num_rows == 3
+        assert queue.table_row_index == 3
+        assert result == self.make_arrow_table()[:3]
+
+    @patch("databricks.sql.utils.CloudFetchQueue._create_next_table", return_value=(make_arrow_table(), 4))
+    def test_next_n_rows_more_than_one_table(self, mock_create_next_table):
+        schema_bytes, description = MagicMock(), MagicMock()
+        queue = utils.CloudFetchQueue(schema_bytes, result_links=[], description=description)
+        assert queue.table == self.make_arrow_table()
+        assert queue.table_num_rows == 4
+        assert queue.table_row_index == 0
+
+        result = queue.next_n_rows(7)
+        assert result.num_rows == 7
+        assert queue.table_row_index == 3
+        assert result == pyarrow.concat_tables([self.make_arrow_table(), self.make_arrow_table()])[:7]
+
+    @patch("databricks.sql.utils.CloudFetchQueue._create_next_table", return_value=(make_arrow_table(), 4))
+    def test_next_n_rows_more_than_one_table(self, mock_create_next_table):
+        schema_bytes, description = MagicMock(), MagicMock()
+        queue = utils.CloudFetchQueue(schema_bytes, result_links=[], description=description)
+        assert queue.table == self.make_arrow_table()
+        assert queue.table_num_rows == 4
+        assert queue.table_row_index == 0
+
+        result = queue.next_n_rows(7)
+        assert result.num_rows == 7
+        assert queue.table_row_index == 3
+        assert result == pyarrow.concat_tables([self.make_arrow_table(), self.make_arrow_table()])[:7]
+
+    @patch("databricks.sql.utils.CloudFetchQueue._create_next_table", side_effect=[(make_arrow_table(), 4), (None, 0)])
+    def test_next_n_rows_only_one_table_returned(self, mock_create_next_table):
+        schema_bytes, description = MagicMock(), MagicMock()
+        queue = utils.CloudFetchQueue(schema_bytes, result_links=[], description=description)
+        assert queue.table == self.make_arrow_table()
+        assert queue.table_num_rows == 4
+        assert queue.table_row_index == 0
+
+        result = queue.next_n_rows(7)
+        assert result.num_rows == 4
+        assert result == self.make_arrow_table()
+
+    @patch("databricks.sql.utils.CloudFetchQueue._create_next_table", return_value=(None, 0))
+    def test_next_n_rows_empty_table(self, mock_create_next_table):
+        schema_bytes = self.get_schema_bytes()
+        description = MagicMock()
+        queue = utils.CloudFetchQueue(schema_bytes, result_links=[], description=description)
+        assert queue.table is None
+
+        result = queue.next_n_rows(100)
+        assert result == pyarrow.ipc.open_stream(bytearray(schema_bytes)).read_all()
+
+    @patch("databricks.sql.utils.CloudFetchQueue._create_next_table", side_effect=[(make_arrow_table(), 4), (None, 0)])
+    def test_remaining_rows_empty_table_fully_returned(self, mock_create_next_table):
+        schema_bytes, description = MagicMock(), MagicMock()
+        queue = utils.CloudFetchQueue(schema_bytes, result_links=[], description=description)
+        assert queue.table == self.make_arrow_table()
+        assert queue.table_num_rows == 4
+        queue.table_row_index = 4
+
+        result = queue.remaining_rows()
+        assert result.num_rows == 0
+        assert result == self.make_arrow_table()[0:0]
+
+    @patch("databricks.sql.utils.CloudFetchQueue._create_next_table", side_effect=[(make_arrow_table(), 4), (None, 0)])
+    def test_remaining_rows_partial_table_fully_returned(self, mock_create_next_table):
+        schema_bytes, description = MagicMock(), MagicMock()
+        queue = utils.CloudFetchQueue(schema_bytes, result_links=[], description=description)
+        assert queue.table == self.make_arrow_table()
+        assert queue.table_num_rows == 4
+        queue.table_row_index = 2
+
+        result = queue.remaining_rows()
+        assert result.num_rows == 2
+        assert result == self.make_arrow_table()[2:]
+
+    @patch("databricks.sql.utils.CloudFetchQueue._create_next_table", side_effect=[(make_arrow_table(), 4), (None, 0)])
+    def test_remaining_rows_one_table_fully_returned(self, mock_create_next_table):
+        schema_bytes, description = MagicMock(), MagicMock()
+        queue = utils.CloudFetchQueue(schema_bytes, result_links=[], description=description)
+        assert queue.table == self.make_arrow_table()
+        assert queue.table_num_rows == 4
+        assert queue.table_row_index == 0
+
+        result = queue.remaining_rows()
+        assert result.num_rows == 4
+        assert result == self.make_arrow_table()
+
+    @patch("databricks.sql.utils.CloudFetchQueue._create_next_table",
+           side_effect=[(make_arrow_table(), 4), (make_arrow_table(), 4), (None, 0)])
+    def test_remaining_rows_multiple_tables_fully_returned(self, mock_create_next_table):
+        schema_bytes, description = MagicMock(), MagicMock()
+        queue = utils.CloudFetchQueue(schema_bytes, result_links=[], description=description)
+        assert queue.table == self.make_arrow_table()
+        assert queue.table_num_rows == 4
+        queue.table_row_index = 3
+
+        result = queue.remaining_rows()
+        assert mock_create_next_table.call_count == 3
+        assert result.num_rows == 5
+        assert result == pyarrow.concat_tables([self.make_arrow_table(), self.make_arrow_table()])[3:]
+
+    @patch("databricks.sql.utils.CloudFetchQueue._create_next_table", return_value=(None, 0))
+    def test_remaining_rows_empty_table(self, mock_create_next_table):
+        schema_bytes = self.get_schema_bytes()
+        description = MagicMock()
+        queue = utils.CloudFetchQueue(schema_bytes, result_links=[], description=description)
+        assert queue.table is None
+
+        result = queue.remaining_rows()
+        assert result == pyarrow.ipc.open_stream(bytearray(schema_bytes)).read_all()

--- a/tests/unit/test_thrift_backend.py
+++ b/tests/unit/test_thrift_backend.py
@@ -327,7 +327,8 @@ class ThriftBackendTestSuite(unittest.TestCase):
                     thrift_backend._handle_execute_response(t_execute_resp, Mock())
                 self.assertIn("some information about the error", str(cm.exception))
 
-    def test_handle_execute_response_sets_compression_in_direct_results(self):
+    @patch("databricks.sql.utils.ResultSetQueueFactory.build_queue", return_value=Mock())
+    def test_handle_execute_response_sets_compression_in_direct_results(self, build_queue):
         for resp_type in self.execute_response_types:
             lz4Compressed=Mock()
             resultSet=MagicMock()
@@ -589,9 +590,10 @@ class ThriftBackendTestSuite(unittest.TestCase):
         self.assertEqual(hive_schema_mock,
                          thrift_backend._hive_schema_to_arrow_schema.call_args[0][0])
 
+    @patch("databricks.sql.utils.ResultSetQueueFactory.build_queue", return_value=Mock())
     @patch("databricks.sql.thrift_backend.TCLIService.Client")
     def test_handle_execute_response_reads_has_more_rows_in_direct_results(
-            self, tcli_service_class):
+            self, tcli_service_class, build_queue):
         for has_more_rows, resp_type in itertools.product([True, False],
                                                           self.execute_response_types):
             with self.subTest(has_more_rows=has_more_rows, resp_type=resp_type):
@@ -622,9 +624,10 @@ class ThriftBackendTestSuite(unittest.TestCase):
 
                 self.assertEqual(has_more_rows, execute_response.has_more_rows)
 
+    @patch("databricks.sql.utils.ResultSetQueueFactory.build_queue", return_value=Mock())
     @patch("databricks.sql.thrift_backend.TCLIService.Client")
     def test_handle_execute_response_reads_has_more_rows_in_result_response(
-            self, tcli_service_class):
+            self, tcli_service_class, build_queue):
         for has_more_rows, resp_type in itertools.product([True, False],
                                                           self.execute_response_types):
             with self.subTest(has_more_rows=has_more_rows, resp_type=resp_type):


### PR DESCRIPTION
Changes:
1. Some static methods in ThriftBackend that we also need for `ResultSetQueue` are moved to `utils.py` to avoid circular dependency (`thrift_backend.py` <> `utils.py`)
2. `ResultSetQueue` abstract base class, with `ResultSetQueueFactory` producing `ArrowQueue` if result is arrow-based, `ArrowQueue` again if column-based, and `CloudFetchQueue` if url-based.