### PR TITLE
Update changelog to indicate that 2.9.1 and 2.9.2 have been yanked.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,15 @@
 
 ## 2.9.2 (2023-08-17)
 
+__Note: this release was yanked from Pypi on 13 September 2023 due to compatibility issues with environments where `urllib3<=2.0.0` were installed. The log changes are incorporated into version 2.9.3 and greater.__
+
 - Other: Add `examples/v3_retries_query_execute.py` (#199)
 - Other: suppress log message when `_enable_v3_retries` is not `True` (#199)
 - Other: make this connector backwards compatible with `urllib3>=1.0.0` (#197)
 
 ## 2.9.1 (2023-08-11)
+
+__Note: this release was yanked from Pypi on 13 September 2023 due to compatibility issues with environments where `urllib3<=2.0.0` were installed.__
 
 - Other: Explicitly pin urllib3 to ^2.0.0 (#191)
 


### PR DESCRIPTION
We've chosen to [yank](https://pypi.org/help/#yanked) these installations because they were immediately nonfunctional for any installation where `urllib3<=2.0.0` was already installed. The releases work as expected installed in a dedicated virtualenv, however, since by default urllib3 version 2 will be installed if you `pip install databricks-sql-connector==2.9.1` or `2.9.2`.

If you are running version 2.9.1 or 2.9.2 you can safely upgrade to 2.9.3 which incorporates the same changes intended for these yanked versions, but have been fully tested to be compatible with both urllib3 1.x and 2.x

We'll also need to:

- [x] Update releases page for [2.9.1](https://github.com/databricks/databricks-sql-python/releases/tag/v2.9.1) and [2.9.2](https://github.com/databricks/databricks-sql-python/releases/tag/v2.9.2) to indicate they've been yanked

### What pip users will see

Running `pip install databricks-sql-connector==2.9.1` or `pip install databricks-sql-connector==2.9.2` will show this warning:

```
WARNING: The candidate selected for download or install is a yanked version: 'databricks-sql-connector' candidate (version 2.9.1 at https://files.pythonhosted.org/packages/86/6e/b976f37f24a0e1c5986861200ab5aa417c749b63655912956263ddf1bbd0/databricks_sql_connector-2.9.1-py3-none-any.whl (from https://pypi.org/simple/databricks-sql-connector/) (requires-python:>=3.7.1,<4.0.0))
Reason for being yanked: Incompatible with urllib3<=2.0.0
```

### Pypi releases screen before yank

<img width="821" alt="CleanShot 2023-09-13 at 12 36 43@2x" src="https://github.com/databricks/databricks-sql-python/assets/17067911/235c10bc-187c-4e6c-b530-e53f17933992">


### Pypi releases screen after yank

<img width="811" alt="CleanShot 2023-09-13 at 12 38 03@2x" src="https://github.com/databricks/databricks-sql-python/assets/17067911/f5ef8951-11d6-4576-8465-050e835d5814">
