### PR TITLE
[PECO-1109] Parameterized Query: add suport for inferring decimal types

### DIFF
--- a/src/databricks/sql/utils.py
+++ b/src/databricks/sql/utils.py
@@ -510,6 +510,7 @@ class DbSqlParameter:
     def __eq__(self, other):
         return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
+
 class DbsqlDynamicDecimalType:
     def __init__(self, value):
         self.value = value

--- a/src/databricks/sql/utils.py
+++ b/src/databricks/sql/utils.py
@@ -500,7 +500,7 @@ class DbSqlType(Enum):
 class DbSqlParameter:
     name: str
     value: Any
-    type: Union[DbSqlType, Enum]
+    type: Union[DbSqlType, DbsqlDynamicDecimalType, Enum]
 
     def __init__(self, name="", value=None, type=None):
         self.name = name

--- a/src/databricks/sql/utils.py
+++ b/src/databricks/sql/utils.py
@@ -510,6 +510,10 @@ class DbSqlParameter:
     def __eq__(self, other):
         return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
 
+class DbsqlDynamicDecimalType:
+    def __init__(self, value):
+        self.value = value
+
 
 def named_parameters_to_dbsqlparams_v1(parameters: Dict[str, str]):
     dbsqlparams = []
@@ -547,9 +551,8 @@ def infer_types(params: list[DbSqlParameter]):
                 raise ValueError("Parameter type cannot be inferred")
 
         if param.type == DbSqlType.DECIMAL:
-            maker = namedtuple("DbsqlDynamicDecimalType", "value")
             cast_exp = calculate_decimal_cast_string(param.value)
-            param.type = maker(cast_exp)
+            param.type = DbsqlDynamicDecimalType(cast_exp)
 
         param.value = str(param.value)
     return new_params

--- a/tests/e2e/common/parameterized_query_tests.py
+++ b/tests/e2e/common/parameterized_query_tests.py
@@ -1,11 +1,18 @@
 import datetime
 from decimal import Decimal
+from enum import Enum
 from typing import Dict, List, Tuple, Union
 
 import pytz
 
-from databricks.sql.client import Connection
+from databricks.sql.exc import DatabaseError
 from databricks.sql.utils import DbSqlParameter, DbSqlType
+
+
+class MyCustomDecimalType(Enum):
+    DECIMAL_38_0 = "DECIMAL(38,0)"
+    DECIMAL_38_2 = "DECIMAL(38,2)"
+    DECIMAL_18_9 = "DECIMAL(18,9)"
 
 
 class PySQLParameterizedQueryTestSuiteMixin:
@@ -63,6 +70,11 @@ class PySQLParameterizedQueryTestSuiteMixin:
         result = self._get_one_result(self.QUERY, params)
         assert result.col == "Hello"
 
+    def test_primitive_inferred_decimal(self):
+        params = {"p": Decimal("1234.56")}
+        result = self._get_one_result(self.QUERY, params)
+        assert result.col == Decimal("1234.56")
+
     def test_dbsqlparam_inferred_bool(self):
 
         params = [DbSqlParameter(name="p", value=True, type=None)]
@@ -103,6 +115,11 @@ class PySQLParameterizedQueryTestSuiteMixin:
         result = self._get_one_result(self.QUERY, params)
         assert result.col == "Hello"
 
+    def test_dbsqlparam_inferred_decimal(self):
+        params = [DbSqlParameter(name="p", value=Decimal("1234.56"), type=None)]
+        result = self._get_one_result(self.QUERY, params)
+        assert result.col == Decimal("1234.56")
+
     def test_dbsqlparam_explicit_bool(self):
 
         params = [DbSqlParameter(name="p", value=True, type=DbSqlType.BOOLEAN)]
@@ -142,3 +159,51 @@ class PySQLParameterizedQueryTestSuiteMixin:
         params = [DbSqlParameter(name="p", value="Hello", type=DbSqlType.STRING)]
         result = self._get_one_result(self.QUERY, params)
         assert result.col == "Hello"
+
+    def test_dbsqlparam_explicit_decimal(self):
+        params = [
+            DbSqlParameter(name="p", value=Decimal("1234.56"), type=DbSqlType.DECIMAL)
+        ]
+        result = self._get_one_result(self.QUERY, params)
+        assert result.col == Decimal("1234.56")
+
+    def test_dbsqlparam_custom_explicit_decimal_38_0(self):
+
+        # This DECIMAL can be contained in a DECIMAL(38,0) column in Databricks
+        value = Decimal("12345678912345678912345678912345678912")
+        params = [
+            DbSqlParameter(name="p", value=value, type=MyCustomDecimalType.DECIMAL_38_0)
+        ]
+        result = self._get_one_result(self.QUERY, params)
+        assert result.col == value
+
+    def test_dbsqlparam_custom_explicit_decimal_38_2(self):
+
+        # This DECIMAL can be contained in a DECIMAL(38,2) column in Databricks
+        value = Decimal("123456789123456789123456789123456789.12")
+        params = [
+            DbSqlParameter(name="p", value=value, type=MyCustomDecimalType.DECIMAL_38_2)
+        ]
+        result = self._get_one_result(self.QUERY, params)
+        assert result.col == value
+
+    def test_dbsqlparam_custom_explicit_decimal_18_9(self):
+
+        # This DECIMAL can be contained in a DECIMAL(38,2) column in Databricks
+        value = Decimal("123456789.123456789")
+        params = [
+            DbSqlParameter(name="p", value=value, type=MyCustomDecimalType.DECIMAL_18_9)
+        ]
+        result = self._get_one_result(self.QUERY, params)
+        assert result.col == value
+
+    def test_primitive_inferred_decimal_raises_exception(self):
+        """The default precision is DECIMAL(6,2). Without a custom DbsqlParameter type, the value will be rounded"""
+
+        # This DECIMAL would require DECIMAL(10,2) but the default is DECIMAL(6,2)
+        params = {"p": Decimal("12345678.91")}
+
+        with self.assertRaises(
+            DatabaseError, msg="cannot be cast to DECIMAL(6,2) because it is malformed"
+        ):
+            result = self._get_one_result(self.QUERY, params)

--- a/tests/e2e/common/parameterized_query_tests.py
+++ b/tests/e2e/common/parameterized_query_tests.py
@@ -189,7 +189,7 @@ class PySQLParameterizedQueryTestSuiteMixin:
 
     def test_dbsqlparam_custom_explicit_decimal_18_9(self):
 
-        # This DECIMAL can be contained in a DECIMAL(38,2) column in Databricks
+        # This DECIMAL can be contained in a DECIMAL(18,9) column in Databricks
         value = Decimal("123456789.123456789")
         params = [
             DbSqlParameter(name="p", value=value, type=MyCustomDecimalType.DECIMAL_18_9)

--- a/tests/unit/test_parameters.py
+++ b/tests/unit/test_parameters.py
@@ -34,7 +34,7 @@ class TestTSparkParameterConversion(object):
                 name="", type="FLOAT", value=TSparkParameterValue(stringValue="1.0")
             ),
             TSparkParameter(
-                name="", type="DECIMAL(6,2)", value=TSparkParameterValue(stringValue="1.0")
+                name="", type="DECIMAL(2,1)", value=TSparkParameterValue(stringValue="1.0")
             ),
         ]
 

--- a/tests/unit/test_parameters.py
+++ b/tests/unit/test_parameters.py
@@ -3,6 +3,7 @@ from databricks.sql.utils import (
     infer_types,
     named_parameters_to_dbsqlparams_v1,
     named_parameters_to_dbsqlparams_v2,
+    calculate_decimal_cast_string
 )
 from databricks.sql.thrift_api.TCLIService.ttypes import (
     TSparkParameter,
@@ -10,6 +11,8 @@ from databricks.sql.thrift_api.TCLIService.ttypes import (
 )
 from databricks.sql.utils import DbSqlParameter, DbSqlType
 import pytest
+
+from decimal import Decimal
 
 
 class TestTSparkParameterConversion(object):
@@ -73,3 +76,25 @@ class TestTSparkParameterConversion(object):
         assert infer_types([DbSqlParameter("", 1.0, DbSqlType.DECIMAL)]) == [
             DbSqlParameter("", "1.0", DbSqlType.DECIMAL)
         ]
+
+class TestCalculateDecimalCast(object):
+
+    def test_38_38(self):
+        input = Decimal(".12345678912345678912345678912345678912")
+        output = calculate_decimal_cast_string(input)
+        assert output == "DECIMAL(38,38)"
+    
+    def test_18_9(self):
+        input = Decimal("123456789.123456789")
+        output = calculate_decimal_cast_string(input)
+        assert output == "DECIMAL(18,9)"
+    
+    def test_38_0(self):
+        input = Decimal("12345678912345678912345678912345678912")
+        output = calculate_decimal_cast_string(input)
+        assert output == "DECIMAL(38,0)"
+
+    def test_6_2(self):
+        input = Decimal("1234.56")
+        output = calculate_decimal_cast_string(input)
+        assert output == "DECIMAL(6,2)"

--- a/tests/unit/test_parameters.py
+++ b/tests/unit/test_parameters.py
@@ -31,7 +31,7 @@ class TestTSparkParameterConversion(object):
                 name="", type="FLOAT", value=TSparkParameterValue(stringValue="1.0")
             ),
             TSparkParameter(
-                name="", type="DECIMAL", value=TSparkParameterValue(stringValue="1.0")
+                name="", type="DECIMAL(6,2)", value=TSparkParameterValue(stringValue="1.0")
             ),
         ]
 


### PR DESCRIPTION
## Description

This connector has strong support for Python Decimal types. But the parameterized query implementation merged last week is missing the ability to infer them. This pull request implements type inference for decimals with e2e tests for four different scenarios:

- A parameter is set equal to a primitive `Decimal()` object (type must be inferred)
- A `Decimal()` parameter value is wrapped in `DbsqlParameter` with the `type` set to `None` (type must be inferred)
- A `Decimal()` parameter value is wrapped in `DbsqlParameter` and the type is set to `DbsqlType.DECIMAL` (type is not inferred but cast expression must be calculated)
- A `Decimal()` parameter value is wrapped in `DbsqlParameter` and the type is set to a custom implementation (type is not inferred and cast expression is accepted from the user as-is)

In the first three scenarios, pysql will inspect the passed Decimal and provide the appropriate Databricks SQL cast expression to contain that decimal (such as `DECIMAL(18,2)` or `DECIMAL(38,5)`)

I also split out the `infer_types` tests so we can make special assertions about decimals and ran `isort` over a couple of files.

I'll open a subsequent PR with a full example of how users can work with these APIs.