### PR TITLE
Github Actions Fix: poetry install fails for python 3.7 tests

### DIFF
--- a/.github/workflows/code-quality-checks.yml
+++ b/.github/workflows/code-quality-checks.yml
@@ -29,6 +29,7 @@ jobs:
       - name: Install Poetry
         uses: snok/install-poetry@v1
         with:
+          version: ${{ matrix.python-version == 3.7 && '1.5.1' || 'latest'  }}
           virtualenvs-create: true
           virtualenvs-in-project: true
           installer-parallel: true
@@ -80,6 +81,7 @@ jobs:
       - name: Install Poetry
         uses: snok/install-poetry@v1
         with:
+          version: ${{ matrix.python-version == 3.7 && '1.5.1' || 'latest'  }}
           virtualenvs-create: true
           virtualenvs-in-project: true
           installer-parallel: true
@@ -132,6 +134,7 @@ jobs:
       - name: Install Poetry
         uses: snok/install-poetry@v1
         with:
+          version: ${{ matrix.python-version == 3.7 && '1.5.1' || 'latest'  }}
           virtualenvs-create: true
           virtualenvs-in-project: true
           installer-parallel: true


### PR DESCRIPTION
The latest version of poetry released on 20 August 2023 (four days ago as of this commit) which drops support for Python 3.7, causing our github action to fail.

Until we complete #207 we need to conditionally install the last version of poetry that supports Python 3.7 (poetry==1.5.1)