### PR TITLE
Query parameters: implement support for binding NoneType parameters

### DIFF
--- a/src/databricks/sql/utils.py
+++ b/src/databricks/sql/utils.py
@@ -559,13 +559,15 @@ def infer_types(params: list[DbSqlParameter]):
             # figure out what type to use
             _type = type_lookup_table.get(type(_value), False)
             if not _type:
-                raise ValueError(f"Could not infer parameter type from {type(param.value)} - {param.value}")
+                raise ValueError(
+                    f"Could not infer parameter type from {type(param.value)} - {param.value}"
+                )
 
         # Decimal require special handling because one column type in Databricks can have multiple precisions
         if _type == DbSqlType.DECIMAL:
             cast_exp = calculate_decimal_cast_string(param.value)
             _type = DbsqlDynamicDecimalType(cast_exp)
-        
+
         # VOID / NULL types must be passed in a unique way as TSparkParameters with no value
         if _type == DbSqlType.VOID:
             new_params.append(DbSqlParameter(name=_name, type=DbSqlType.VOID))

--- a/src/databricks/sql/utils.py
+++ b/src/databricks/sql/utils.py
@@ -551,13 +551,13 @@ def infer_types(params: list[DbSqlParameter]):
     for param in params:
         _name: str = param.name
         _value: Any = param.value
-        _type: DbSqlType
+        _type: Union[DbSqlType, DbsqlDynamicDecimalType, Enum, None]
 
         if param.type:
             _type = param.type
         else:
             # figure out what type to use
-            _type = type_lookup_table.get(type(_value), False)
+            _type = type_lookup_table.get(type(_value), None)
             if not _type:
                 raise ValueError(
                     f"Could not infer parameter type from {type(param.value)} - {param.value}"

--- a/tests/e2e/common/parameterized_query_tests.py
+++ b/tests/e2e/common/parameterized_query_tests.py
@@ -34,6 +34,12 @@ class PySQLParameterizedQueryTestSuiteMixin:
 
         return Decimal(str(input)).quantize(Decimal("0." + "0" * place_value))
 
+    def test_primitive_inferred_none(self):
+
+        params = {"p": None}
+        result = self._get_one_result(self.QUERY, params)
+        assert result.col == None
+
     def test_primitive_inferred_bool(self):
 
         params = {"p": True}
@@ -78,6 +84,12 @@ class PySQLParameterizedQueryTestSuiteMixin:
         params = {"p": Decimal("1234.56")}
         result = self._get_one_result(self.QUERY, params)
         assert result.col == Decimal("1234.56")
+
+    def test_dbsqlparam_inferred_none(self):
+
+        params = [DbSqlParameter(name="p", value=None, type=None)]
+        result = self._get_one_result(self.QUERY, params)
+        assert result.col == None
 
     def test_dbsqlparam_inferred_bool(self):
 
@@ -124,6 +136,12 @@ class PySQLParameterizedQueryTestSuiteMixin:
         result = self._get_one_result(self.QUERY, params)
         assert result.col == Decimal("1234.56")
 
+    def test_dbsqlparam_explicit_none(self):
+
+        params = [DbSqlParameter(name="p", value=None, type=DbSqlType.VOID)]
+        result = self._get_one_result(self.QUERY, params)
+        assert result.col == None
+    
     def test_dbsqlparam_explicit_bool(self):
 
         params = [DbSqlParameter(name="p", value=True, type=DbSqlType.BOOLEAN)]

--- a/tests/e2e/test_driver.py
+++ b/tests/e2e/test_driver.py
@@ -340,7 +340,7 @@ class PySQLCoreTestSuite(SmokeTestMixin, CoreTestMixin, DecimalTestsMixin, Times
             assert rows[0]["col_1"] == "you're"
 
             # Test escape syntax in parameter
-            cursor.execute("SELECT * FROM {} WHERE {}.col_1 LIKE %(var)s".format(table_name, table_name), parameters={"var": "you're"})
+            cursor.execute("SELECT * FROM {} WHERE {}.col_1 LIKE :var".format(table_name, table_name), parameters={"var": "you're"})
             rows = cursor.fetchall()
             assert rows[0]["col_1"] == "you're"
 

--- a/tests/unit/test_parameters.py
+++ b/tests/unit/test_parameters.py
@@ -97,6 +97,17 @@ class TestTSparkParameterConversion(object):
         assert x.value == "1.0"
         assert isinstance(x.type, DbsqlDynamicDecimalType)
         assert x.type.value == "DECIMAL(2,1)"
+
+    def test_infer_types_none(self):
+        
+        input = DbSqlParameter("", None)
+        output: List[DbSqlParameter] = infer_types([input])
+        
+        x = output[0]
+
+        assert x.value == None
+        assert x.type == DbSqlType.VOID
+        assert x.type.value == "VOID"
        
 
 class TestCalculateDecimalCast(object):


### PR DESCRIPTION
## Description

This PR adds support and test for inferring `NoneType` parameter values passed to DBR as parameters. Prior to this, binding a `None` as a parameter was impossible. This includes both unit and e2e tests. Should be an easy review.


<details><summary>The original PR / issue description appears below</summary>

### Background

Trying to run the SQLAlchemy test suite after query parameterisation merged, we can’t bind a parameter with a value of NoneType because the connector can’t infer what column type it should be.

Of course, any nullable column type can accept a NULL. I don’t see in in the specification how to handle this but my guess is that I can just use a STRING column and pass a null value.

After some experimentation in the DBSQL web UI I found that CASTing a NULL into any other type still returns a NULL of that type. For example:

```sql
SELECT CAST(NULL as STRING)
SELECT CAST(NULL as BIGINT)
SELECT CAST(NULL as DATE)
SELECT CAST(NULL as TIMESTAMP)
SELECT CAST(NULL as BINARY)
SELECT CAST(NULL as VOID)
```

all return the same value: `null`.

So what this PR ought to do is construct a TSparkParameter such that it writes out a CAST expression which returns a `null`. But I've run into trouble.

### Description

This pull request is supposed to add support for binding a Python `None` to a parameter marker in a query. **It does not work**. I'm opening this pull request and branch for visibility about the specific test I'm running.

When I tried setting TSparkParameter.value to `"NULL"` I get this exception:

```
[undefined]databricks.sql.exc.DatabaseError: [INVALID_PARAMETER_MARKER_VALUE.INVALID_VALUE_FOR_DATA_TYPE] An invalid parameter mapping was provided: the value 'NULL' for parameter 'p' cannot be cast to VOID because it is malformed.
self = <tests.e2e.test_driver.PySQLCoreTestSuite testMethod=test_dbsqlparam_inferred_none>
```

I assume this is because the resulting CAST expression looks like this:

```sql
SELECT CAST("NULL" as VOID)
```

Which doesn't work because `"NULL"` is a string and I need to actually cast the literal value `NULL` (no quote marks).

However, when I try setting the TSparkParameter value to `None` I get a blind transport error:

```
./tests/e2e/test_driver.py::PySQLCoreTestSuite::test_dbsqlparam_inferred_none Failed: [undefined]databricks.sql.exc.RequestError: Error during request to server: org.apache.thrift.transport.TTransportException
self = <tests.e2e.test_driver.PySQLCoreTestSuite testMethod=test_dbsqlparam_inferred_none>

    def test_dbsqlparam_inferred_none(self):
    
        params = [DbSqlParameter(name="p", value=None, type=None)]
>       result = self._get_one_result(self.QUERY, params)

tests/e2e/common/parameterized_query_tests.py:85: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
tests/e2e/common/parameterized_query_tests.py:30: in _get_one_result
    cursor.execute(query, parameters=parameters)
src/databricks/sql/client.py:509: in execute
    execute_response = self.thrift_backend.execute_command(
src/databricks/sql/thrift_backend.py:844: in execute_command
    resp = self.make_request(self._client.ExecuteStatement, req)
src/databricks/sql/thrift_backend.py:483: in make_request
    self._handle_request_error(error_info, attempt, elapsed)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <databricks.sql.thrift_backend.ThriftBackend object at 0x10279b950>
error_info = RequestErrorInfo(error=TApplicationException(None), error_message='org.apache.thrift.transport.TTransportException', r...nifest=None, resultRetentionSeconds=None, resultByteLimit=None, resultDataFormat=None, originatingClientIdentity=None))
attempt = 1, elapsed = 0.10815000534057617

    def _handle_request_error(self, error_info, attempt, elapsed):
        max_attempts = self._retry_stop_after_attempts_count
        max_duration_s = self._retry_stop_after_attempts_duration
    
        if (
            error_info.retry_delay is not None
            and elapsed + error_info.retry_delay > max_duration_s
        ):
            no_retry_reason = NoRetryReason.OUT_OF_TIME
        elif error_info.retry_delay is not None and attempt >= max_attempts:
            no_retry_reason = NoRetryReason.OUT_OF_ATTEMPTS
        elif error_info.retry_delay is None:
            no_retry_reason = NoRetryReason.NOT_RETRYABLE
        else:
            no_retry_reason = None
    
        full_error_info_context = error_info.full_info_logging_context(
            no_retry_reason, attempt, max_attempts, elapsed, max_duration_s
        )
    
        if no_retry_reason is not None:
            user_friendly_error_message = error_info.user_friendly_error_message(
                no_retry_reason, attempt, elapsed
            )
            network_request_error = RequestError(
                user_friendly_error_message, full_error_info_context, error_info.error
            )
            logger.info(network_request_error.message_with_context())
    
>           raise network_request_error
E           databricks.sql.exc.RequestError: Error during request to server: org.apache.thrift.transport.TTransportException

src/databricks/sql/thrift_backend.py:314: RequestError
```

</detail>