### PR TITLE
Use urllib3 for retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2.8.x (Unreleased)
 
+- Replace retry handling with DatabricksRetryPolicy. This is disabled by default. To enable, set `enable_v3_retries=True` when creating `databricks.sql.client`
 - Other: Fix typo in README quick start example
 - Other: Add autospec to Client mocks and tidy up `make_request`
 

--- a/src/databricks/sql/auth/retry.py
+++ b/src/databricks/sql/auth/retry.py
@@ -30,7 +30,7 @@ class CommandType(Enum):
         value_name_map = {i.value: i.name for i in cls}
         valid_command = value_name_map.get(value, False)
         if valid_command:
-            return getattr(cls, valid_command)
+            return getattr(cls, str(valid_command))
         else:
             return cls.OTHER
 

--- a/src/databricks/sql/auth/retry.py
+++ b/src/databricks/sql/auth/retry.py
@@ -1,0 +1,378 @@
+import logging
+import time
+import typing
+from enum import Enum
+from typing import List, Optional, Tuple, Union
+
+from urllib3 import BaseHTTPResponse  # type: ignore
+from urllib3 import Retry
+from urllib3.util.retry import RequestHistory
+
+from databricks.sql.exc import (
+    CursorAlreadyClosedError,
+    MaxRetryDurationError,
+    NonRecoverableNetworkError,
+    SessionAlreadyClosedError,
+    UnsafeToRetryError,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class CommandType(Enum):
+    EXECUTE_STATEMENT = "ExecuteStatement"
+    CLOSE_SESSION = "CloseSession"
+    CLOSE_OPERATION = "CloseOperation"
+    OTHER = "Other"
+
+    @classmethod
+    def get(cls, value: str):
+        value_name_map = {i.value: i.name for i in cls}
+        valid_command = value_name_map.get(value, False)
+        if valid_command:
+            return getattr(cls, valid_command)
+        else:
+            return cls.OTHER
+
+
+class DatabricksRetryPolicy(Retry):
+    """
+    Implements our v3 retry policy by extending urllib3's robust default retry behaviour.
+
+    See `should_retry()` for details about what we do and do not retry.
+
+    :param delay_min:
+        Float of seconds for the minimum delay between retries. Passed to urllib3 as its
+        backoff_factor.
+
+    :param delay_max:
+        Float of seconds for the maximum delay between retries. Passed to urllib3 as its
+        backoff_max
+
+    :param stop_after_attempts_count:
+        Integer maximum number of attempts that will be retried. Passed to urllib3 as its
+        total.
+
+    :param stop_after_attempts_duration:
+        Float of maximum number of seconds from the beginning of the first request that a
+        request may be retried. This behaviour is not implemented in urllib3.
+
+    :param delay_default:
+        Float of seconds the connector will wait between sucessive GetOperationStatus
+        requests. This parameter is not used to retry failed network requests. We include
+        it in this class to keep all retry behaviour encapsulated in this file.
+
+    :param force_dangerous_codes:
+        List of integer HTTP status codes that the connector will retry, even for dangerous
+        commands like ExecuteStatement. This is passed to urllib3 by extending its status_forcelist
+
+    :param _retry_start_time:
+        Float unix timestamp. Used to monitor the overall request duration across successive
+        retries. Never set this value directly. Use self.start_retry_time() instead. Users
+        never set this value. It is set by ThriftBackend immediately before issuing a network
+        request.
+
+    :param _command_type:
+        CommandType of the current request being retried. Used to modify retry behaviour based
+        on the type of Thrift command being issued. See self.should_retry() for details. Users
+        never set this value directly. It is set by ThriftBackend immediately before issuing
+        a network request.
+
+    :param urllib3_kwargs:
+        Dictionary of arguments that are passed to Retry.__init__. Any setting of Retry() that
+        Databricks does not override or extend may be modified here.
+    """
+
+    def __init__(
+        self,
+        delay_min: float,
+        delay_max: float,
+        stop_after_attempts_count: int,
+        stop_after_attempts_duration: float,
+        delay_default: float,
+        force_dangerous_codes: List[int],
+        _retry_start_time: Optional[float] = None,
+        _command_type: Optional[CommandType] = None,
+        urllib3_kwargs: dict = {},
+    ):
+        # These values do not change from one command to the next
+        self.delay_max = delay_max
+        self.delay_min = delay_min
+        self.stop_after_attempts_count = stop_after_attempts_count
+        self.stop_after_attempts_duration = stop_after_attempts_duration
+        self.delay_default = delay_default
+        self.force_dangerous_codes = force_dangerous_codes
+
+        # These values do change from one command to the next
+        self._retry_start_time = _retry_start_time
+        self.command_type = _command_type
+
+        # the urllib3 kwargs are a mix of configuration (some of which we override)
+        # and counters like `total` or `connect` which may change between successive retries
+        # we only care about urllib3 kwargs that we alias, override, or add to in some way
+
+        # the length of _history increases as retries are performed
+        _history: Union[Tuple[RequestHistory, ...], None] = urllib3_kwargs.get(
+            "history"
+        )
+
+        if not _history:
+            # no attempts were made so we can retry the current command as many times as specified by the user
+            _attempts_remaining = self.stop_after_attempts_count
+        else:
+            # at least one of our attempts has been consumed, and urllib3 will have set a total
+            _total: int = urllib3_kwargs.pop("total")
+            _attempts_remaining = _total
+
+        _urllib_kwargs_we_care_about = dict(
+            total=_attempts_remaining,
+            respect_retry_after_header=True,
+            backoff_factor=self.delay_min,
+            backoff_max=self.delay_max,
+            allowed_methods=["POST"],
+            status_forcelist=[429, 503, *self.force_dangerous_codes],
+        )
+
+        urllib3_kwargs.update(**_urllib_kwargs_we_care_about)
+
+        super().__init__(
+            **urllib3_kwargs,  # type: ignore
+        )
+
+    def new(self, **urllib3_incremented_counters: typing.Any) -> Retry:
+        """This method is responsible for passing the entire Retry state to its next iteration.
+
+        urllib3 calls Retry.new() between successive requests as part of its `.increment()` method as shown below:
+
+        ```python
+            new_retry = self.new(
+                total=total,
+                connect=connect,
+                read=read,
+                redirect=redirect,
+                status=status_count,
+                other=other,
+                history=history,
+        )
+        ```
+
+        The arguments it passes to `.new()` (total, connect, read, etc.) are those which modified by `.increment()`.
+
+        Since our subclass has a new __init__ signature and requires custom state variables, we override the method
+        to pipe our Databricks-specific state while preserving the super-class's behaviour.
+        """
+
+        # These arguments will match the function signature for self.__init__
+        databricks_init_params = dict(
+            delay_min=self.delay_min,
+            delay_max=self.delay_max,
+            stop_after_attempts_count=self.stop_after_attempts_count,
+            stop_after_attempts_duration=self.stop_after_attempts_duration,
+            delay_default=self.delay_default,
+            force_dangerous_codes=self.force_dangerous_codes,
+            _retry_start_time=self._retry_start_time,
+            _command_type=self._command_type,
+            urllib3_kwargs={},
+        )
+
+        # Gather urllib3's current retry state _before_ increment was called
+        # These arguments match the function signature for super().__init__
+        # Note: if we update urllib3 we may need to add/remove arguments from this dict
+        urllib3_init_params = dict(
+            total=self.total,
+            connect=self.connect,
+            read=self.read,
+            redirect=self.redirect,
+            status=self.status,
+            other=self.other,
+            allowed_methods=self.allowed_methods,
+            status_forcelist=self.status_forcelist,
+            backoff_factor=self.backoff_factor,  # type: ignore
+            backoff_max=self.backoff_max,  # type: ignore
+            raise_on_redirect=self.raise_on_redirect,
+            raise_on_status=self.raise_on_status,
+            history=self.history,
+            remove_headers_on_redirect=self.remove_headers_on_redirect,
+            respect_retry_after_header=self.respect_retry_after_header,
+            backoff_jitter=self.backoff_jitter,  # type: ignore
+        )
+
+        # Update urllib3's current state to reflect the incremented counters
+        urllib3_init_params.update(**urllib3_incremented_counters)
+
+        # Include urllib3's current state in our __init__ params
+        databricks_init_params["urllib3_kwargs"].update(**urllib3_init_params)  # type: ignore
+
+        return type(self)(
+            **databricks_init_params,  # type: ignore[arg-type]
+        )
+
+    @property
+    def command_type(self) -> Optional[CommandType]:
+        return self._command_type or None
+
+    @command_type.setter
+    def command_type(self, value: CommandType):
+        self._command_type = value
+
+    @property
+    def get_operation_status_delay(self) -> float:
+        """Time in seconds the connector will wait between requests polling a GetOperationStatus Request
+
+        This property is never read by urllib3 for the purpose of retries. It's stored in this class
+        to keep all retry logic in one place
+        """
+        return self.delay_default
+
+    def start_retry_timer(self):
+        """Timer is used to monitor the overall time across successive requests
+
+        Should only be called by ThriftBackend before sending a Thrift command"""
+        self._retry_start_time = time.time()
+
+    def check_timer_duration(self):
+        """Return time in seconds since the timer was started"""
+        return time.time() - self._retry_start_time
+
+    def check_proposed_wait(self, proposed_wait: Union[int, float]) -> None:
+        """Raise an exception if the proposed wait would exceed the configured max_attempts_duration"""
+
+        proposed_overall_time = self.check_timer_duration() + proposed_wait
+        if proposed_overall_time > self.stop_after_attempts_duration:
+            raise MaxRetryDurationError(
+                f"Retry request would exceed Retry policy max retry duration of {self.stop_after_attempts_duration} seconds"
+            )
+
+    def sleep_for_retry(self, response: BaseHTTPResponse) -> bool:  # type: ignore
+        """Sleeps for the duration specified in the response Retry-After header, if present
+
+        A MaxRetryDurationError will be raised if doing so would exceed self.max_attempts_duration
+
+        This method is only called by urllib3 internals.
+        """
+        retry_after = self.get_retry_after(response)
+        if retry_after:
+            self.check_proposed_wait(retry_after)
+            time.sleep(retry_after)
+            return True
+
+        return False
+
+    def get_backoff_time(self) -> float:
+        """Calls urllib3's built-in get_backoff_time.
+
+        Never returns a value larger than self.delay_max
+        A MaxRetryDurationError will be raised if the calculated backoff would exceed self.max_attempts_duration
+
+        Note: within urllib3, a backoff is only calculated in cases where a Retry-After header is not present
+            in the previous unsuccessful request.
+        """
+
+        proposed_backoff = super().get_backoff_time()
+        proposed_backoff = min(proposed_backoff, self.delay_max)
+        self.check_proposed_wait(proposed_backoff)
+
+        return proposed_backoff
+
+    def should_retry(self, method: str, status_code: int) -> Tuple[bool, str]:
+        """This method encapsulates the connector's approach to retries.
+
+        We always retry a request unless one of these conditions is met:
+
+            1. The request received a 200 (Success) status code
+               Because the request succeeded. No retry is required.
+            2. The request received a 501 (Not Implemented) status code
+               Because this request can never succeed.
+            3. The request received a 404 (Not Found) code and the request CommandType
+               was CloseSession or CloseOperation. This code indicates that the session
+               or cursor was already closed. Further retries will always return the same
+               code.
+            4. The request CommandType was ExecuteStatement and the HTTP code does not
+               appear in the default status_forcelist or force_dangerous_codes list. By
+               default, thisd means ExecuteStatement is only retried for codes 429 and 503.
+               This limit prevents automatically retrying non-idempotent commands that could
+               be destructive.
+
+            5. OSErrors (handled automatically by urllib3 outside this method)
+            6. Redirects (handled automatically by urllib3 outside this method)
+
+        Returns True if the request should be retried. Returns False or raises an exception
+        if a retry would violate the configured policy.
+        """
+
+        # Request succeeded. Don't retry.
+        if status_code == 200:
+            return False, "200 codes are not retried"
+
+        # Request failed and server said NotImplemented. This isn't recoverable. Don't retry.
+        if status_code == 501:
+            raise NonRecoverableNetworkError("Received code 501 from server.")
+
+        # Request failed and this method is not retryable. We only retry POST requests.
+        if not self._is_method_retryable(method):  # type: ignore
+            return False, "Only POST requests are retried"
+
+        # Request failed with 404 because CloseSession return 404 if you repeat the request.
+        if (
+            status_code == 404
+            and self.command_type == CommandType.CLOSE_SESSION
+            and len(self.history) > 0
+        ):
+            raise SessionAlreadyClosedError(
+                "CloseSession received 404 code from Databricks. Session is already closed."
+            )
+
+        # Request failed with 404 because CloseOperation return 404 if you repeat the request.
+        if (
+            status_code == 404
+            and self.command_type == CommandType.CLOSE_OPERATION
+            and len(self.history) > 0
+        ):
+            raise CursorAlreadyClosedError(
+                "CloseOperation received 404 code from Databricks. Cursor is already closed."
+            )
+
+        # Request failed, was an ExecuteStatement and the command may have reached the server
+        if (
+            self.command_type == CommandType.EXECUTE_STATEMENT
+            and status_code not in self.status_forcelist
+            and status_code not in self.force_dangerous_codes
+        ):
+            raise UnsafeToRetryError(
+                "ExecuteStatement command can only be retried for codes 429 and 503"
+            )
+
+        # Request failed with a dangerous code, was an ExecuteStatement, but user forced retries
+        if (
+            self.command_type == CommandType.EXECUTE_STATEMENT
+            and status_code in self.force_dangerous_codes
+        ):
+            return (
+                True,
+                f"Request failed with dangerous code {status_code} that is one of the configured _retry_dangerous_codes.",
+            )
+
+        # None of the above conditions applied. Eagerly retry.
+        logger.debug(
+            f"This request should be retried: {self.command_type and self.command_type.value}"
+        )
+        return (
+            True,
+            "Failed requests are retried by default per configured DatabricksRetryPolicy",
+        )
+
+    def is_retry(
+        self, method: str, status_code: int, has_retry_after: bool = False
+    ) -> bool:
+        """
+        Called by urllib3 when determining whether or not to retry
+
+        Logs a debug message if the request will be retried
+        """
+
+        should_retry, msg = self.should_retry(method, status_code)
+
+        if should_retry:
+            logger.debug(msg)
+
+        return should_retry

--- a/src/databricks/sql/auth/retry.py
+++ b/src/databricks/sql/auth/retry.py
@@ -90,7 +90,7 @@ class DatabricksRetryPolicy(Retry):
         self.delay_min = delay_min
         self.stop_after_attempts_count = stop_after_attempts_count
         self.stop_after_attempts_duration = stop_after_attempts_duration
-        self.delay_default = delay_default
+        self._delay_default = delay_default
         self.force_dangerous_codes = force_dangerous_codes
 
         # the urllib3 kwargs are a mix of configuration (some of which we override)
@@ -236,13 +236,15 @@ class DatabricksRetryPolicy(Retry):
         self._command_type = value
 
     @property
-    def get_operation_status_delay(self) -> float:
+    def delay_default(self) -> float:
         """Time in seconds the connector will wait between requests polling a GetOperationStatus Request
 
         This property is never read by urllib3 for the purpose of retries. It's stored in this class
-        to keep all retry logic in one place
+        to keep all retry logic in one place.
+
+        This property is only set by __init__ and cannot be modified afterward.
         """
-        return self.delay_default
+        return self._delay_default
 
     def start_retry_timer(self) -> None:
         """Timer is used to monitor the overall time across successive requests

--- a/src/databricks/sql/auth/retry.py
+++ b/src/databricks/sql/auth/retry.py
@@ -229,7 +229,7 @@ class DatabricksRetryPolicy(Retry):
 
     @property
     def command_type(self) -> Optional[CommandType]:
-        return self._command_type or None
+        return self._command_type
 
     @command_type.setter
     def command_type(self, value: CommandType) -> None:

--- a/src/databricks/sql/auth/thrift_http_client.py
+++ b/src/databricks/sql/auth/thrift_http_client.py
@@ -1,7 +1,7 @@
 import base64
 import logging
 import urllib.parse
-from typing import Dict, Union
+from typing import Dict, Union, Optional
 
 import six
 import thrift
@@ -14,6 +14,8 @@ from http.client import HTTPResponse
 from io import BytesIO
 
 from urllib3 import HTTPConnectionPool, HTTPSConnectionPool, ProxyManager
+
+from databricks.sql.auth.retry import CommandType, DatabricksRetryPolicy
 
 
 class THttpClient(thrift.transport.THttpClient.THttpClient):
@@ -28,6 +30,7 @@ class THttpClient(thrift.transport.THttpClient.THttpClient):
         key_file=None,
         ssl_context=None,
         max_connections: int = 1,
+        retry_policy: Union[DatabricksRetryPolicy, int] = 0,
     ):
         if port is not None:
             warnings.warn(
@@ -81,6 +84,10 @@ class THttpClient(thrift.transport.THttpClient.THttpClient):
 
         self.max_connections = max_connections
 
+        # If retry_policy == 0 then urllib3 will not retry automatically
+        # this falls back to the pre-v3 behaviour where thrift_backend.py handles retry logic
+        self.retry_policy = retry_policy
+
         self.__wbuf = BytesIO()
         self.__resp: Union[None, HTTPResponse] = None
         self.__timeout = None
@@ -91,6 +98,13 @@ class THttpClient(thrift.transport.THttpClient.THttpClient):
     def setCustomHeaders(self, headers: Dict[str, str]):
         self._headers = headers
         super().setCustomHeaders(headers)
+
+    def startRetryTimer(self):
+        """Notify DatabricksRetryPolicy of the request start time
+
+        This is used to enforce the retry_stop_after_attempts_duration
+        """
+        self.retry_policy and self.retry_policy.start_retry_timer()
 
     def open(self):
 
@@ -167,6 +181,7 @@ class THttpClient(thrift.transport.THttpClient.THttpClient):
             headers=headers,
             preload_content=False,
             timeout=self.__timeout,
+            retries=self.retry_policy,
         )
 
         # Get reply to flush the request
@@ -188,3 +203,12 @@ class THttpClient(thrift.transport.THttpClient.THttpClient):
         )
         cr = base64.b64encode(ap.encode()).strip()
         return "Basic " + six.ensure_str(cr)
+
+    def set_retry_command_type(self, value: CommandType):
+        """Pass the provided CommandType to the retry policy"""
+        if isinstance(self.retry_policy, DatabricksRetryPolicy):
+            self.retry_policy.command_type = value
+        else:
+            logger.warning(
+                "DatabricksRetryPolicy is currently bypassed. The CommandType cannot be set."
+            )

--- a/src/databricks/sql/auth/thrift_http_client.py
+++ b/src/databricks/sql/auth/thrift_http_client.py
@@ -1,7 +1,7 @@
 import base64
 import logging
 import urllib.parse
-from typing import Dict, Union, Optional
+from typing import Dict, Union
 
 import six
 import thrift

--- a/src/databricks/sql/exc.py
+++ b/src/databricks/sql/exc.py
@@ -93,3 +93,25 @@ class RequestError(OperationalError):
     """
 
     pass
+
+
+class MaxRetryDurationError(RequestError):
+    """Thrown if the next HTTP request retry would exceed the configured
+    stop_after_attempts_duration
+    """
+
+
+class NonRecoverableNetworkError(RequestError):
+    """Thrown if an HTTP code 501 is received"""
+
+
+class UnsafeToRetryError(RequestError):
+    """Thrown if ExecuteStatement request receives a code other than 200, 429, or 503"""
+
+
+class SessionAlreadyClosedError(RequestError):
+    """Thrown if CloseSession receives a code 404. ThriftBackend should gracefully proceed as this is expected."""
+
+
+class CursorAlreadyClosedError(RequestError):
+    """Thrown if CancelOperation receives a code 404. ThriftBackend should gracefully proceed as this is expected."""

--- a/src/databricks/sql/thrift_backend.py
+++ b/src/databricks/sql/thrift_backend.py
@@ -17,9 +17,11 @@ import thrift.transport.TTransport
 import urllib3.exceptions
 
 import databricks.sql.auth.thrift_http_client
+from databricks.sql.auth.thrift_http_client import CommandType
 from databricks.sql.auth.authenticators import AuthProvider
 from databricks.sql.thrift_api.TCLIService import TCLIService, ttypes
 from databricks.sql import *
+from databricks.sql.exc import MaxRetryDurationError
 from databricks.sql.thrift_api.TCLIService.TCLIService import (
     Client as TCLIServiceClient,
 )
@@ -70,6 +72,12 @@ class ThriftBackend:
     CLOSED_OP_STATE = ttypes.TOperationState.CLOSED_STATE
     ERROR_OP_STATE = ttypes.TOperationState.ERROR_STATE
 
+    _retry_delay_min: float
+    _retry_delay_max: float
+    _retry_stop_after_attempts_count: int
+    _retry_stop_after_attempts_duration: float
+    _retry_delay_default: float
+
     def __init__(
         self,
         server_hostname: str,
@@ -113,9 +121,15 @@ class ThriftBackend:
         #
         # _retry_stop_after_attempts_count
         #  The maximum number of times we should retry retryable requests (defaults to 24)
+        # _retry_dangerous_codes
+        #  An iterable of integer HTTP status codes. ExecuteStatement commands will be retried if these codes are received.
+        #  (defaults to [])
         # _socket_timeout
         #  The timeout in seconds for socket send, recv and connect operations. Should be a positive float or integer.
         #  (defaults to 900)
+        # _enable_v3_retries
+        # Whether to use the DatabricksRetryPolicy implemented in urllib3
+        # (defaults to False)
         # max_download_threads
         #  Number of threads for handling cloud fetch downloads. Defaults to 10
 
@@ -166,10 +180,28 @@ class ThriftBackend:
 
         self._auth_provider = auth_provider
 
+        # Connector version 3 retry approach
+        self.enable_v3_retries = kwargs.get("_enable_v3_retries", False)
+        self.force_dangerous_codes = kwargs.get("_retry_dangerous_codes", [])
+
+        additional_transport_args = {}
+        if self.enable_v3_retries:
+            self.retry_policy = databricks.sql.auth.thrift_http_client.DatabricksRetryPolicy(
+                delay_min=self._retry_delay_min,
+                delay_max=self._retry_delay_max,
+                stop_after_attempts_count=self._retry_stop_after_attempts_count,
+                stop_after_attempts_duration=self._retry_stop_after_attempts_duration,
+                delay_default=self._retry_delay_default,
+                force_dangerous_codes=self.force_dangerous_codes,
+            )
+
+            additional_transport_args["retry_policy"] = self.retry_policy
+
         self._transport = databricks.sql.auth.thrift_http_client.THttpClient(
             auth_provider=self._auth_provider,
             uri_or_host=uri,
             ssl_context=ssl_context,
+            **additional_transport_args,  # type: ignore
         )
 
         timeout = kwargs.get("_socket_timeout", DEFAULT_SOCKET_TIMEOUT)
@@ -188,6 +220,7 @@ class ThriftBackend:
 
         self._request_lock = threading.RLock()
 
+    # TODO: Move this bounding logic into DatabricksRetryPolicy for v3 (PECO-918)
     def _initialize_retry_args(self, kwargs):
         # Configure retries & timing: use user-settings or defaults, and bound
         # by policy. Log.warn when given param gets restricted.
@@ -335,15 +368,20 @@ class ThriftBackend:
 
             error, error_message, retry_delay = None, None, None
             try:
+
                 # The MagicMocks in our unit tests have a `name` property instead of `__name__`.
-                logger.debug(
-                    "Sending request: {}(<REDACTED>)".format(
-                        getattr(
-                            method, "__name__", getattr(method, "name", "UnknownMethod")
-                        )
-                    )
+                this_method_name = getattr(
+                    method, "__name__", getattr(method, "name", "UnknownMethod")
                 )
+
+                logger.debug("Sending request: {}(<REDACTED>)".format(this_method_name))
                 unsafe_logger.debug("Sending request: {}".format(request))
+
+                # These three lines are no-ops if the v3 retry policy is not in use
+                this_command_type = CommandType.get(this_method_name)
+                self._transport.set_retry_command_type(this_command_type)
+                self._transport.startRetryTimer()
+                
                 response = method(request)
 
                 # Calling `close()` here releases the active HTTP connection back to the pool
@@ -359,9 +397,16 @@ class ThriftBackend:
             except urllib3.exceptions.HTTPError as err:
                 # retry on timeout. Happens a lot in Azure and it is safe as data has not been sent to server yet
 
+                # TODO: don't use exception handling for GOS polling...
+
                 gos_name = TCLIServiceClient.GetOperationStatus.__name__
                 if method.__name__ == gos_name:
-                    retry_delay = bound_retry_delay(attempt, self._retry_delay_default)
+                    delay_default = (
+                        self.enable_v3_retries
+                        and self.retry_policy.get_operation_status_delay
+                        or self._retry_delay_default
+                    )
+                    retry_delay = bound_retry_delay(attempt, delay_default)
                     logger.info(
                         f"GetOperationStatus failed with HTTP error and will be retried: {str(err)}"
                     )

--- a/src/databricks/sql/thrift_backend.py
+++ b/src/databricks/sql/thrift_backend.py
@@ -381,7 +381,7 @@ class ThriftBackend:
                 this_command_type = CommandType.get(this_method_name)
                 self._transport.set_retry_command_type(this_command_type)
                 self._transport.startRetryTimer()
-                
+
                 response = method(request)
 
                 # Calling `close()` here releases the active HTTP connection back to the pool

--- a/src/databricks/sql/thrift_backend.py
+++ b/src/databricks/sql/thrift_backend.py
@@ -403,7 +403,7 @@ class ThriftBackend:
                 if method.__name__ == gos_name:
                     delay_default = (
                         self.enable_v3_retries
-                        and self.retry_policy.get_operation_status_delay
+                        and self.retry_policy.delay_default
                         or self._retry_delay_default
                     )
                     retry_delay = bound_retry_delay(attempt, delay_default)

--- a/src/databricks/sqlalchemy/dialect/__init__.py
+++ b/src/databricks/sqlalchemy/dialect/__init__.py
@@ -74,7 +74,7 @@ class DatabricksDialect(default.DefaultDialect):
     driver: str = "databricks-sql-python"
     default_schema_name: str = "default"
 
-    preparer = DatabricksIdentifierPreparer
+    preparer = DatabricksIdentifierPreparer  # type: ignore
     type_compiler = DatabricksTypeCompiler
     ddl_compiler = DatabricksDDLCompiler
     supports_statement_cache: bool = True

--- a/tests/e2e/common/retry_test_mixins.py
+++ b/tests/e2e/common/retry_test_mixins.py
@@ -1,3 +1,20 @@
+from contextlib import contextmanager
+from typing import List
+from unittest.mock import MagicMock, PropertyMock, patch
+
+import pytest
+from urllib3.exceptions import MaxRetryError
+
+from databricks.sql.auth.retry import DatabricksRetryPolicy
+from databricks.sql.exc import (
+    MaxRetryDurationError,
+    NonRecoverableNetworkError,
+    RequestError,
+    SessionAlreadyClosedError,
+    UnsafeToRetryError,
+)
+
+
 class Client429ResponseMixin:
     def test_client_should_retry_automatically_when_getting_429(self):
         with self.cursor() as cursor:
@@ -15,8 +32,10 @@ class Client429ResponseMixin:
                     rows = cursor.fetchall()
                     self.assertEqual(len(rows), 1)
                     self.assertEqual(rows[0][0], 1)
-        expected = "Maximum rate of 1 requests per SECOND has been exceeded. " \
-                   "Please reduce the rate of requests and try again after 1 seconds."
+        expected = (
+            "Maximum rate of 1 requests per SECOND has been exceeded. "
+            "Please reduce the rate of requests and try again after 1 seconds."
+        )
         exception_str = str(cm.exception)
 
         # FIXME (Ali Smesseim, 7-Jul-2020): ODBC driver does not always return the
@@ -36,3 +55,267 @@ class Client503ResponseMixin:
             with self.connection(self.conf_to_disable_temporarily_unavailable_retries):
                 pass
         self.assertIn(error_msg_substring, str(cm.exception))
+
+
+@contextmanager
+def mocked_server_response(status: int = 200, headers: dict = {"Retry-After": None}):
+    """Context manager for patching urllib3 responses"""
+
+    # When mocking mocking a BaseHTTPResponse for urllib3 the mock must include
+    #   1. A status code
+    #   2. A headers dict
+    #   3. mock.get_redirect_location() return falsy
+    mock_response = MagicMock(headers=headers, status=status)
+    mock_response.get_redirect_location.return_value = False
+
+    with patch("urllib3.connectionpool.HTTPSConnectionPool._get_conn") as getconn_mock:
+        getconn_mock.return_value.getresponse.return_value = mock_response
+        try:
+            yield getconn_mock
+        finally:
+            pass
+
+
+@contextmanager
+def mock_sequential_server_responses(responses: List[dict]):
+    """Same as the mocked_server_response context manager but it will yield
+    the provided responses in the order received
+
+    `responses` should be a list of dictionaries containing these members:
+        - status: int
+        - headers: dict
+    """
+
+    mock_responses = []
+
+    # Each resp should have these members:
+
+    for resp in responses:
+        _mock = MagicMock(headers=resp["headers"], status=resp["status"])
+        _mock.get_redirect_location.return_value = False
+        mock_responses.append(_mock)
+
+    with patch("urllib3.connectionpool.HTTPSConnectionPool._get_conn") as getconn_mock:
+        getconn_mock.return_value.getresponse.side_effect = mock_responses
+        try:
+            yield getconn_mock
+        finally:
+            pass
+
+
+class PySQLRetryTestsMixin:
+    """Home for retry tests where we patch urllib to return different codes and monitor that it tries to retry"""
+
+    # For testing purposes
+    _retry_policy = {
+        "_enable_v3_retries": True,
+        "_retry_delay_min": 0.1,
+        "_retry_delay_max": 5,
+        "_retry_stop_after_attempts_count": 5,
+        "_retry_stop_after_attempts_duration": 10,
+        "_retry_delay_default": 0.5,
+    }
+
+    def test_retry_urllib3_settings_are_honored(self):
+        """Databricks overrides some of urllib3's configuration. This tests confirms that what configuration
+        we DON'T override is preserved in urllib3's internals
+        """
+
+        urllib3_config = {"connect": 10, "read": 11, "redirect": 12}
+        rp = DatabricksRetryPolicy(
+            delay_min=0.1,
+            delay_max=10.0,
+            stop_after_attempts_count=10,
+            stop_after_attempts_duration=10.0,
+            delay_default=1.0,
+            force_dangerous_codes=[],
+            urllib3_kwargs=urllib3_config,
+        )
+
+        assert rp.connect == 10
+        assert rp.read == 11
+        assert rp.redirect == 12
+
+    def test_oserror_retries(self):
+        """If a network error occurs during make_request, the request is retried according to policy"""
+        with patch(
+            "urllib3.connectionpool.HTTPSConnectionPool._validate_conn",
+        ) as mock_validate_conn:
+            mock_validate_conn.side_effect = OSError("Some arbitrary network error")
+            with self.assertRaises(MaxRetryError) as cm:
+                with self.connection(extra_params=self._retry_policy) as conn:
+                    pass
+
+            assert mock_validate_conn.call_count == 6
+
+    def test_retry_max_count_not_exceeded(self):
+        """GIVEN the max_attempts_count is 5
+        WHEN the server sends nothing but 429 responses
+        THEN the connector issues six request (original plus five retries)
+            before raising an exception
+        """
+        with mocked_server_response(status=404) as mock_obj:
+            with self.assertRaises(MaxRetryError) as cm:
+                with self.connection(extra_params=self._retry_policy) as conn:
+                    pass
+            assert mock_obj.return_value.getresponse.call_count == 6
+
+    def test_retry_max_duration_not_exceeded(self):
+        """GIVEN the max attempt duration of 10 seconds
+        WHEN the server sends a Retry-After header of 60 seconds
+        THEN the connector raises a MaxRetryDurationError
+        """
+        with mocked_server_response(status=429, headers={"Retry-After": "60"}):
+            with self.assertRaises(RequestError) as cm:
+                with self.connection(extra_params=self._retry_policy) as conn:
+                    pass
+            assert isinstance(cm.exception.args[1], MaxRetryDurationError)
+
+    def test_retry_abort_non_recoverable_error(self):
+        """GIVEN the server returns a code 501
+        WHEN the connector receives this response
+        THEN nothing is retried and an exception is raised
+        """
+
+        # Code 501 is a Not Implemented error
+        with mocked_server_response(status=501):
+            with self.assertRaises(RequestError) as cm:
+                with self.connection(extra_params=self._retry_policy) as conn:
+                    pass
+                assert isinstance(cm.exception.args[1], NonRecoverableNetworkError)
+
+    def test_retry_abort_unsafe_execute_statement_retry_condition(self):
+        """GIVEN the server sends a code other than 429 or 503
+        WHEN the connector sent an ExecuteStatement command
+        THEN nothing is retried because it's idempotent
+        """
+        with self.connection(extra_params=self._retry_policy) as conn:
+            with conn.cursor() as cursor:
+                # Code 502 is a Bad Gateway, which we commonly see in production under heavy load
+                with mocked_server_response(status=502):
+                    with self.assertRaises(RequestError) as cm:
+                        cursor.execute("Not a real query")
+                        assert isinstance(cm.exception.args[1], UnsafeToRetryError)
+
+    def test_retry_dangerous_codes(self):
+        """GIVEN the server sends a dangerous code and the user forced this to be retryable
+        WHEN the connector sent an ExecuteStatement command
+        THEN the command is retried
+        """
+
+        # These http codes are not retried by default
+        # For some applications, idempotency is not important so we give users a way to force retries anyway
+        DANGEROUS_CODES = [502, 504]
+
+        additional_settings = {
+            "_retry_dangerous_codes": DANGEROUS_CODES,
+            "_retry_stop_after_attempts_count": 1,
+        }
+
+        # Prove that these codes are not retried by default
+        with self.connection(extra_params={**self._retry_policy}) as conn:
+            with conn.cursor() as cursor:
+                for dangerous_code in DANGEROUS_CODES:
+                    with mocked_server_response(status=dangerous_code) as mock_obj:
+                        with self.assertRaises(RequestError) as cm:
+                            cursor.execute("Not a real query")
+                            assert isinstance(cm.exception.args[1], UnsafeToRetryError)
+
+        # Prove that these codes are retried if forced by the user
+        with self.connection(
+            extra_params={**self._retry_policy, **additional_settings}
+        ) as conn:
+            with conn.cursor() as cursor:
+                for dangerous_code in DANGEROUS_CODES:
+                    with mocked_server_response(status=dangerous_code) as mock_obj:
+                        with pytest.raises(MaxRetryError) as cm:
+                            cursor.execute("Not a real query")
+
+    def test_retry_safe_execute_statement_retry_condition(self):
+        """GIVEN the server sends either code 429 or 503
+        WHEN the connector sent an ExecuteStatement command
+        THEN the request is retried because these are idempotent
+        """
+
+        responses = [
+            {"status": 429, "headers": {"Retry-After": "1"}},
+            {"status": 503, "headers": {"Retry-After": None}},
+        ]
+
+        with self.connection(
+            extra_params={**self._retry_policy, "_retry_stop_after_attempts_count": 1}
+        ) as conn:
+            with conn.cursor() as cursor:
+                # Code 502 is a Bad Gateway, which we commonly see in production under heavy load
+                with mock_sequential_server_responses(responses) as mock_obj:
+                    with pytest.raises(MaxRetryError):
+                        cursor.execute("This query never reaches the server")
+                    assert mock_obj.return_value.getresponse.call_count == 2
+
+    def test_retry_abort_close_session_on_404(self):
+        """GIVEN the connector sends a CloseSession command
+        WHEN server sends a 404 (which is normally retried)
+        THEN nothing is retried because 404 means the session already closed
+        """
+
+        # First response is a Bad Gateway -> Result is the command actually goes through
+        # Second response is a 404 because the session is no longer found
+        responses = [
+            {"status": 502, "headers": {"Retry-After": "1"}},
+            {"status": 404, "headers": {"Retry-After": None}},
+        ]
+
+        with self.connection(extra_params={**self._retry_policy}) as conn:
+            with mock_sequential_server_responses(responses):
+                with self.assertLogs(
+                    "databricks.sql",
+                    level="INFO",
+                ) as cm:
+                    conn.close()
+                    expected_message_was_found = False
+                    for log in cm.output:
+                        if expected_message_was_found:
+                            break
+                        target = "Session was closed by a prior request"
+                        expected_message_was_found = target in log
+            self.assertTrue(
+                expected_message_was_found, "Did not find expected log messages"
+            )
+
+    def test_retry_abort_close_operation_on_404(self):
+        """GIVEN the connector sends a CancelOperation command
+        WHEN server sends a 404 (which is normally retried)
+        THEN nothing is retried because 404 means the operation was already canceled
+        """
+
+        # First response is a Bad Gateway -> Result is the command actually goes through
+        # Second response is a 404 because the session is no longer found
+        responses = [
+            {"status": 502, "headers": {"Retry-After": "1"}},
+            {"status": 404, "headers": {"Retry-After": None}},
+        ]
+
+        with self.connection(extra_params={**self._retry_policy}) as conn:
+            with conn.cursor() as curs:
+                with patch(
+                    "databricks.sql.utils.ExecuteResponse.has_been_closed_server_side",
+                    new_callable=PropertyMock,
+                    return_value=False,
+                ):
+                    # This call guarantees we have an open cursor at the server
+                    curs.execute("SELECT 1")
+                    with mock_sequential_server_responses(responses):
+                        with self.assertLogs(
+                            "databricks.sql",
+                            level="INFO",
+                        ) as cm:
+                            curs.close()
+                        expected_message_was_found = False
+                        for log in cm.output:
+                            if expected_message_was_found:
+                                break
+                            target = "Operation was canceled by a prior request"
+                            expected_message_was_found = target in log
+                self.assertTrue(
+                    expected_message_was_found, "Did not find expected log messages"
+                )

--- a/tests/e2e/common/retry_test_mixins.py
+++ b/tests/e2e/common/retry_test_mixins.py
@@ -205,7 +205,7 @@ class PySQLRetryTestsMixin:
 
         # These http codes are not retried by default
         # For some applications, idempotency is not important so we give users a way to force retries anyway
-        DANGEROUS_CODES = [502, 504]
+        DANGEROUS_CODES = [502, 504, 400]
 
         additional_settings = {
             "_retry_dangerous_codes": DANGEROUS_CODES,

--- a/tests/e2e/test_driver.py
+++ b/tests/e2e/test_driver.py
@@ -27,6 +27,7 @@ from tests.e2e.common.timestamp_tests import TimestampTestsMixin
 from tests.e2e.common.decimal_tests import DecimalTestsMixin
 from tests.e2e.common.retry_test_mixins import Client429ResponseMixin, Client503ResponseMixin
 from tests.e2e.common.staging_ingestion_tests import PySQLStagingIngestionTestSuiteMixin
+from tests.e2e.common.retry_test_mixins import PySQLRetryTestsMixin
 
 log = logging.getLogger(__name__)
 
@@ -141,7 +142,7 @@ class PySQLLargeQueriesSuite(PySQLTestCase, LargeQueriesMixin):
 # Exclude Retry tests because they require specific setups, and LargeQueries too slow for core
 # tests
 class PySQLCoreTestSuite(SmokeTestMixin, CoreTestMixin, DecimalTestsMixin, TimestampTestsMixin,
-                         PySQLTestCase, PySQLStagingIngestionTestSuiteMixin):
+                         PySQLTestCase, PySQLStagingIngestionTestSuiteMixin, PySQLRetryTestsMixin):
     validate_row_value_type = True
     validate_result = True
 


### PR DESCRIPTION
## Description

This pull request implements a sub-class of `urllib3`'s `Retry` class. The goal is reliability, testability, and extensibility of our retry behaviour which prior to this change was entangled with the command execution flow in `thrift_backend.py`. This new behavior is gated behind a new config called `enable_v3_retries`.

The code is extensively commented and includes accurate docstrings. All tests pass.