### PR TITLE
Don't raise exception when closing a stale Thrift session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2.6.x (Unreleased)
 
+- Fix: connector raised exception when calling close() on a closed Thrift session
 - Improve e2e test development ergonomics
 - Redact logged thrift responses by default
 - Add support for OAuth on Databricks Azure

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,6 +118,8 @@ access_token="dapi***"
 staging_ingestion_user="***@example.com"
 ```
 
+To see logging output from pytest while running tests, set `log_cli = "true"` under `tool.pytest.ini_options` in `pyproject.toml`. You can also set `log_cli_level` to any of the default Python log levels: `DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`
+
 There are several e2e test suites available:
 - `PySQLCoreTestSuite`
 - `PySQLLargeQueriesSuite`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,8 @@ exclude = '/(\.eggs|\.git|\.hg|\.mypy_cache|\.nox|\.tox|\.venv|\.svn|_build|buck
 
 [tool.pytest.ini_options]
 minversion = "6.0"
+log_cli = "false"
+log_cli_level = "INFO"
 testpaths = [
     "tests"
 ]

--- a/src/databricks/sql/client.py
+++ b/src/databricks/sql/client.py
@@ -247,7 +247,14 @@ class Connection:
         if close_cursors:
             for cursor in self._cursors:
                 cursor.close()
-        self.thrift_backend.close_session(self._session_handle)
+        try:
+            self.thrift_backend.close_session(self._session_handle)
+        except DatabaseError as e:
+            if "Invalid SessionHandle" in str(e):
+                pass
+            else:
+                raise e
+
         self.open = False
 
     def commit(self):

--- a/src/databricks/sql/client.py
+++ b/src/databricks/sql/client.py
@@ -255,9 +255,12 @@ class Connection:
                 logger.warning(
                     f"Attempted to close session that was already closed: {e}"
                 )
-                pass
             else:
-                raise e
+                logger.warning(
+                    f"Attempt to close session raised an exception at the server: {e}"
+                )
+        except Exception as e:
+            logger.error(f"Attempt to close session raised a local exception: {e}")
 
         self.open = False
 

--- a/src/databricks/sql/client.py
+++ b/src/databricks/sql/client.py
@@ -213,6 +213,9 @@ class Connection:
 
     def get_session_id(self):
         return self.thrift_backend.handle_to_id(self._session_handle)
+    
+    def get_session_id_hex(self):
+        return self.thrift_backend.handle_to_hex_id(self._session_handle)
 
     def cursor(
         self,

--- a/src/databricks/sql/client.py
+++ b/src/databricks/sql/client.py
@@ -247,8 +247,12 @@ class Connection:
         if close_cursors:
             for cursor in self._cursors:
                 cursor.close()
+
+        logger.info(f"Closing session {self.get_session_id_hex()}")
+        if not self.open:
+            logger.debug("Session appears to have been closed already")
+
         try:
-            logger.info(f"Closing session {self.get_session_id_hex()}")
             self.thrift_backend.close_session(self._session_handle)
         except DatabaseError as e:
             if "Invalid SessionHandle" in str(e):

--- a/src/databricks/sql/client.py
+++ b/src/databricks/sql/client.py
@@ -190,7 +190,7 @@ class Connection:
             session_configuration, catalog, schema
         )
         self.open = True
-        logger.info("Successfully opened session " + str(self.get_session_id()))
+        logger.info("Successfully opened session " + str(self.get_session_id_hex()))
         self._cursors = []  # type: List[Cursor]
 
     def __enter__(self):
@@ -248,9 +248,11 @@ class Connection:
             for cursor in self._cursors:
                 cursor.close()
         try:
+            logger.info(f"Closing session {self.get_session_id_hex()}")
             self.thrift_backend.close_session(self._session_handle)
         except DatabaseError as e:
             if "Invalid SessionHandle" in str(e):
+                logger.warning(f"Attempted to close session that was already closed: {e}")
                 pass
             else:
                 raise e

--- a/src/databricks/sql/client.py
+++ b/src/databricks/sql/client.py
@@ -213,7 +213,7 @@ class Connection:
 
     def get_session_id(self):
         return self.thrift_backend.handle_to_id(self._session_handle)
-    
+
     def get_session_id_hex(self):
         return self.thrift_backend.handle_to_hex_id(self._session_handle)
 
@@ -252,7 +252,9 @@ class Connection:
             self.thrift_backend.close_session(self._session_handle)
         except DatabaseError as e:
             if "Invalid SessionHandle" in str(e):
-                logger.warning(f"Attempted to close session that was already closed: {e}")
+                logger.warning(
+                    f"Attempted to close session that was already closed: {e}"
+                )
                 pass
             else:
                 raise e

--- a/src/databricks/sql/thrift_backend.py
+++ b/src/databricks/sql/thrift_backend.py
@@ -1022,7 +1022,7 @@ class ThriftBackend:
     @staticmethod
     def handle_to_id(session_handle):
         return session_handle.sessionId.guid
-    
+
     @staticmethod
     def handle_to_hex_id(session_handle: TCLIService.TSessionHandle):
         this_uuid = uuid.UUID(bytes=session_handle.sessionId.guid)

--- a/src/databricks/sql/thrift_backend.py
+++ b/src/databricks/sql/thrift_backend.py
@@ -3,6 +3,7 @@ import errno
 import logging
 import math
 import time
+import uuid
 import threading
 import lz4.frame
 from ssl import CERT_NONE, CERT_REQUIRED, create_default_context
@@ -1021,3 +1022,8 @@ class ThriftBackend:
     @staticmethod
     def handle_to_id(session_handle):
         return session_handle.sessionId.guid
+    
+    @staticmethod
+    def handle_to_hex_id(session_handle: TCLIService.TSessionHandle):
+        this_uuid = uuid.UUID(bytes=session_handle.sessionId.guid)
+        return str(this_uuid)

--- a/test.env.example
+++ b/test.env.example
@@ -5,3 +5,7 @@ access_token=""
 
 # Only required to run the PySQLStagingIngestionTestSuite
 staging_ingestion_user=""
+
+# Only required to run SQLAlchemy tests
+catalog=""
+schema=""

--- a/tests/e2e/test_driver.py
+++ b/tests/e2e/test_driver.py
@@ -616,6 +616,20 @@ class PySQLCoreTestSuite(SmokeTestMixin, CoreTestMixin, DecimalTestsMixin, Times
                     assert "RESOURCE_DOES_NOT_EXIST" in cm.exception.message
 
 
+    def test_closing_a_closed_connection_doesnt_fail(self):
+
+        with self.assertLogs("databricks.sql", "WARNING") as cm:
+            with self.connection() as conn:
+                conn.close()
+
+            expected_message_was_found = False
+            for log in cm.output:
+                if expected_message_was_found:
+                    break
+                target = "Attempted to close session that was already closed"
+                expected_message_was_found = target in log
+            
+            self.assertTrue(expected_message_was_found, "Did not find expected log messages")
 
 
 # use a RetrySuite to encapsulate these tests which we'll typically want to run together; however keep

--- a/tests/e2e/test_driver.py
+++ b/tests/e2e/test_driver.py
@@ -619,7 +619,9 @@ class PySQLCoreTestSuite(SmokeTestMixin, CoreTestMixin, DecimalTestsMixin, Times
     def test_closing_a_closed_connection_doesnt_fail(self):
 
         with self.assertLogs("databricks.sql", "WARNING") as cm:
+            # Second .close() call is when this context manager exits
             with self.connection() as conn:
+                # First .close() call is explicit here
                 conn.close()
 
             expected_message_was_found = False

--- a/tests/e2e/test_driver.py
+++ b/tests/e2e/test_driver.py
@@ -618,7 +618,7 @@ class PySQLCoreTestSuite(SmokeTestMixin, CoreTestMixin, DecimalTestsMixin, Times
 
     def test_closing_a_closed_connection_doesnt_fail(self):
 
-        with self.assertLogs("databricks.sql", "WARNING") as cm:
+        with self.assertLogs("databricks.sql", level="DEBUG",) as cm:
             # Second .close() call is when this context manager exits
             with self.connection() as conn:
                 # First .close() call is explicit here
@@ -628,7 +628,7 @@ class PySQLCoreTestSuite(SmokeTestMixin, CoreTestMixin, DecimalTestsMixin, Times
             for log in cm.output:
                 if expected_message_was_found:
                     break
-                target = "Attempted to close session that was already closed"
+                target = "Session appears to have been closed already"
                 expected_message_was_found = target in log
             
             self.assertTrue(expected_message_was_found, "Did not find expected log messages")


### PR DESCRIPTION
Prior to this change, if a context manager or a user explicitly called `Connection.close()` twice on the same connection, the second call would raise an exception: 

```
databricks.sql.exc.DatabaseError: Invalid SessionHandle: SessionHandle [<GUID>]
```

This sometimes affects dbt, airflow and others if they use connections as a context manager.

This pull request explicitly catches this error, logs it cleanly, and then continues execution. The pull request is broken into a few commits that do this:

1. Make it easy to see log messages when running pytest
2. Implement a method that converts the `bytes` session_handle we receive from Thrift server into a human readable GUID
3. **Explicitly catch the InvalidSession handle error** (this is the most important part of this PR)
4. Log when this happens so we can observe it (this shouldn't happen in the normal course of usage)
5. Update the changelog
6. Unrelated: update `test.env.example` to include the environment variables we need for running sqlalchemy e2e tests. This is just convenient. Has no impact on the connector as installed for users.

