### PR TITLE
Make backwards compatible with urllib3~=1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ numpy = [
 sqlalchemy = "^1.3.24"
 openpyxl = "^3.0.10"
 alembic = "^1.0.11"
-urllib3 = "^2.0.0"
+urllib3 = ">=1.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.1.2"

--- a/src/databricks/sql/auth/retry.py
+++ b/src/databricks/sql/auth/retry.py
@@ -10,7 +10,7 @@ try:
     from urllib3 import BaseHTTPResponse  # type: ignore
 except ImportError:
     # If urllib3~=1.0 is installed
-    from urllib3 import HTTPResponse as BaseHTTPResponse 
+    from urllib3 import HTTPResponse as BaseHTTPResponse
 from urllib3 import Retry
 from urllib3.util.retry import RequestHistory
 

--- a/src/databricks/sql/auth/retry.py
+++ b/src/databricks/sql/auth/retry.py
@@ -4,7 +4,13 @@ import typing
 from enum import Enum
 from typing import List, Optional, Tuple, Union
 
-from urllib3 import BaseHTTPResponse  # type: ignore
+# We only use this import for type hinting
+try:
+    # If urllib3~=2.0 is installed
+    from urllib3 import BaseHTTPResponse  # type: ignore
+except ImportError:
+    # If urllib3~=1.0 is installed
+    from urllib3 import HTTPResponse as BaseHTTPResponse 
 from urllib3 import Retry
 from urllib3.util.retry import RequestHistory
 


### PR DESCRIPTION
This is required to support dbt-databricks because dbt-core is pinned to `urllib3~=1.0`