### PR TITLE
Make backwards compatible with urllib3~=1.0 [Follow up #197] 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.9.4 (Unreleased)
 
-## 2.9.3 (2023-08-23)
+## 2.9.3 (2023-08-24)
 
 - Fix: Connections failed when urllib3~=1.0.0 is installed (#206)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,22 +1,26 @@
 # Release History
 
-## 2.9.x (Unreleased)
+## 2.9.4 (Unreleased)
+
+## 2.9.3 (2023-08-23)
+
+- Fix: Connections failed when urllib3~=1.0.0 is installed (#206)
 
 ## 2.9.2 (2023-08-17)
 
-- Other: Add `examples/v3_retries_query_execute.py` 
-- Other: suppress log message when `_enable_v3_retries` is not `True`
-- Other: make this connector backwards compatible with `urllib3>=1.0.0`
+- Other: Add `examples/v3_retries_query_execute.py` (#199)
+- Other: suppress log message when `_enable_v3_retries` is not `True` (#199)
+- Other: make this connector backwards compatible with `urllib3>=1.0.0` (#197)
 
 ## 2.9.1 (2023-08-11)
 
-- Other: Explicitly pin urllib3 to ^2.0.0
+- Other: Explicitly pin urllib3 to ^2.0.0 (#191)
 
 ## 2.9.0 (2023-08-10)
 
-- Replace retry handling with DatabricksRetryPolicy. This is disabled by default. To enable, set `enable_v3_retries=True` when creating `databricks.sql.client`
-- Other: Fix typo in README quick start example
-- Other: Add autospec to Client mocks and tidy up `make_request`
+- Replace retry handling with DatabricksRetryPolicy. This is disabled by default. To enable, set `enable_v3_retries=True` when creating `databricks.sql.client` (#182)
+- Other: Fix typo in README quick start example (#186)
+- Other: Add autospec to Client mocks and tidy up `make_request` (#188)
 
 ## 2.8.0 (2023-07-21)
 

--- a/src/databricks/sql/auth/retry.py
+++ b/src/databricks/sql/auth/retry.py
@@ -56,8 +56,7 @@ class DatabricksRetryPolicy(Retry):
         `backoff_factor`.
 
     :param delay_max:
-        Float of seconds for the maximum delay between retries. This is an alias for urllib3's
-        `backoff_max`
+        Float of seconds for the maximum delay between retries.
 
     :param stop_after_attempts_count:
         Integer maximum number of attempts that will be retried. This is an alias for urllib3's
@@ -122,7 +121,6 @@ class DatabricksRetryPolicy(Retry):
             total=_attempts_remaining,
             respect_retry_after_header=True,
             backoff_factor=self.delay_min,
-            backoff_max=self.delay_max,
             allowed_methods=["POST"],
             status_forcelist=[429, 503, *self.force_dangerous_codes],
         )
@@ -212,13 +210,11 @@ class DatabricksRetryPolicy(Retry):
             allowed_methods=self.allowed_methods,
             status_forcelist=self.status_forcelist,
             backoff_factor=self.backoff_factor,  # type: ignore
-            backoff_max=self.backoff_max,  # type: ignore
             raise_on_redirect=self.raise_on_redirect,
             raise_on_status=self.raise_on_status,
             history=self.history,
             remove_headers_on_redirect=self.remove_headers_on_redirect,
             respect_retry_after_header=self.respect_retry_after_header,
-            backoff_jitter=self.backoff_jitter,  # type: ignore
         )
 
         # Update urllib3's current state to reflect the incremented counters


### PR DESCRIPTION
## Description

Not sure how we missed this when testing #197, but `urllib3~=1.x` does not implement `backoff_max` or `backoff_jitter` configurations. So executions would fail for users who installed `urllib31=1.x`. This PR completes the work of #197 and updates our retry test mocks to be compatible with the internal workings of the older urllib3 version.

urllib3 version 1 expects the response to include a `.msg` attribute with `.keys()` and `.items()` methods. While in real-life execution this would be an `HTTPMessage` object, the `dict()` that our mocks use for headers is already sufficient and implements those methods. `.msg` is ignored in urllib3 version 2 so the same mock definition works regardless of which version of urllib3 is installed. 

Going forward, we should have some kind of smoke test that runs our tests with both versions of urllib3 installed. A bare install of this connector always pulls urllib3 version 2, but many customers and partners will have already installed an older urllib3 -- this case isn't captured in our current testing pattern.

## Related Tickets & Documents
Resolves https://github.com/databricks/databricks-sql-python/issues/205
Resolves ES-836977