### PR TITLE
[Issue 115] sqlalchemy: fix has_table so it honours schema= argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2.7.x (Unreleased)
 
 - Add support for Cloud Fetch
+- SQLAlchemy has_table function now honours schema= argument and adds catalog= argument
 - Fix: Revised SQLAlchemy dialect and examples for compatibility with SQLAlchemy==1.3.x
 - Fix: oauth would fail if expired credentials appeared in ~/.netrc
 - Fix: Python HTTP proxies were broken after switch to urllib3

--- a/src/databricks/sqlalchemy/dialect/__init__.py
+++ b/src/databricks/sqlalchemy/dialect/__init__.py
@@ -267,18 +267,22 @@ class DatabricksDialect(default.DefaultDialect):
         # Databricks SQL Does not support transactions
         pass
 
-    def has_table(self, connection, table_name, schema=None, catalog=None, **kwargs) -> bool:
+    def has_table(
+        self, connection, table_name, schema=None, catalog=None, **kwargs
+    ) -> bool:
         """SQLAlchemy docstrings say dialect providers must implement this method"""
 
         _schema = schema or self.schema
         _catalog = catalog or self.catalog
-       
+
         # DBR >12.x uses underscores in error messages
         DBR_LTE_12_NOT_FOUND_STRING = "Table or view not found"
         DBR_GT_12_NOT_FOUND_STRING = "TABLE_OR_VIEW_NOT_FOUND"
 
         try:
-            res = connection.execute(f"DESCRIBE TABLE {_catalog}.{_schema}.{table_name}")
+            res = connection.execute(
+                f"DESCRIBE TABLE {_catalog}.{_schema}.{table_name}"
+            )
             return True
         except DatabaseError as e:
             if DBR_GT_12_NOT_FOUND_STRING in str(

--- a/src/databricks/sqlalchemy/dialect/__init__.py
+++ b/src/databricks/sqlalchemy/dialect/__init__.py
@@ -267,17 +267,18 @@ class DatabricksDialect(default.DefaultDialect):
         # Databricks SQL Does not support transactions
         pass
 
-    def has_table(self, connection, table_name, schema=None, **kwargs) -> bool:
+    def has_table(self, connection, table_name, schema=None, catalog=None, **kwargs) -> bool:
         """SQLAlchemy docstrings say dialect providers must implement this method"""
 
-        schema = schema or "default"
-
+        _schema = schema or self.schema
+        _catalog = catalog or self.catalog
+       
         # DBR >12.x uses underscores in error messages
         DBR_LTE_12_NOT_FOUND_STRING = "Table or view not found"
         DBR_GT_12_NOT_FOUND_STRING = "TABLE_OR_VIEW_NOT_FOUND"
 
         try:
-            res = connection.execute(f"DESCRIBE TABLE {table_name}")
+            res = connection.execute(f"DESCRIBE TABLE {_catalog}.{_schema}.{table_name}")
             return True
         except DatabaseError as e:
             if DBR_GT_12_NOT_FOUND_STRING in str(

--- a/tests/e2e/sqlalchemy/test_basic.py
+++ b/tests/e2e/sqlalchemy/test_basic.py
@@ -340,3 +340,34 @@ def test_get_table_names_smoke_test(samples_engine: Engine):
     with samples_engine.connect() as conn:
         _names = samples_engine.table_names(schema="nyctaxi", connection=conn)
         _names is not None, "get_table_names did not succeed"
+
+def test_has_table_across_schemas(db_engine: Engine, samples_engine: Engine):
+    """For this test to pass these conditions must be met:
+        - Table samples.nyctaxi.trips must exist
+        - Table samples.tpch.customer must exist
+        - The `catalog` and `schema` environment variables must be set and valid
+    """
+
+    with samples_engine.connect() as conn:
+             
+            # Check for table within schema declared at engine creation time
+            assert samples_engine.dialect.has_table(connection=conn, table_name="trips")
+
+            # Check for table within another schema in the same catalog
+            assert samples_engine.dialect.has_table(connection=conn, table_name="customer", schema="tpch")
+
+            # Check for a table within a different catalog
+            other_catalog = os.environ.get("catalog")
+            other_schema = os.environ.get("schema")
+
+            # Create a table in a different catalog
+            with db_engine.connect() as conn:
+                conn.execute("CREATE TABLE test_has_table (numbers_are_cool INT);")
+
+                try:
+                    # Verify with a different engine that this table is not found in the samples catalog
+                    assert not samples_engine.dialect.has_table(connection=conn, table_name="test_has_table")
+                    # Verify with a different engine that this table is found in a separate catalog
+                    assert samples_engine.dialect.has_table(connection=conn, table_name="test_has_table", schema=other_schema, catalog=other_catalog)
+                finally:
+                    conn.execute("DROP TABLE test_has_table;")

--- a/tests/e2e/sqlalchemy/test_basic.py
+++ b/tests/e2e/sqlalchemy/test_basic.py
@@ -341,6 +341,7 @@ def test_get_table_names_smoke_test(samples_engine: Engine):
         _names = samples_engine.table_names(schema="nyctaxi", connection=conn)
         _names is not None, "get_table_names did not succeed"
 
+
 def test_has_table_across_schemas(db_engine: Engine, samples_engine: Engine):
     """For this test to pass these conditions must be met:
         - Table samples.nyctaxi.trips must exist
@@ -349,25 +350,34 @@ def test_has_table_across_schemas(db_engine: Engine, samples_engine: Engine):
     """
 
     with samples_engine.connect() as conn:
-             
-            # Check for table within schema declared at engine creation time
-            assert samples_engine.dialect.has_table(connection=conn, table_name="trips")
 
-            # Check for table within another schema in the same catalog
-            assert samples_engine.dialect.has_table(connection=conn, table_name="customer", schema="tpch")
+        # 1) Check for table within schema declared at engine creation time
+        assert samples_engine.dialect.has_table(connection=conn, table_name="trips")
 
-            # Check for a table within a different catalog
-            other_catalog = os.environ.get("catalog")
-            other_schema = os.environ.get("schema")
+        # 2) Check for table within another schema in the same catalog
+        assert samples_engine.dialect.has_table(
+            connection=conn, table_name="customer", schema="tpch"
+        )
 
-            # Create a table in a different catalog
-            with db_engine.connect() as conn:
-                conn.execute("CREATE TABLE test_has_table (numbers_are_cool INT);")
+        # 3) Check for a table within a different catalog
+        other_catalog = os.environ.get("catalog")
+        other_schema = os.environ.get("schema")
 
-                try:
-                    # Verify with a different engine that this table is not found in the samples catalog
-                    assert not samples_engine.dialect.has_table(connection=conn, table_name="test_has_table")
-                    # Verify with a different engine that this table is found in a separate catalog
-                    assert samples_engine.dialect.has_table(connection=conn, table_name="test_has_table", schema=other_schema, catalog=other_catalog)
-                finally:
-                    conn.execute("DROP TABLE test_has_table;")
+        # Create a table in a different catalog
+        with db_engine.connect() as conn:
+            conn.execute("CREATE TABLE test_has_table (numbers_are_cool INT);")
+
+            try:
+                # Verify that this table is not found in the samples catalog
+                assert not samples_engine.dialect.has_table(
+                    connection=conn, table_name="test_has_table"
+                )
+                # Verify that this table is found in a separate catalog
+                assert samples_engine.dialect.has_table(
+                    connection=conn,
+                    table_name="test_has_table",
+                    schema=other_schema,
+                    catalog=other_catalog,
+                )
+            finally:
+                conn.execute("DROP TABLE test_has_table;")


### PR DESCRIPTION
## Description

Our `has_table` method was badly implemented because it didn't honour the provided `schema=` argument. I've updated the method and added an integration test. I also added a `catalog=` argument so users can run `has_table` across catalogs in UC-land.

## Related Tickets & Documents

Closes #115

~~This change is branched off of #173 so there appears to be more happening than is necessary. You only need to review the last two commits.~~ I rebased off of `main` so now there is a sensible number of commits.