### PR TITLE
Use hex string version of operation ID instead of bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add support for Cloud Fetch
 - Fix: Revised SQLAlchemy dialect and examples for compatibility with SQLAlchemy==1.3.x
+- Connector now logs operation handle guids as hexadecimal instead of bytes
 
 ## 2.7.0 (2023-06-26)
 

--- a/src/databricks/sql/client.py
+++ b/src/databricks/sql/client.py
@@ -206,7 +206,7 @@ class Connection:
         if self.open:
             logger.debug(
                 "Closing unclosed connection for session "
-                "{}".format(self.get_session_id())
+                "{}".format(self.get_session_id_hex())
             )
             try:
                 self._close(close_cursors=False)

--- a/src/databricks/sql/thrift_backend.py
+++ b/src/databricks/sql/thrift_backend.py
@@ -532,7 +532,8 @@ class ThriftBackend:
                 raise ServerOperationError(
                     get_operations_resp.displayMessage,
                     {
-                        "operation-id": op_handle and self.guid_to_hex_id(op_handle.operationId.guid),
+                        "operation-id": op_handle
+                        and self.guid_to_hex_id(op_handle.operationId.guid),
                         "diagnostic-info": get_operations_resp.diagnosticInfo,
                     },
                 )
@@ -540,7 +541,8 @@ class ThriftBackend:
                 raise ServerOperationError(
                     get_operations_resp.errorMessage,
                     {
-                        "operation-id": op_handle and self.guid_to_hex_id(op_handle.operationId.guid),
+                        "operation-id": op_handle
+                        and self.guid_to_hex_id(op_handle.operationId.guid),
                         "diagnostic-info": None,
                     },
                 )
@@ -549,7 +551,10 @@ class ThriftBackend:
                 "Command {} unexpectedly closed server side".format(
                     op_handle and self.guid_to_hex_id(op_handle.operationId.guid)
                 ),
-                {"operation-id": op_handle and self.guid_to_hex_id(op_handle.operationId.guid)},
+                {
+                    "operation-id": op_handle
+                    and self.guid_to_hex_id(op_handle.operationId.guid)
+                },
             )
 
     def _poll_for_status(self, op_handle):
@@ -942,7 +947,11 @@ class ThriftBackend:
         return resp.status
 
     def cancel_command(self, active_op_handle):
-        logger.debug("Cancelling command {}".format(self.guid_to_hex_id(active_op_handle.operationId.guid)))
+        logger.debug(
+            "Cancelling command {}".format(
+                self.guid_to_hex_id(active_op_handle.operationId.guid)
+            )
+        )
         req = ttypes.TCancelOperationReq(active_op_handle)
         self.make_request(self._client.CancelOperation, req)
 
@@ -954,7 +963,7 @@ class ThriftBackend:
     def handle_to_hex_id(session_handle: TCLIService.TSessionHandle):
         this_uuid = uuid.UUID(bytes=session_handle.sessionId.guid)
         return str(this_uuid)
-    
+
     @staticmethod
     def guid_to_hex_id(guid: bytes) -> str:
         """Return a hexadecimal string instead of bytes


### PR DESCRIPTION
_This PR is easiest to review commit-by-commit_

This pull request modifies how we log failures for operations. Rather than printing the operationId as `bytes` we can convert it to hex, which we can cross-reference with the Query History API.

## Related Tickets & Documents

Closes #163