### PR TITLE
[Issue 171] Improve sqlalchemy dialect backward compatibility with 1.3.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 2.7.x (Unreleased)
 
+- Fix: Revised SQLAlchemy dialect and examples for compatibility with SQLAlchemy==1.3.x
+
 ## 2.7.0 (2023-06-26)
 
 - Fix: connector raised exception when calling close() on a closed Thrift session

--- a/examples/sqlalchemy.py
+++ b/examples/sqlalchemy.py
@@ -42,8 +42,14 @@ more about customer use cases there. That said, the following behaviours have be
 """
 
 import os
-from sqlalchemy.orm import declarative_base, Session
+import sqlalchemy
+from sqlalchemy.orm import Session
 from sqlalchemy import Column, String, Integer, BOOLEAN, create_engine, select
+
+try:
+    from sqlalchemy.orm import declarative_base
+except ImportError:
+    from sqlalchemy.ext.declarative import declarative_base
 
 host = os.getenv("DATABRICKS_SERVER_HOSTNAME")
 http_path = os.getenv("DATABRICKS_HTTP_PATH")
@@ -59,10 +65,20 @@ extra_connect_args = {
     "_user_agent_entry": "PySQL Example Script",
 }
 
-engine = create_engine(
-    f"databricks://token:{access_token}@{host}?http_path={http_path}&catalog={catalog}&schema={schema}",
-    connect_args=extra_connect_args,
-)
+if sqlalchemy.__version__.startswith("1.3"):
+    # SQLAlchemy 1.3.x fails to parse the http_path, catalog, and schema from our connection string
+    # Pass these in as connect_args instead
+
+    conn_string = f"databricks://token:{access_token}@{host}"
+    connect_args = dict(catalog=catalog, schema=schema, http_path=http_path)
+    all_connect_args = {**extra_connect_args, **connect_args}
+    engine = create_engine(conn_string, connect_args=all_connect_args)
+else:
+    engine = create_engine(
+        f"databricks://token:{access_token}@{host}?http_path={http_path}&catalog={catalog}&schema={schema}",
+        connect_args=extra_connect_args,
+    )
+
 session = Session(bind=engine)
 base = declarative_base(bind=engine)
 

--- a/examples/sqlalchemy.py
+++ b/examples/sqlalchemy.py
@@ -102,9 +102,14 @@ session.add(sample_object_2)
 
 session.commit()
 
-stmt = select(SampleObject).where(SampleObject.name.in_(["Bim Adewunmi", "Miki Meek"]))
+# SQLAlchemy 1.3 has slightly different methods
+if sqlalchemy.__version__.startswith("1.3"):
+    stmt = select([SampleObject]).where(SampleObject.name.in_(["Bim Adewunmi", "Miki Meek"]))
+    output = [i for i in session.execute(stmt)]
+else:
+    stmt = select(SampleObject).where(SampleObject.name.in_(["Bim Adewunmi", "Miki Meek"]))
+    output = [i for i in session.scalars(stmt)]
 
-output = [i for i in session.scalars(stmt)]
 assert len(output) == 2
 
 base.metadata.drop_all()

--- a/examples/sqlalchemy.py
+++ b/examples/sqlalchemy.py
@@ -89,7 +89,7 @@ class SampleObject(base):
 
     name = Column(String(255), primary_key=True)
     episodes = Column(Integer)
-    some_bool = Column(BOOLEAN)
+    some_bool = Column(BOOLEAN(create_constraint=False))
 
 
 base.metadata.create_all()

--- a/src/databricks/sqlalchemy/dialect/__init__.py
+++ b/src/databricks/sqlalchemy/dialect/__init__.py
@@ -286,21 +286,19 @@ class DatabricksDialect(default.DefaultDialect):
                 return False
             else:
                 raise e
-            
-   
+
     def get_connection_cursor(self, connection):
-        """Added for backwards compatibility with 1.3.x
-        """
+        """Added for backwards compatibility with 1.3.x"""
         if hasattr(connection, "_dbapi_connection"):
             return connection._dbapi_connection.dbapi_connection.cursor()
         elif hasattr(connection, "raw_connection"):
             return connection.raw_connection().cursor()
         elif hasattr(connection, "connection"):
             return connection.connection.cursor()
-        
-        raise SQLAlchemyError("Databricks dialect can't obtain a cursor context manager from the dbapi")
 
-
+        raise SQLAlchemyError(
+            "Databricks dialect can't obtain a cursor context manager from the dbapi"
+        )
 
     @reflection.cache
     def get_schema_names(self, connection, **kw):
@@ -328,7 +326,7 @@ def receive_do_connect(dialect, conn_rec, cargs, cparams):
     if sqlalchemy.__version__.startswith("1.3"):
         # SQLAlchemy 1.3.x fails to parse the http_path, catalog, and schema from our connection string
         # These should be passed in as connect_args when building the Engine
-        
+
         if "schema" in cparams:
             dialect.schema = cparams["schema"]
 

--- a/src/databricks/sqlalchemy/dialect/__init__.py
+++ b/src/databricks/sqlalchemy/dialect/__init__.py
@@ -4,6 +4,7 @@
 import decimal, re, datetime
 from dateutil.parser import parse
 
+import sqlalchemy
 from sqlalchemy import types, processors, event
 from sqlalchemy.engine import default, Engine
 from sqlalchemy.exc import DatabaseError
@@ -314,3 +315,13 @@ def receive_do_connect(dialect, conn_rec, cargs, cparams):
         new_user_agent = "sqlalchemy"
 
     cparams["_user_agent_entry"] = new_user_agent
+
+    if sqlalchemy.__version__.startswith("1.3"):
+        # SQLAlchemy 1.3.x fails to parse the http_path, catalog, and schema from our connection string
+        # These should be passed in as connect_args when building the Engine
+        
+        if "schema" in cparams:
+            dialect.schema = cparams["schema"]
+
+        if "catalog" in cparams:
+            dialect.catalog = cparams["catalog"]

--- a/tests/e2e/sqlalchemy/test_basic.py
+++ b/tests/e2e/sqlalchemy/test_basic.py
@@ -114,7 +114,7 @@ def test_create_table_not_null(db_engine, metadata_obj):
         metadata_obj,
         Column("name", String(255)),
         Column("episodes", Integer),
-        Column("some_bool", BOOLEAN, nullable=False),
+        Column("some_bool", BOOLEAN(create_constraint=False), nullable=False),
     )
 
     metadata_obj.create_all()
@@ -167,7 +167,7 @@ def test_create_insert_drop_table_core(base, db_engine, metadata_obj: MetaData):
         metadata_obj,
         Column("name", String(255)),
         Column("episodes", Integer),
-        Column("some_bool", BOOLEAN),
+        Column("some_bool", BOOLEAN(create_constraint=False)),
         Column("dollars", DECIMAL(10, 2)),
     )
 
@@ -206,7 +206,7 @@ def test_create_insert_drop_table_orm(base, session: Session):
 
         name = Column(String(255), primary_key=True)
         episodes = Column(Integer)
-        some_bool = Column(BOOLEAN)
+        some_bool = Column(BOOLEAN(create_constraint=False))
 
     base.metadata.create_all()
 
@@ -234,7 +234,7 @@ def test_dialect_type_mappings(base, db_engine, metadata_obj: MetaData):
         metadata_obj,
         Column("string_example", String(255)),
         Column("integer_example", Integer),
-        Column("boolean_example", BOOLEAN),
+        Column("boolean_example", BOOLEAN(create_constraint=False)),
         Column("decimal_example", DECIMAL(10, 2)),
         Column("date_example", Date),
     )

--- a/tests/e2e/sqlalchemy/test_basic.py
+++ b/tests/e2e/sqlalchemy/test_basic.py
@@ -2,8 +2,13 @@ import os, datetime, decimal
 import pytest
 from unittest import skipIf
 from sqlalchemy import create_engine, select, insert, Column, MetaData, Table
-from sqlalchemy.orm import declarative_base, Session
+from sqlalchemy.orm import Session
 from sqlalchemy.types import SMALLINT, Integer, BOOLEAN, String, DECIMAL, Date
+
+try:
+    from sqlalchemy.orm import declarative_base
+except ImportError:
+    from sqlalchemy.ext.declarative import declarative_base
 
 
 USER_AGENT_TOKEN = "PySQL e2e Tests"
@@ -19,6 +24,20 @@ def db_engine():
     SCHEMA = os.environ.get("schema")
 
     connect_args = {"_user_agent_entry": USER_AGENT_TOKEN}
+    
+    connect_args = {
+        **connect_args,
+        "http_path": HTTP_PATH,
+        "server_hostname": HOST,
+        "catalog": CATALOG,
+        "schema": SCHEMA
+    }
+
+    engine = create_engine(
+        f"databricks://token:{ACCESS_TOKEN}@{HOST}",
+        connect_args=connect_args,
+    )
+    return engine
 
     engine = create_engine(
         f"databricks://token:{ACCESS_TOKEN}@{HOST}?http_path={HTTP_PATH}&catalog={CATALOG}&schema={SCHEMA}",

--- a/tests/e2e/sqlalchemy/test_basic.py
+++ b/tests/e2e/sqlalchemy/test_basic.py
@@ -98,6 +98,7 @@ def test_connect_args(db_engine):
     assert expected in user_agent
 
 
+@pytest.mark.skipif(sqlalchemy_1_3(), reason="Pandas requires SQLAlchemy >= 1.4")
 def test_pandas_upload(db_engine, metadata_obj):
 
     import pandas as pd
@@ -237,7 +238,11 @@ def test_create_insert_drop_table_orm(base, session: Session):
         SampleObject.name.in_(["Bim Adewunmi", "Miki Meek"])
     )
 
-    output = [i for i in session.scalars(stmt)]
+    if sqlalchemy_1_3():
+        output = [i for i in session.execute(stmt)]
+    else:
+        output = [i for i in session.scalars(stmt)]
+
     assert len(output) == 2
 
     base.metadata.drop_all()


### PR DESCRIPTION
## Description

In #113 we relaxed the version requirement for SQLAlchemy. But some changes are needed to the client code to actually _work_ with version 1.3. This wasn't caught in our e2e tests initially because our test infra installs the newest supported version of SQLAlchemy -- so the tests never actually ran under `1.3.24`.

This pull request is split into easily understood commits that make sense to review one-by-one. Here are the changes needed to backport 1.3 support:

- [ ] sqla 1.4 changed how connection strings are parsed ([changelog](https://docs.sqlalchemy.org/en/20/changelog/migration_14.html#the-url-object-is-now-immutable)). To use databricks-sql-connector with version 1.3 you must include `http_path`, `catalog`, and `schema` in your extra `connect_args` _not in the connection string_. This pull request reflects that change in `examples/sqlalchemy.py` and our test suite.
- [ ] sqla 1.4 no longer automatically adds CHECK constraints for Boolean and Enum column types ([changelog](https://docs.sqlalchemy.org/en/20/changelog/migration_14.html#enum-and-boolean-datatypes-no-longer-default-to-create-constraint)). To support version 1.3 in our code we have to explicitly disable this.
- [ ] sqla 1.4 changed the dialect properties used to access the underlying dbapi connection (this is not mentioned in the changelog afaik), which we use when calling `databricks-sql-connector`'s `get_columns` and `get_tables` methods.
- [ ] sqla 1.4 changed the semantics when using the `select()` construct ([changelog](https://docs.sqlalchemy.org/en/20/changelog/migration_14.html#orm-query-is-internally-unified-with-select-update-delete-2-0-style-execution-available)). That change is not backwards compatible. So I added conditional logic in our tests and example script.
- [ ] Pandas requires sqlalchemy 1.4 so I add a skip condition for our pandas ingestion e2e test. It simply won't work for version 1.3
- [ ] Issue #171 tries to directly access the sqlalchemy `Inspector` object for reflection. I added a smoke test to ensure that this works in a basic use-case. **This pull request _does not_ implement a comprehensive suite of tests. More changes may be needed. We will expect further feedback from users on older versions of SQLAlchemy.**

## Related Tickets & Documents

Closes https://github.com/databricks/databricks-sql-python/issues/171
Follow-up for https://github.com/databricks/databricks-sql-python/pull/113

## Tests

I ran the e2e tests with SQLAlchemy 1.4.48 and 1.3.24. All tests now pass. I also ran `examples/sqlalchemy.py` under both installations to confirm it works.

To test this yourself, check out this branch and run `poetry install`. Then run `poetry run pip install sqlalchemy==1.3.24` to force the SQLAlchemy version back to 1.3. Then just run the sqlalchemy e2e tests.

You can also run `pip install databricks-sql-connector==2.7.1.dev1` and run the `examples/sqlalchemy.py` script from a fresh virtualenv to ensure that it works for you.

#### 1.3.24

<img width="396" alt="CleanShot 2023-07-10 at 17 03 28@2x" src="https://github.com/databricks/databricks-sql-python/assets/17067911/3ddec4de-fc1f-41cf-8589-f77db0df59e9">


#### 1.4.48

<img width="332" alt="CleanShot 2023-07-10 at 16 58 58@2x" src="https://github.com/databricks/databricks-sql-python/assets/17067911/49fac3d9-c7ff-4de7-af06-9a15917ccef0">


Prior to this change, version 1.3.24 would error-out immediately.