### PR TITLE
Bump to 2.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 2.9.x (Unreleased)
 
+## 2.9.1 (2023-08-11)
+
 - Other: Explicitly pin urllib3 to ^2.0.0
 
 ## 2.9.0 (2023-08-10)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "databricks-sql-connector"
-version = "2.9.0"
+version = "2.9.1"
 description = "Databricks SQL Connector for Python"
 authors = ["Databricks <databricks-sql-connector-maintainers@databricks.com>"]
 license = "Apache-2.0"

--- a/src/databricks/sql/__init__.py
+++ b/src/databricks/sql/__init__.py
@@ -28,7 +28,7 @@ DATETIME = DBAPITypeObject("timestamp")
 DATE = DBAPITypeObject("date")
 ROWID = DBAPITypeObject()
 
-__version__ = "2.9.0"
+__version__ = "2.9.1"
 USER_AGENT_NAME = "PyDatabricksSqlConnector"
 
 # These two functions are pyhive legacy


### PR DESCRIPTION
Explicitly pinning the urllib3 dependency is important for non-isolated execution environments (like DBR) where `urllib3` is shared across Python environments. This connector expects version ^2.0.0 and raises exceptions without it. 