### PR TITLE
Revert "[PECO-1083] Updated thrift files and added check for protocol version"

### DIFF
--- a/src/databricks/sql/client.py
+++ b/src/databricks/sql/client.py
@@ -5,7 +5,6 @@ import pyarrow
 import requests
 import json
 import os
-from databricks.sql.thrift_api.TCLIService import ttypes
 
 from databricks.sql import __version__
 from databricks.sql import *
@@ -225,11 +224,6 @@ class Connection:
 
     def get_session_id(self):
         return self.thrift_backend.handle_to_id(self._session_handle)
-
-    def get_session_protocol_version(self):
-        return self.thrift_backend.extract_protocol_version_from_handle(
-            self._session_handle
-        )
 
     def get_session_id_hex(self):
         return self.thrift_backend.handle_to_hex_id(self._session_handle)
@@ -507,13 +501,6 @@ class Cursor:
         """
         if parameters is None:
             parameters = []
-        elif (
-            self.connection.get_session_protocol_version()
-            < ttypes.TProtocolVersion.SPARK_CLI_SERVICE_PROTOCOL_V8
-        ):
-            raise Error(
-                "Parameterized operations are not supported by this server. DBR 14.1 is required."
-            )
         else:
             parameters = named_parameters_to_tsparkparams(parameters)
 

--- a/src/databricks/sql/thrift_api/TCLIService/ttypes.py
+++ b/src/databricks/sql/thrift_api/TCLIService/ttypes.py
@@ -36,7 +36,6 @@ class TProtocolVersion(object):
     SPARK_CLI_SERVICE_PROTOCOL_V5 = 42245
     SPARK_CLI_SERVICE_PROTOCOL_V6 = 42246
     SPARK_CLI_SERVICE_PROTOCOL_V7 = 42247
-    SPARK_CLI_SERVICE_PROTOCOL_V8 = 42248
 
     _VALUES_TO_NAMES = {
         -7: "__HIVE_JDBC_WORKAROUND",
@@ -58,7 +57,6 @@ class TProtocolVersion(object):
         42245: "SPARK_CLI_SERVICE_PROTOCOL_V5",
         42246: "SPARK_CLI_SERVICE_PROTOCOL_V6",
         42247: "SPARK_CLI_SERVICE_PROTOCOL_V7",
-        42248: "SPARK_CLI_SERVICE_PROTOCOL_V8",
     }
 
     _NAMES_TO_VALUES = {
@@ -81,7 +79,6 @@ class TProtocolVersion(object):
         "SPARK_CLI_SERVICE_PROTOCOL_V5": 42245,
         "SPARK_CLI_SERVICE_PROTOCOL_V6": 42246,
         "SPARK_CLI_SERVICE_PROTOCOL_V7": 42247,
-        "SPARK_CLI_SERVICE_PROTOCOL_V8": 42248,
     }
 
 
@@ -508,21 +505,6 @@ class TResultPersistenceMode(object):
         "ONLY_LARGE_RESULTS": 0,
         "ALL_QUERY_RESULTS": 1,
         "ALL_RESULTS": 2,
-    }
-
-
-class TDBSqlCloseOperationReason(object):
-    NONE = 0
-    COMMAND_INACTIVITY_TIMEOUT = 1
-
-    _VALUES_TO_NAMES = {
-        0: "NONE",
-        1: "COMMAND_INACTIVITY_TIMEOUT",
-    }
-
-    _NAMES_TO_VALUES = {
-        "NONE": 0,
-        "COMMAND_INACTIVITY_TIMEOUT": 1,
     }
 
 
@@ -3269,18 +3251,16 @@ class TSparkArrowResultLink(object):
      - startRowOffset
      - rowCount
      - bytesNum
-     - httpHeaders
 
     """
 
 
-    def __init__(self, fileLink=None, expiryTime=None, startRowOffset=None, rowCount=None, bytesNum=None, httpHeaders=None,):
+    def __init__(self, fileLink=None, expiryTime=None, startRowOffset=None, rowCount=None, bytesNum=None,):
         self.fileLink = fileLink
         self.expiryTime = expiryTime
         self.startRowOffset = startRowOffset
         self.rowCount = rowCount
         self.bytesNum = bytesNum
-        self.httpHeaders = httpHeaders
 
     def read(self, iprot):
         if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
@@ -3316,17 +3296,6 @@ class TSparkArrowResultLink(object):
                     self.bytesNum = iprot.readI64()
                 else:
                     iprot.skip(ftype)
-            elif fid == 6:
-                if ftype == TType.MAP:
-                    self.httpHeaders = {}
-                    (_ktype105, _vtype106, _size104) = iprot.readMapBegin()
-                    for _i108 in range(_size104):
-                        _key109 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        _val110 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.httpHeaders[_key109] = _val110
-                    iprot.readMapEnd()
-                else:
-                    iprot.skip(ftype)
             else:
                 iprot.skip(ftype)
             iprot.readFieldEnd()
@@ -3356,14 +3325,6 @@ class TSparkArrowResultLink(object):
         if self.bytesNum is not None:
             oprot.writeFieldBegin('bytesNum', TType.I64, 5)
             oprot.writeI64(self.bytesNum)
-            oprot.writeFieldEnd()
-        if self.httpHeaders is not None:
-            oprot.writeFieldBegin('httpHeaders', TType.MAP, 6)
-            oprot.writeMapBegin(TType.STRING, TType.STRING, len(self.httpHeaders))
-            for kiter111, viter112 in self.httpHeaders.items():
-                oprot.writeString(kiter111.encode('utf-8') if sys.version_info[0] == 2 else kiter111)
-                oprot.writeString(viter112.encode('utf-8') if sys.version_info[0] == 2 else viter112)
-            oprot.writeMapEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -3403,12 +3364,11 @@ class TDBSqlCloudResultFile(object):
      - compressedBytes
      - fileLink
      - linkExpiryTime
-     - httpHeaders
 
     """
 
 
-    def __init__(self, filePath=None, startRowOffset=None, rowCount=None, uncompressedBytes=None, compressedBytes=None, fileLink=None, linkExpiryTime=None, httpHeaders=None,):
+    def __init__(self, filePath=None, startRowOffset=None, rowCount=None, uncompressedBytes=None, compressedBytes=None, fileLink=None, linkExpiryTime=None,):
         self.filePath = filePath
         self.startRowOffset = startRowOffset
         self.rowCount = rowCount
@@ -3416,7 +3376,6 @@ class TDBSqlCloudResultFile(object):
         self.compressedBytes = compressedBytes
         self.fileLink = fileLink
         self.linkExpiryTime = linkExpiryTime
-        self.httpHeaders = httpHeaders
 
     def read(self, iprot):
         if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
@@ -3462,17 +3421,6 @@ class TDBSqlCloudResultFile(object):
                     self.linkExpiryTime = iprot.readI64()
                 else:
                     iprot.skip(ftype)
-            elif fid == 8:
-                if ftype == TType.MAP:
-                    self.httpHeaders = {}
-                    (_ktype114, _vtype115, _size113) = iprot.readMapBegin()
-                    for _i117 in range(_size113):
-                        _key118 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        _val119 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.httpHeaders[_key118] = _val119
-                    iprot.readMapEnd()
-                else:
-                    iprot.skip(ftype)
             else:
                 iprot.skip(ftype)
             iprot.readFieldEnd()
@@ -3510,14 +3458,6 @@ class TDBSqlCloudResultFile(object):
         if self.linkExpiryTime is not None:
             oprot.writeFieldBegin('linkExpiryTime', TType.I64, 7)
             oprot.writeI64(self.linkExpiryTime)
-            oprot.writeFieldEnd()
-        if self.httpHeaders is not None:
-            oprot.writeFieldBegin('httpHeaders', TType.MAP, 8)
-            oprot.writeMapBegin(TType.STRING, TType.STRING, len(self.httpHeaders))
-            for kiter120, viter121 in self.httpHeaders.items():
-                oprot.writeString(kiter120.encode('utf-8') if sys.version_info[0] == 2 else kiter120)
-                oprot.writeString(viter121.encode('utf-8') if sys.version_info[0] == 2 else viter121)
-            oprot.writeMapEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -3579,22 +3519,22 @@ class TRowSet(object):
             elif fid == 2:
                 if ftype == TType.LIST:
                     self.rows = []
-                    (_etype125, _size122) = iprot.readListBegin()
-                    for _i126 in range(_size122):
-                        _elem127 = TRow()
-                        _elem127.read(iprot)
-                        self.rows.append(_elem127)
+                    (_etype107, _size104) = iprot.readListBegin()
+                    for _i108 in range(_size104):
+                        _elem109 = TRow()
+                        _elem109.read(iprot)
+                        self.rows.append(_elem109)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
                 if ftype == TType.LIST:
                     self.columns = []
-                    (_etype131, _size128) = iprot.readListBegin()
-                    for _i132 in range(_size128):
-                        _elem133 = TColumn()
-                        _elem133.read(iprot)
-                        self.columns.append(_elem133)
+                    (_etype113, _size110) = iprot.readListBegin()
+                    for _i114 in range(_size110):
+                        _elem115 = TColumn()
+                        _elem115.read(iprot)
+                        self.columns.append(_elem115)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -3611,33 +3551,33 @@ class TRowSet(object):
             elif fid == 1281:
                 if ftype == TType.LIST:
                     self.arrowBatches = []
-                    (_etype137, _size134) = iprot.readListBegin()
-                    for _i138 in range(_size134):
-                        _elem139 = TSparkArrowBatch()
-                        _elem139.read(iprot)
-                        self.arrowBatches.append(_elem139)
+                    (_etype119, _size116) = iprot.readListBegin()
+                    for _i120 in range(_size116):
+                        _elem121 = TSparkArrowBatch()
+                        _elem121.read(iprot)
+                        self.arrowBatches.append(_elem121)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
             elif fid == 1282:
                 if ftype == TType.LIST:
                     self.resultLinks = []
-                    (_etype143, _size140) = iprot.readListBegin()
-                    for _i144 in range(_size140):
-                        _elem145 = TSparkArrowResultLink()
-                        _elem145.read(iprot)
-                        self.resultLinks.append(_elem145)
+                    (_etype125, _size122) = iprot.readListBegin()
+                    for _i126 in range(_size122):
+                        _elem127 = TSparkArrowResultLink()
+                        _elem127.read(iprot)
+                        self.resultLinks.append(_elem127)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
             elif fid == 3329:
                 if ftype == TType.LIST:
                     self.cloudFetchResults = []
-                    (_etype149, _size146) = iprot.readListBegin()
-                    for _i150 in range(_size146):
-                        _elem151 = TDBSqlCloudResultFile()
-                        _elem151.read(iprot)
-                        self.cloudFetchResults.append(_elem151)
+                    (_etype131, _size128) = iprot.readListBegin()
+                    for _i132 in range(_size128):
+                        _elem133 = TDBSqlCloudResultFile()
+                        _elem133.read(iprot)
+                        self.cloudFetchResults.append(_elem133)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -3658,15 +3598,15 @@ class TRowSet(object):
         if self.rows is not None:
             oprot.writeFieldBegin('rows', TType.LIST, 2)
             oprot.writeListBegin(TType.STRUCT, len(self.rows))
-            for iter152 in self.rows:
-                iter152.write(oprot)
+            for iter134 in self.rows:
+                iter134.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.columns is not None:
             oprot.writeFieldBegin('columns', TType.LIST, 3)
             oprot.writeListBegin(TType.STRUCT, len(self.columns))
-            for iter153 in self.columns:
-                iter153.write(oprot)
+            for iter135 in self.columns:
+                iter135.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.binaryColumns is not None:
@@ -3680,22 +3620,22 @@ class TRowSet(object):
         if self.arrowBatches is not None:
             oprot.writeFieldBegin('arrowBatches', TType.LIST, 1281)
             oprot.writeListBegin(TType.STRUCT, len(self.arrowBatches))
-            for iter154 in self.arrowBatches:
-                iter154.write(oprot)
+            for iter136 in self.arrowBatches:
+                iter136.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.resultLinks is not None:
             oprot.writeFieldBegin('resultLinks', TType.LIST, 1282)
             oprot.writeListBegin(TType.STRUCT, len(self.resultLinks))
-            for iter155 in self.resultLinks:
-                iter155.write(oprot)
+            for iter137 in self.resultLinks:
+                iter137.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.cloudFetchResults is not None:
             oprot.writeFieldBegin('cloudFetchResults', TType.LIST, 3329)
             oprot.writeListBegin(TType.STRUCT, len(self.cloudFetchResults))
-            for iter156 in self.cloudFetchResults:
-                iter156.write(oprot)
+            for iter138 in self.cloudFetchResults:
+                iter138.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -3759,11 +3699,11 @@ class TDBSqlTempView(object):
             elif fid == 3:
                 if ftype == TType.MAP:
                     self.properties = {}
-                    (_ktype158, _vtype159, _size157) = iprot.readMapBegin()
-                    for _i161 in range(_size157):
-                        _key162 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        _val163 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.properties[_key162] = _val163
+                    (_ktype140, _vtype141, _size139) = iprot.readMapBegin()
+                    for _i143 in range(_size139):
+                        _key144 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _val145 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.properties[_key144] = _val145
                     iprot.readMapEnd()
                 else:
                     iprot.skip(ftype)
@@ -3793,9 +3733,9 @@ class TDBSqlTempView(object):
         if self.properties is not None:
             oprot.writeFieldBegin('properties', TType.MAP, 3)
             oprot.writeMapBegin(TType.STRING, TType.STRING, len(self.properties))
-            for kiter164, viter165 in self.properties.items():
-                oprot.writeString(kiter164.encode('utf-8') if sys.version_info[0] == 2 else kiter164)
-                oprot.writeString(viter165.encode('utf-8') if sys.version_info[0] == 2 else viter165)
+            for kiter146, viter147 in self.properties.items():
+                oprot.writeString(kiter146.encode('utf-8') if sys.version_info[0] == 2 else kiter146)
+                oprot.writeString(viter147.encode('utf-8') if sys.version_info[0] == 2 else viter147)
             oprot.writeMapEnd()
             oprot.writeFieldEnd()
         if self.viewSchema is not None:
@@ -4147,22 +4087,22 @@ class TDBSqlSessionConf(object):
             if fid == 1:
                 if ftype == TType.MAP:
                     self.confs = {}
-                    (_ktype167, _vtype168, _size166) = iprot.readMapBegin()
-                    for _i170 in range(_size166):
-                        _key171 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        _val172 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.confs[_key171] = _val172
+                    (_ktype149, _vtype150, _size148) = iprot.readMapBegin()
+                    for _i152 in range(_size148):
+                        _key153 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _val154 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.confs[_key153] = _val154
                     iprot.readMapEnd()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.LIST:
                     self.tempViews = []
-                    (_etype176, _size173) = iprot.readListBegin()
-                    for _i177 in range(_size173):
-                        _elem178 = TDBSqlTempView()
-                        _elem178.read(iprot)
-                        self.tempViews.append(_elem178)
+                    (_etype158, _size155) = iprot.readListBegin()
+                    for _i159 in range(_size155):
+                        _elem160 = TDBSqlTempView()
+                        _elem160.read(iprot)
+                        self.tempViews.append(_elem160)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -4185,23 +4125,23 @@ class TDBSqlSessionConf(object):
             elif fid == 6:
                 if ftype == TType.LIST:
                     self.expressionsInfos = []
-                    (_etype182, _size179) = iprot.readListBegin()
-                    for _i183 in range(_size179):
-                        _elem184 = TExpressionInfo()
-                        _elem184.read(iprot)
-                        self.expressionsInfos.append(_elem184)
+                    (_etype164, _size161) = iprot.readListBegin()
+                    for _i165 in range(_size161):
+                        _elem166 = TExpressionInfo()
+                        _elem166.read(iprot)
+                        self.expressionsInfos.append(_elem166)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
             elif fid == 7:
                 if ftype == TType.MAP:
                     self.internalConfs = {}
-                    (_ktype186, _vtype187, _size185) = iprot.readMapBegin()
-                    for _i189 in range(_size185):
-                        _key190 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        _val191 = TDBSqlConfValue()
-                        _val191.read(iprot)
-                        self.internalConfs[_key190] = _val191
+                    (_ktype168, _vtype169, _size167) = iprot.readMapBegin()
+                    for _i171 in range(_size167):
+                        _key172 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _val173 = TDBSqlConfValue()
+                        _val173.read(iprot)
+                        self.internalConfs[_key172] = _val173
                     iprot.readMapEnd()
                 else:
                     iprot.skip(ftype)
@@ -4218,16 +4158,16 @@ class TDBSqlSessionConf(object):
         if self.confs is not None:
             oprot.writeFieldBegin('confs', TType.MAP, 1)
             oprot.writeMapBegin(TType.STRING, TType.STRING, len(self.confs))
-            for kiter192, viter193 in self.confs.items():
-                oprot.writeString(kiter192.encode('utf-8') if sys.version_info[0] == 2 else kiter192)
-                oprot.writeString(viter193.encode('utf-8') if sys.version_info[0] == 2 else viter193)
+            for kiter174, viter175 in self.confs.items():
+                oprot.writeString(kiter174.encode('utf-8') if sys.version_info[0] == 2 else kiter174)
+                oprot.writeString(viter175.encode('utf-8') if sys.version_info[0] == 2 else viter175)
             oprot.writeMapEnd()
             oprot.writeFieldEnd()
         if self.tempViews is not None:
             oprot.writeFieldBegin('tempViews', TType.LIST, 2)
             oprot.writeListBegin(TType.STRUCT, len(self.tempViews))
-            for iter194 in self.tempViews:
-                iter194.write(oprot)
+            for iter176 in self.tempViews:
+                iter176.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.currentDatabase is not None:
@@ -4245,16 +4185,16 @@ class TDBSqlSessionConf(object):
         if self.expressionsInfos is not None:
             oprot.writeFieldBegin('expressionsInfos', TType.LIST, 6)
             oprot.writeListBegin(TType.STRUCT, len(self.expressionsInfos))
-            for iter195 in self.expressionsInfos:
-                iter195.write(oprot)
+            for iter177 in self.expressionsInfos:
+                iter177.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.internalConfs is not None:
             oprot.writeFieldBegin('internalConfs', TType.MAP, 7)
             oprot.writeMapBegin(TType.STRING, TType.STRUCT, len(self.internalConfs))
-            for kiter196, viter197 in self.internalConfs.items():
-                oprot.writeString(kiter196.encode('utf-8') if sys.version_info[0] == 2 else kiter196)
-                viter197.write(oprot)
+            for kiter178, viter179 in self.internalConfs.items():
+                oprot.writeString(kiter178.encode('utf-8') if sys.version_info[0] == 2 else kiter178)
+                viter179.write(oprot)
             oprot.writeMapEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -4284,20 +4224,18 @@ class TStatus(object):
      - errorCode
      - errorMessage
      - displayMessage
-     - errorDetailsJson
      - responseValidation
 
     """
 
 
-    def __init__(self, statusCode=None, infoMessages=None, sqlState=None, errorCode=None, errorMessage=None, displayMessage=None, errorDetailsJson=None, responseValidation=None,):
+    def __init__(self, statusCode=None, infoMessages=None, sqlState=None, errorCode=None, errorMessage=None, displayMessage=None, responseValidation=None,):
         self.statusCode = statusCode
         self.infoMessages = infoMessages
         self.sqlState = sqlState
         self.errorCode = errorCode
         self.errorMessage = errorMessage
         self.displayMessage = displayMessage
-        self.errorDetailsJson = errorDetailsJson
         self.responseValidation = responseValidation
 
     def read(self, iprot):
@@ -4317,10 +4255,10 @@ class TStatus(object):
             elif fid == 2:
                 if ftype == TType.LIST:
                     self.infoMessages = []
-                    (_etype201, _size198) = iprot.readListBegin()
-                    for _i202 in range(_size198):
-                        _elem203 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.infoMessages.append(_elem203)
+                    (_etype183, _size180) = iprot.readListBegin()
+                    for _i184 in range(_size180):
+                        _elem185 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.infoMessages.append(_elem185)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -4342,11 +4280,6 @@ class TStatus(object):
             elif fid == 6:
                 if ftype == TType.STRING:
                     self.displayMessage = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                else:
-                    iprot.skip(ftype)
-            elif fid == 1281:
-                if ftype == TType.STRING:
-                    self.errorDetailsJson = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3329:
@@ -4371,8 +4304,8 @@ class TStatus(object):
         if self.infoMessages is not None:
             oprot.writeFieldBegin('infoMessages', TType.LIST, 2)
             oprot.writeListBegin(TType.STRING, len(self.infoMessages))
-            for iter204 in self.infoMessages:
-                oprot.writeString(iter204.encode('utf-8') if sys.version_info[0] == 2 else iter204)
+            for iter186 in self.infoMessages:
+                oprot.writeString(iter186.encode('utf-8') if sys.version_info[0] == 2 else iter186)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.sqlState is not None:
@@ -4390,10 +4323,6 @@ class TStatus(object):
         if self.displayMessage is not None:
             oprot.writeFieldBegin('displayMessage', TType.STRING, 6)
             oprot.writeString(self.displayMessage.encode('utf-8') if sys.version_info[0] == 2 else self.displayMessage)
-            oprot.writeFieldEnd()
-        if self.errorDetailsJson is not None:
-            oprot.writeFieldBegin('errorDetailsJson', TType.STRING, 1281)
-            oprot.writeString(self.errorDetailsJson.encode('utf-8') if sys.version_info[0] == 2 else self.errorDetailsJson)
             oprot.writeFieldEnd()
         if self.responseValidation is not None:
             oprot.writeFieldBegin('responseValidation', TType.STRING, 3329)
@@ -4794,21 +4723,21 @@ class TOpenSessionReq(object):
             elif fid == 4:
                 if ftype == TType.MAP:
                     self.configuration = {}
-                    (_ktype206, _vtype207, _size205) = iprot.readMapBegin()
-                    for _i209 in range(_size205):
-                        _key210 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        _val211 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.configuration[_key210] = _val211
+                    (_ktype188, _vtype189, _size187) = iprot.readMapBegin()
+                    for _i191 in range(_size187):
+                        _key192 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _val193 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.configuration[_key192] = _val193
                     iprot.readMapEnd()
                 else:
                     iprot.skip(ftype)
             elif fid == 1281:
                 if ftype == TType.LIST:
                     self.getInfos = []
-                    (_etype215, _size212) = iprot.readListBegin()
-                    for _i216 in range(_size212):
-                        _elem217 = iprot.readI32()
-                        self.getInfos.append(_elem217)
+                    (_etype197, _size194) = iprot.readListBegin()
+                    for _i198 in range(_size194):
+                        _elem199 = iprot.readI32()
+                        self.getInfos.append(_elem199)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -4820,11 +4749,11 @@ class TOpenSessionReq(object):
             elif fid == 1283:
                 if ftype == TType.MAP:
                     self.connectionProperties = {}
-                    (_ktype219, _vtype220, _size218) = iprot.readMapBegin()
-                    for _i222 in range(_size218):
-                        _key223 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        _val224 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.connectionProperties[_key223] = _val224
+                    (_ktype201, _vtype202, _size200) = iprot.readMapBegin()
+                    for _i204 in range(_size200):
+                        _key205 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _val206 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.connectionProperties[_key205] = _val206
                     iprot.readMapEnd()
                 else:
                     iprot.skip(ftype)
@@ -4870,16 +4799,16 @@ class TOpenSessionReq(object):
         if self.configuration is not None:
             oprot.writeFieldBegin('configuration', TType.MAP, 4)
             oprot.writeMapBegin(TType.STRING, TType.STRING, len(self.configuration))
-            for kiter225, viter226 in self.configuration.items():
-                oprot.writeString(kiter225.encode('utf-8') if sys.version_info[0] == 2 else kiter225)
-                oprot.writeString(viter226.encode('utf-8') if sys.version_info[0] == 2 else viter226)
+            for kiter207, viter208 in self.configuration.items():
+                oprot.writeString(kiter207.encode('utf-8') if sys.version_info[0] == 2 else kiter207)
+                oprot.writeString(viter208.encode('utf-8') if sys.version_info[0] == 2 else viter208)
             oprot.writeMapEnd()
             oprot.writeFieldEnd()
         if self.getInfos is not None:
             oprot.writeFieldBegin('getInfos', TType.LIST, 1281)
             oprot.writeListBegin(TType.I32, len(self.getInfos))
-            for iter227 in self.getInfos:
-                oprot.writeI32(iter227)
+            for iter209 in self.getInfos:
+                oprot.writeI32(iter209)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.client_protocol_i64 is not None:
@@ -4889,9 +4818,9 @@ class TOpenSessionReq(object):
         if self.connectionProperties is not None:
             oprot.writeFieldBegin('connectionProperties', TType.MAP, 1283)
             oprot.writeMapBegin(TType.STRING, TType.STRING, len(self.connectionProperties))
-            for kiter228, viter229 in self.connectionProperties.items():
-                oprot.writeString(kiter228.encode('utf-8') if sys.version_info[0] == 2 else kiter228)
-                oprot.writeString(viter229.encode('utf-8') if sys.version_info[0] == 2 else viter229)
+            for kiter210, viter211 in self.connectionProperties.items():
+                oprot.writeString(kiter210.encode('utf-8') if sys.version_info[0] == 2 else kiter210)
+                oprot.writeString(viter211.encode('utf-8') if sys.version_info[0] == 2 else viter211)
             oprot.writeMapEnd()
             oprot.writeFieldEnd()
         if self.initialNamespace is not None:
@@ -4976,11 +4905,11 @@ class TOpenSessionResp(object):
             elif fid == 4:
                 if ftype == TType.MAP:
                     self.configuration = {}
-                    (_ktype231, _vtype232, _size230) = iprot.readMapBegin()
-                    for _i234 in range(_size230):
-                        _key235 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        _val236 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.configuration[_key235] = _val236
+                    (_ktype213, _vtype214, _size212) = iprot.readMapBegin()
+                    for _i216 in range(_size212):
+                        _key217 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _val218 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.configuration[_key217] = _val218
                     iprot.readMapEnd()
                 else:
                     iprot.skip(ftype)
@@ -4998,11 +4927,11 @@ class TOpenSessionResp(object):
             elif fid == 1281:
                 if ftype == TType.LIST:
                     self.getInfos = []
-                    (_etype240, _size237) = iprot.readListBegin()
-                    for _i241 in range(_size237):
-                        _elem242 = TGetInfoValue()
-                        _elem242.read(iprot)
-                        self.getInfos.append(_elem242)
+                    (_etype222, _size219) = iprot.readListBegin()
+                    for _i223 in range(_size219):
+                        _elem224 = TGetInfoValue()
+                        _elem224.read(iprot)
+                        self.getInfos.append(_elem224)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -5031,16 +4960,16 @@ class TOpenSessionResp(object):
         if self.configuration is not None:
             oprot.writeFieldBegin('configuration', TType.MAP, 4)
             oprot.writeMapBegin(TType.STRING, TType.STRING, len(self.configuration))
-            for kiter243, viter244 in self.configuration.items():
-                oprot.writeString(kiter243.encode('utf-8') if sys.version_info[0] == 2 else kiter243)
-                oprot.writeString(viter244.encode('utf-8') if sys.version_info[0] == 2 else viter244)
+            for kiter225, viter226 in self.configuration.items():
+                oprot.writeString(kiter225.encode('utf-8') if sys.version_info[0] == 2 else kiter225)
+                oprot.writeString(viter226.encode('utf-8') if sys.version_info[0] == 2 else viter226)
             oprot.writeMapEnd()
             oprot.writeFieldEnd()
         if self.getInfos is not None:
             oprot.writeFieldBegin('getInfos', TType.LIST, 1281)
             oprot.writeListBegin(TType.STRUCT, len(self.getInfos))
-            for iter245 in self.getInfos:
-                iter245.write(oprot)
+            for iter227 in self.getInfos:
+                iter227.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.initialNamespace is not None:
@@ -5745,8 +5674,6 @@ class TExecuteStatementReq(object):
      - useArrowNativeTypes
      - resultRowLimit
      - parameters
-     - maxBytesPerBatch
-     - statementConf
      - operationId
      - sessionConf
      - rejectHighCostQueries
@@ -5763,16 +5690,11 @@ class TExecuteStatementReq(object):
      - resultByteLimit
      - resultDataFormat
      - originatingClientIdentity
-     - preferSingleFileResult
-     - preferDriverOnlyUpload
-     - enforceEmbeddedSchemaCorrectness
-     - idempotencyToken
-     - throwErrorOnByteLimitTruncation
 
     """
 
 
-    def __init__(self, sessionHandle=None, statement=None, confOverlay=None, runAsync=False, getDirectResults=None, queryTimeout=0, canReadArrowResult=None, canDownloadResult=None, canDecompressLZ4Result=None, maxBytesPerFile=None, useArrowNativeTypes=None, resultRowLimit=None, parameters=None, maxBytesPerBatch=None, statementConf=None, operationId=None, sessionConf=None, rejectHighCostQueries=None, estimatedCost=None, executionVersion=None, requestValidation=None, resultPersistenceMode=None, trimArrowBatchesToLimit=None, fetchDisposition=None, enforceResultPersistenceMode=None, statementList=None, persistResultManifest=None, resultRetentionSeconds=None, resultByteLimit=None, resultDataFormat=None, originatingClientIdentity=None, preferSingleFileResult=None, preferDriverOnlyUpload=None, enforceEmbeddedSchemaCorrectness=False, idempotencyToken=None, throwErrorOnByteLimitTruncation=None,):
+    def __init__(self, sessionHandle=None, statement=None, confOverlay=None, runAsync=False, getDirectResults=None, queryTimeout=0, canReadArrowResult=None, canDownloadResult=None, canDecompressLZ4Result=None, maxBytesPerFile=None, useArrowNativeTypes=None, resultRowLimit=None, parameters=None, operationId=None, sessionConf=None, rejectHighCostQueries=None, estimatedCost=None, executionVersion=None, requestValidation=None, resultPersistenceMode=None, trimArrowBatchesToLimit=None, fetchDisposition=None, enforceResultPersistenceMode=None, statementList=None, persistResultManifest=None, resultRetentionSeconds=None, resultByteLimit=None, resultDataFormat=None, originatingClientIdentity=None,):
         self.sessionHandle = sessionHandle
         self.statement = statement
         self.confOverlay = confOverlay
@@ -5786,8 +5708,6 @@ class TExecuteStatementReq(object):
         self.useArrowNativeTypes = useArrowNativeTypes
         self.resultRowLimit = resultRowLimit
         self.parameters = parameters
-        self.maxBytesPerBatch = maxBytesPerBatch
-        self.statementConf = statementConf
         self.operationId = operationId
         self.sessionConf = sessionConf
         self.rejectHighCostQueries = rejectHighCostQueries
@@ -5804,11 +5724,6 @@ class TExecuteStatementReq(object):
         self.resultByteLimit = resultByteLimit
         self.resultDataFormat = resultDataFormat
         self.originatingClientIdentity = originatingClientIdentity
-        self.preferSingleFileResult = preferSingleFileResult
-        self.preferDriverOnlyUpload = preferDriverOnlyUpload
-        self.enforceEmbeddedSchemaCorrectness = enforceEmbeddedSchemaCorrectness
-        self.idempotencyToken = idempotencyToken
-        self.throwErrorOnByteLimitTruncation = throwErrorOnByteLimitTruncation
 
     def read(self, iprot):
         if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
@@ -5833,11 +5748,11 @@ class TExecuteStatementReq(object):
             elif fid == 3:
                 if ftype == TType.MAP:
                     self.confOverlay = {}
-                    (_ktype247, _vtype248, _size246) = iprot.readMapBegin()
-                    for _i250 in range(_size246):
-                        _key251 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        _val252 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.confOverlay[_key251] = _val252
+                    (_ktype229, _vtype230, _size228) = iprot.readMapBegin()
+                    for _i232 in range(_size228):
+                        _key233 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _val234 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.confOverlay[_key233] = _val234
                     iprot.readMapEnd()
                 else:
                     iprot.skip(ftype)
@@ -5891,23 +5806,12 @@ class TExecuteStatementReq(object):
             elif fid == 1288:
                 if ftype == TType.LIST:
                     self.parameters = []
-                    (_etype256, _size253) = iprot.readListBegin()
-                    for _i257 in range(_size253):
-                        _elem258 = TSparkParameter()
-                        _elem258.read(iprot)
-                        self.parameters.append(_elem258)
+                    (_etype238, _size235) = iprot.readListBegin()
+                    for _i239 in range(_size235):
+                        _elem240 = TSparkParameter()
+                        _elem240.read(iprot)
+                        self.parameters.append(_elem240)
                     iprot.readListEnd()
-                else:
-                    iprot.skip(ftype)
-            elif fid == 1289:
-                if ftype == TType.I64:
-                    self.maxBytesPerBatch = iprot.readI64()
-                else:
-                    iprot.skip(ftype)
-            elif fid == 1296:
-                if ftype == TType.STRUCT:
-                    self.statementConf = TStatementConf()
-                    self.statementConf.read(iprot)
                 else:
                     iprot.skip(ftype)
             elif fid == 3329:
@@ -5965,11 +5869,11 @@ class TExecuteStatementReq(object):
             elif fid == 3345:
                 if ftype == TType.LIST:
                     self.statementList = []
-                    (_etype262, _size259) = iprot.readListBegin()
-                    for _i263 in range(_size259):
-                        _elem264 = TDBSqlStatement()
-                        _elem264.read(iprot)
-                        self.statementList.append(_elem264)
+                    (_etype244, _size241) = iprot.readListBegin()
+                    for _i245 in range(_size241):
+                        _elem246 = TDBSqlStatement()
+                        _elem246.read(iprot)
+                        self.statementList.append(_elem246)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -5999,31 +5903,6 @@ class TExecuteStatementReq(object):
                     self.originatingClientIdentity = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
                 else:
                     iprot.skip(ftype)
-            elif fid == 3351:
-                if ftype == TType.BOOL:
-                    self.preferSingleFileResult = iprot.readBool()
-                else:
-                    iprot.skip(ftype)
-            elif fid == 3352:
-                if ftype == TType.BOOL:
-                    self.preferDriverOnlyUpload = iprot.readBool()
-                else:
-                    iprot.skip(ftype)
-            elif fid == 3353:
-                if ftype == TType.BOOL:
-                    self.enforceEmbeddedSchemaCorrectness = iprot.readBool()
-                else:
-                    iprot.skip(ftype)
-            elif fid == 3360:
-                if ftype == TType.STRING:
-                    self.idempotencyToken = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                else:
-                    iprot.skip(ftype)
-            elif fid == 3361:
-                if ftype == TType.BOOL:
-                    self.throwErrorOnByteLimitTruncation = iprot.readBool()
-                else:
-                    iprot.skip(ftype)
             else:
                 iprot.skip(ftype)
             iprot.readFieldEnd()
@@ -6045,9 +5924,9 @@ class TExecuteStatementReq(object):
         if self.confOverlay is not None:
             oprot.writeFieldBegin('confOverlay', TType.MAP, 3)
             oprot.writeMapBegin(TType.STRING, TType.STRING, len(self.confOverlay))
-            for kiter265, viter266 in self.confOverlay.items():
-                oprot.writeString(kiter265.encode('utf-8') if sys.version_info[0] == 2 else kiter265)
-                oprot.writeString(viter266.encode('utf-8') if sys.version_info[0] == 2 else viter266)
+            for kiter247, viter248 in self.confOverlay.items():
+                oprot.writeString(kiter247.encode('utf-8') if sys.version_info[0] == 2 else kiter247)
+                oprot.writeString(viter248.encode('utf-8') if sys.version_info[0] == 2 else viter248)
             oprot.writeMapEnd()
             oprot.writeFieldEnd()
         if self.runAsync is not None:
@@ -6089,17 +5968,9 @@ class TExecuteStatementReq(object):
         if self.parameters is not None:
             oprot.writeFieldBegin('parameters', TType.LIST, 1288)
             oprot.writeListBegin(TType.STRUCT, len(self.parameters))
-            for iter267 in self.parameters:
-                iter267.write(oprot)
+            for iter249 in self.parameters:
+                iter249.write(oprot)
             oprot.writeListEnd()
-            oprot.writeFieldEnd()
-        if self.maxBytesPerBatch is not None:
-            oprot.writeFieldBegin('maxBytesPerBatch', TType.I64, 1289)
-            oprot.writeI64(self.maxBytesPerBatch)
-            oprot.writeFieldEnd()
-        if self.statementConf is not None:
-            oprot.writeFieldBegin('statementConf', TType.STRUCT, 1296)
-            self.statementConf.write(oprot)
             oprot.writeFieldEnd()
         if self.operationId is not None:
             oprot.writeFieldBegin('operationId', TType.STRUCT, 3329)
@@ -6144,8 +6015,8 @@ class TExecuteStatementReq(object):
         if self.statementList is not None:
             oprot.writeFieldBegin('statementList', TType.LIST, 3345)
             oprot.writeListBegin(TType.STRUCT, len(self.statementList))
-            for iter268 in self.statementList:
-                iter268.write(oprot)
+            for iter250 in self.statementList:
+                iter250.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.persistResultManifest is not None:
@@ -6167,26 +6038,6 @@ class TExecuteStatementReq(object):
         if self.originatingClientIdentity is not None:
             oprot.writeFieldBegin('originatingClientIdentity', TType.STRING, 3350)
             oprot.writeString(self.originatingClientIdentity.encode('utf-8') if sys.version_info[0] == 2 else self.originatingClientIdentity)
-            oprot.writeFieldEnd()
-        if self.preferSingleFileResult is not None:
-            oprot.writeFieldBegin('preferSingleFileResult', TType.BOOL, 3351)
-            oprot.writeBool(self.preferSingleFileResult)
-            oprot.writeFieldEnd()
-        if self.preferDriverOnlyUpload is not None:
-            oprot.writeFieldBegin('preferDriverOnlyUpload', TType.BOOL, 3352)
-            oprot.writeBool(self.preferDriverOnlyUpload)
-            oprot.writeFieldEnd()
-        if self.enforceEmbeddedSchemaCorrectness is not None:
-            oprot.writeFieldBegin('enforceEmbeddedSchemaCorrectness', TType.BOOL, 3353)
-            oprot.writeBool(self.enforceEmbeddedSchemaCorrectness)
-            oprot.writeFieldEnd()
-        if self.idempotencyToken is not None:
-            oprot.writeFieldBegin('idempotencyToken', TType.STRING, 3360)
-            oprot.writeString(self.idempotencyToken.encode('utf-8') if sys.version_info[0] == 2 else self.idempotencyToken)
-            oprot.writeFieldEnd()
-        if self.throwErrorOnByteLimitTruncation is not None:
-            oprot.writeFieldBegin('throwErrorOnByteLimitTruncation', TType.BOOL, 3361)
-            oprot.writeBool(self.throwErrorOnByteLimitTruncation)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -6437,97 +6288,6 @@ class TSparkParameter(object):
         return not (self == other)
 
 
-class TStatementConf(object):
-    """
-    Attributes:
-     - sessionless
-     - initialNamespace
-     - client_protocol
-     - client_protocol_i64
-
-    """
-
-
-    def __init__(self, sessionless=None, initialNamespace=None, client_protocol=None, client_protocol_i64=None,):
-        self.sessionless = sessionless
-        self.initialNamespace = initialNamespace
-        self.client_protocol = client_protocol
-        self.client_protocol_i64 = client_protocol_i64
-
-    def read(self, iprot):
-        if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
-            iprot._fast_decode(self, iprot, [self.__class__, self.thrift_spec])
-            return
-        iprot.readStructBegin()
-        while True:
-            (fname, ftype, fid) = iprot.readFieldBegin()
-            if ftype == TType.STOP:
-                break
-            if fid == 1:
-                if ftype == TType.BOOL:
-                    self.sessionless = iprot.readBool()
-                else:
-                    iprot.skip(ftype)
-            elif fid == 2:
-                if ftype == TType.STRUCT:
-                    self.initialNamespace = TNamespace()
-                    self.initialNamespace.read(iprot)
-                else:
-                    iprot.skip(ftype)
-            elif fid == 3:
-                if ftype == TType.I32:
-                    self.client_protocol = iprot.readI32()
-                else:
-                    iprot.skip(ftype)
-            elif fid == 4:
-                if ftype == TType.I64:
-                    self.client_protocol_i64 = iprot.readI64()
-                else:
-                    iprot.skip(ftype)
-            else:
-                iprot.skip(ftype)
-            iprot.readFieldEnd()
-        iprot.readStructEnd()
-
-    def write(self, oprot):
-        if oprot._fast_encode is not None and self.thrift_spec is not None:
-            oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
-            return
-        oprot.writeStructBegin('TStatementConf')
-        if self.sessionless is not None:
-            oprot.writeFieldBegin('sessionless', TType.BOOL, 1)
-            oprot.writeBool(self.sessionless)
-            oprot.writeFieldEnd()
-        if self.initialNamespace is not None:
-            oprot.writeFieldBegin('initialNamespace', TType.STRUCT, 2)
-            self.initialNamespace.write(oprot)
-            oprot.writeFieldEnd()
-        if self.client_protocol is not None:
-            oprot.writeFieldBegin('client_protocol', TType.I32, 3)
-            oprot.writeI32(self.client_protocol)
-            oprot.writeFieldEnd()
-        if self.client_protocol_i64 is not None:
-            oprot.writeFieldBegin('client_protocol_i64', TType.I64, 4)
-            oprot.writeI64(self.client_protocol_i64)
-            oprot.writeFieldEnd()
-        oprot.writeFieldStop()
-        oprot.writeStructEnd()
-
-    def validate(self):
-        return
-
-    def __repr__(self):
-        L = ['%s=%r' % (key, value)
-             for key, value in self.__dict__.items()]
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
-
-    def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
-
-    def __ne__(self, other):
-        return not (self == other)
-
-
 class TExecuteStatementResp(object):
     """
     Attributes:
@@ -6632,11 +6392,11 @@ class TExecuteStatementResp(object):
             elif fid == 3337:
                 if ftype == TType.LIST:
                     self.operationHandles = []
-                    (_etype272, _size269) = iprot.readListBegin()
-                    for _i273 in range(_size269):
-                        _elem274 = TOperationHandle()
-                        _elem274.read(iprot)
-                        self.operationHandles.append(_elem274)
+                    (_etype254, _size251) = iprot.readListBegin()
+                    for _i255 in range(_size251):
+                        _elem256 = TOperationHandle()
+                        _elem256.read(iprot)
+                        self.operationHandles.append(_elem256)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -6697,8 +6457,8 @@ class TExecuteStatementResp(object):
         if self.operationHandles is not None:
             oprot.writeFieldBegin('operationHandles', TType.LIST, 3337)
             oprot.writeListBegin(TType.STRUCT, len(self.operationHandles))
-            for iter275 in self.operationHandles:
-                iter275.write(oprot)
+            for iter257 in self.operationHandles:
+                iter257.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -7376,10 +7136,10 @@ class TGetTablesReq(object):
             elif fid == 5:
                 if ftype == TType.LIST:
                     self.tableTypes = []
-                    (_etype279, _size276) = iprot.readListBegin()
-                    for _i280 in range(_size276):
-                        _elem281 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.tableTypes.append(_elem281)
+                    (_etype261, _size258) = iprot.readListBegin()
+                    for _i262 in range(_size258):
+                        _elem263 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.tableTypes.append(_elem263)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -7435,8 +7195,8 @@ class TGetTablesReq(object):
         if self.tableTypes is not None:
             oprot.writeFieldBegin('tableTypes', TType.LIST, 5)
             oprot.writeListBegin(TType.STRING, len(self.tableTypes))
-            for iter282 in self.tableTypes:
-                oprot.writeString(iter282.encode('utf-8') if sys.version_info[0] == 2 else iter282)
+            for iter264 in self.tableTypes:
+                oprot.writeString(iter264.encode('utf-8') if sys.version_info[0] == 2 else iter264)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.getDirectResults is not None:
@@ -8783,7 +8543,6 @@ class TGetOperationStatusResp(object):
      - numModifiedRows
      - displayMessage
      - diagnosticInfo
-     - errorDetailsJson
      - responseValidation
      - idempotencyType
      - statementTimeout
@@ -8792,7 +8551,7 @@ class TGetOperationStatusResp(object):
     """
 
 
-    def __init__(self, status=None, operationState=None, sqlState=None, errorCode=None, errorMessage=None, taskStatus=None, operationStarted=None, operationCompleted=None, hasResultSet=None, progressUpdateResponse=None, numModifiedRows=None, displayMessage=None, diagnosticInfo=None, errorDetailsJson=None, responseValidation=None, idempotencyType=None, statementTimeout=None, statementTimeoutLevel=None,):
+    def __init__(self, status=None, operationState=None, sqlState=None, errorCode=None, errorMessage=None, taskStatus=None, operationStarted=None, operationCompleted=None, hasResultSet=None, progressUpdateResponse=None, numModifiedRows=None, displayMessage=None, diagnosticInfo=None, responseValidation=None, idempotencyType=None, statementTimeout=None, statementTimeoutLevel=None,):
         self.status = status
         self.operationState = operationState
         self.sqlState = sqlState
@@ -8806,7 +8565,6 @@ class TGetOperationStatusResp(object):
         self.numModifiedRows = numModifiedRows
         self.displayMessage = displayMessage
         self.diagnosticInfo = diagnosticInfo
-        self.errorDetailsJson = errorDetailsJson
         self.responseValidation = responseValidation
         self.idempotencyType = idempotencyType
         self.statementTimeout = statementTimeout
@@ -8886,11 +8644,6 @@ class TGetOperationStatusResp(object):
             elif fid == 1282:
                 if ftype == TType.STRING:
                     self.diagnosticInfo = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                else:
-                    iprot.skip(ftype)
-            elif fid == 1283:
-                if ftype == TType.STRING:
-                    self.errorDetailsJson = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3329:
@@ -8974,10 +8727,6 @@ class TGetOperationStatusResp(object):
         if self.diagnosticInfo is not None:
             oprot.writeFieldBegin('diagnosticInfo', TType.STRING, 1282)
             oprot.writeString(self.diagnosticInfo.encode('utf-8') if sys.version_info[0] == 2 else self.diagnosticInfo)
-            oprot.writeFieldEnd()
-        if self.errorDetailsJson is not None:
-            oprot.writeFieldBegin('errorDetailsJson', TType.STRING, 1283)
-            oprot.writeString(self.errorDetailsJson.encode('utf-8') if sys.version_info[0] == 2 else self.errorDetailsJson)
             oprot.writeFieldEnd()
         if self.responseValidation is not None:
             oprot.writeFieldBegin('responseValidation', TType.STRING, 3329)
@@ -9161,14 +8910,12 @@ class TCloseOperationReq(object):
     """
     Attributes:
      - operationHandle
-     - closeReason
 
     """
 
 
-    def __init__(self, operationHandle=None, closeReason=    0,):
+    def __init__(self, operationHandle=None,):
         self.operationHandle = operationHandle
-        self.closeReason = closeReason
 
     def read(self, iprot):
         if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
@@ -9185,11 +8932,6 @@ class TCloseOperationReq(object):
                     self.operationHandle.read(iprot)
                 else:
                     iprot.skip(ftype)
-            elif fid == 3329:
-                if ftype == TType.I32:
-                    self.closeReason = iprot.readI32()
-                else:
-                    iprot.skip(ftype)
             else:
                 iprot.skip(ftype)
             iprot.readFieldEnd()
@@ -9203,10 +8945,6 @@ class TCloseOperationReq(object):
         if self.operationHandle is not None:
             oprot.writeFieldBegin('operationHandle', TType.STRUCT, 1)
             self.operationHandle.write(oprot)
-            oprot.writeFieldEnd()
-        if self.closeReason is not None:
-            oprot.writeFieldBegin('closeReason', TType.I32, 3329)
-            oprot.writeI32(self.closeReason)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -9381,13 +9119,12 @@ class TGetResultSetMetadataResp(object):
      - remoteResultCacheEnabled
      - isServerless
      - resultDataFormat
-     - truncatedByThriftLimit
-     - resultByteLimit
+     - truncatedByLimit
 
     """
 
 
-    def __init__(self, status=None, schema=None, resultFormat=None, lz4Compressed=None, arrowSchema=None, cacheLookupResult=None, uncompressedBytes=None, compressedBytes=None, isStagingOperation=None, reasonForNoCloudFetch=None, resultFiles=None, manifestFile=None, manifestFileFormat=None, cacheLookupLatency=None, remoteCacheMissReason=None, fetchDisposition=None, remoteResultCacheEnabled=None, isServerless=None, resultDataFormat=None, truncatedByThriftLimit=None, resultByteLimit=None,):
+    def __init__(self, status=None, schema=None, resultFormat=None, lz4Compressed=None, arrowSchema=None, cacheLookupResult=None, uncompressedBytes=None, compressedBytes=None, isStagingOperation=None, reasonForNoCloudFetch=None, resultFiles=None, manifestFile=None, manifestFileFormat=None, cacheLookupLatency=None, remoteCacheMissReason=None, fetchDisposition=None, remoteResultCacheEnabled=None, isServerless=None, resultDataFormat=None, truncatedByLimit=None,):
         self.status = status
         self.schema = schema
         self.resultFormat = resultFormat
@@ -9407,8 +9144,7 @@ class TGetResultSetMetadataResp(object):
         self.remoteResultCacheEnabled = remoteResultCacheEnabled
         self.isServerless = isServerless
         self.resultDataFormat = resultDataFormat
-        self.truncatedByThriftLimit = truncatedByThriftLimit
-        self.resultByteLimit = resultByteLimit
+        self.truncatedByLimit = truncatedByLimit
 
     def read(self, iprot):
         if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
@@ -9474,11 +9210,11 @@ class TGetResultSetMetadataResp(object):
             elif fid == 3330:
                 if ftype == TType.LIST:
                     self.resultFiles = []
-                    (_etype286, _size283) = iprot.readListBegin()
-                    for _i287 in range(_size283):
-                        _elem288 = TDBSqlCloudResultFile()
-                        _elem288.read(iprot)
-                        self.resultFiles.append(_elem288)
+                    (_etype268, _size265) = iprot.readListBegin()
+                    for _i269 in range(_size265):
+                        _elem270 = TDBSqlCloudResultFile()
+                        _elem270.read(iprot)
+                        self.resultFiles.append(_elem270)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -9525,12 +9261,7 @@ class TGetResultSetMetadataResp(object):
                     iprot.skip(ftype)
             elif fid == 3345:
                 if ftype == TType.BOOL:
-                    self.truncatedByThriftLimit = iprot.readBool()
-                else:
-                    iprot.skip(ftype)
-            elif fid == 3346:
-                if ftype == TType.I64:
-                    self.resultByteLimit = iprot.readI64()
+                    self.truncatedByLimit = iprot.readBool()
                 else:
                     iprot.skip(ftype)
             else:
@@ -9586,8 +9317,8 @@ class TGetResultSetMetadataResp(object):
         if self.resultFiles is not None:
             oprot.writeFieldBegin('resultFiles', TType.LIST, 3330)
             oprot.writeListBegin(TType.STRUCT, len(self.resultFiles))
-            for iter289 in self.resultFiles:
-                iter289.write(oprot)
+            for iter271 in self.resultFiles:
+                iter271.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.manifestFile is not None:
@@ -9622,13 +9353,9 @@ class TGetResultSetMetadataResp(object):
             oprot.writeFieldBegin('resultDataFormat', TType.STRUCT, 3344)
             self.resultDataFormat.write(oprot)
             oprot.writeFieldEnd()
-        if self.truncatedByThriftLimit is not None:
-            oprot.writeFieldBegin('truncatedByThriftLimit', TType.BOOL, 3345)
-            oprot.writeBool(self.truncatedByThriftLimit)
-            oprot.writeFieldEnd()
-        if self.resultByteLimit is not None:
-            oprot.writeFieldBegin('resultByteLimit', TType.I64, 3346)
-            oprot.writeI64(self.resultByteLimit)
+        if self.truncatedByLimit is not None:
+            oprot.writeFieldBegin('truncatedByLimit', TType.BOOL, 3345)
+            oprot.writeBool(self.truncatedByLimit)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -10378,25 +10105,25 @@ class TProgressUpdateResp(object):
             if fid == 1:
                 if ftype == TType.LIST:
                     self.headerNames = []
-                    (_etype293, _size290) = iprot.readListBegin()
-                    for _i294 in range(_size290):
-                        _elem295 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        self.headerNames.append(_elem295)
+                    (_etype275, _size272) = iprot.readListBegin()
+                    for _i276 in range(_size272):
+                        _elem277 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        self.headerNames.append(_elem277)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.LIST:
                     self.rows = []
-                    (_etype299, _size296) = iprot.readListBegin()
-                    for _i300 in range(_size296):
-                        _elem301 = []
-                        (_etype305, _size302) = iprot.readListBegin()
-                        for _i306 in range(_size302):
-                            _elem307 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                            _elem301.append(_elem307)
+                    (_etype281, _size278) = iprot.readListBegin()
+                    for _i282 in range(_size278):
+                        _elem283 = []
+                        (_etype287, _size284) = iprot.readListBegin()
+                        for _i288 in range(_size284):
+                            _elem289 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                            _elem283.append(_elem289)
                         iprot.readListEnd()
-                        self.rows.append(_elem301)
+                        self.rows.append(_elem283)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -10433,17 +10160,17 @@ class TProgressUpdateResp(object):
         if self.headerNames is not None:
             oprot.writeFieldBegin('headerNames', TType.LIST, 1)
             oprot.writeListBegin(TType.STRING, len(self.headerNames))
-            for iter308 in self.headerNames:
-                oprot.writeString(iter308.encode('utf-8') if sys.version_info[0] == 2 else iter308)
+            for iter290 in self.headerNames:
+                oprot.writeString(iter290.encode('utf-8') if sys.version_info[0] == 2 else iter290)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.rows is not None:
             oprot.writeFieldBegin('rows', TType.LIST, 2)
             oprot.writeListBegin(TType.LIST, len(self.rows))
-            for iter309 in self.rows:
-                oprot.writeListBegin(TType.STRING, len(iter309))
-                for iter310 in iter309:
-                    oprot.writeString(iter310.encode('utf-8') if sys.version_info[0] == 2 else iter310)
+            for iter291 in self.rows:
+                oprot.writeListBegin(TType.STRING, len(iter291))
+                for iter292 in iter291:
+                    oprot.writeString(iter292.encode('utf-8') if sys.version_info[0] == 2 else iter292)
                 oprot.writeListEnd()
             oprot.writeListEnd()
             oprot.writeFieldEnd()
@@ -10710,7 +10437,6 @@ TSparkArrowResultLink.thrift_spec = (
     (3, TType.I64, 'startRowOffset', None, None, ),  # 3
     (4, TType.I64, 'rowCount', None, None, ),  # 4
     (5, TType.I64, 'bytesNum', None, None, ),  # 5
-    (6, TType.MAP, 'httpHeaders', (TType.STRING, 'UTF8', TType.STRING, 'UTF8', False), None, ),  # 6
 )
 all_structs.append(TDBSqlCloudResultFile)
 TDBSqlCloudResultFile.thrift_spec = (
@@ -10722,7 +10448,6 @@ TDBSqlCloudResultFile.thrift_spec = (
     (5, TType.I64, 'compressedBytes', None, None, ),  # 5
     (6, TType.STRING, 'fileLink', 'UTF8', None, ),  # 6
     (7, TType.I64, 'linkExpiryTime', None, None, ),  # 7
-    (8, TType.MAP, 'httpHeaders', (TType.STRING, 'UTF8', TType.STRING, 'UTF8', False), None, ),  # 8
 )
 all_structs.append(TRowSet)
 TRowSet.thrift_spec = (
@@ -15385,7 +15110,7 @@ TStatus.thrift_spec = (
     None,  # 1278
     None,  # 1279
     None,  # 1280
-    (1281, TType.STRING, 'errorDetailsJson', 'UTF8', None, ),  # 1281
+    None,  # 1281
     None,  # 1282
     None,  # 1283
     None,  # 1284
@@ -33410,14 +33135,14 @@ TExecuteStatementReq.thrift_spec = (
     (1286, TType.STRUCT, 'useArrowNativeTypes', [TSparkArrowTypes, None], None, ),  # 1286
     (1287, TType.I64, 'resultRowLimit', None, None, ),  # 1287
     (1288, TType.LIST, 'parameters', (TType.STRUCT, [TSparkParameter, None], False), None, ),  # 1288
-    (1289, TType.I64, 'maxBytesPerBatch', None, None, ),  # 1289
+    None,  # 1289
     None,  # 1290
     None,  # 1291
     None,  # 1292
     None,  # 1293
     None,  # 1294
     None,  # 1295
-    (1296, TType.STRUCT, 'statementConf', [TStatementConf, None], None, ),  # 1296
+    None,  # 1296
     None,  # 1297
     None,  # 1298
     None,  # 1299
@@ -35472,17 +35197,6 @@ TExecuteStatementReq.thrift_spec = (
     (3348, TType.I64, 'resultByteLimit', None, None, ),  # 3348
     (3349, TType.STRUCT, 'resultDataFormat', [TDBSqlResultFormat, None], None, ),  # 3349
     (3350, TType.STRING, 'originatingClientIdentity', 'UTF8', None, ),  # 3350
-    (3351, TType.BOOL, 'preferSingleFileResult', None, None, ),  # 3351
-    (3352, TType.BOOL, 'preferDriverOnlyUpload', None, None, ),  # 3352
-    (3353, TType.BOOL, 'enforceEmbeddedSchemaCorrectness', None, False, ),  # 3353
-    None,  # 3354
-    None,  # 3355
-    None,  # 3356
-    None,  # 3357
-    None,  # 3358
-    None,  # 3359
-    (3360, TType.STRING, 'idempotencyToken', 'UTF8', None, ),  # 3360
-    (3361, TType.BOOL, 'throwErrorOnByteLimitTruncation', None, None, ),  # 3361
 )
 all_structs.append(TDBSqlStatement)
 TDBSqlStatement.thrift_spec = (
@@ -35503,14 +35217,6 @@ TSparkParameter.thrift_spec = (
     (2, TType.STRING, 'name', 'UTF8', None, ),  # 2
     (3, TType.STRING, 'type', 'UTF8', None, ),  # 3
     (4, TType.STRUCT, 'value', [TSparkParameterValue, None], None, ),  # 4
-)
-all_structs.append(TStatementConf)
-TStatementConf.thrift_spec = (
-    None,  # 0
-    (1, TType.BOOL, 'sessionless', None, None, ),  # 1
-    (2, TType.STRUCT, 'initialNamespace', [TNamespace, None], None, ),  # 2
-    (3, TType.I32, 'client_protocol', None, None, ),  # 3
-    (4, TType.I64, 'client_protocol_i64', None, None, ),  # 4
 )
 all_structs.append(TExecuteStatementResp)
 TExecuteStatementResp.thrift_spec = (
@@ -81715,7 +81421,7 @@ TGetOperationStatusResp.thrift_spec = (
     None,  # 1280
     (1281, TType.STRING, 'displayMessage', 'UTF8', None, ),  # 1281
     (1282, TType.STRING, 'diagnosticInfo', 'UTF8', None, ),  # 1282
-    (1283, TType.STRING, 'errorDetailsJson', 'UTF8', None, ),  # 1283
+    None,  # 1283
     None,  # 1284
     None,  # 1285
     None,  # 1286
@@ -87109,3334 +86815,6 @@ all_structs.append(TCloseOperationReq)
 TCloseOperationReq.thrift_spec = (
     None,  # 0
     (1, TType.STRUCT, 'operationHandle', [TOperationHandle, None], None, ),  # 1
-    None,  # 2
-    None,  # 3
-    None,  # 4
-    None,  # 5
-    None,  # 6
-    None,  # 7
-    None,  # 8
-    None,  # 9
-    None,  # 10
-    None,  # 11
-    None,  # 12
-    None,  # 13
-    None,  # 14
-    None,  # 15
-    None,  # 16
-    None,  # 17
-    None,  # 18
-    None,  # 19
-    None,  # 20
-    None,  # 21
-    None,  # 22
-    None,  # 23
-    None,  # 24
-    None,  # 25
-    None,  # 26
-    None,  # 27
-    None,  # 28
-    None,  # 29
-    None,  # 30
-    None,  # 31
-    None,  # 32
-    None,  # 33
-    None,  # 34
-    None,  # 35
-    None,  # 36
-    None,  # 37
-    None,  # 38
-    None,  # 39
-    None,  # 40
-    None,  # 41
-    None,  # 42
-    None,  # 43
-    None,  # 44
-    None,  # 45
-    None,  # 46
-    None,  # 47
-    None,  # 48
-    None,  # 49
-    None,  # 50
-    None,  # 51
-    None,  # 52
-    None,  # 53
-    None,  # 54
-    None,  # 55
-    None,  # 56
-    None,  # 57
-    None,  # 58
-    None,  # 59
-    None,  # 60
-    None,  # 61
-    None,  # 62
-    None,  # 63
-    None,  # 64
-    None,  # 65
-    None,  # 66
-    None,  # 67
-    None,  # 68
-    None,  # 69
-    None,  # 70
-    None,  # 71
-    None,  # 72
-    None,  # 73
-    None,  # 74
-    None,  # 75
-    None,  # 76
-    None,  # 77
-    None,  # 78
-    None,  # 79
-    None,  # 80
-    None,  # 81
-    None,  # 82
-    None,  # 83
-    None,  # 84
-    None,  # 85
-    None,  # 86
-    None,  # 87
-    None,  # 88
-    None,  # 89
-    None,  # 90
-    None,  # 91
-    None,  # 92
-    None,  # 93
-    None,  # 94
-    None,  # 95
-    None,  # 96
-    None,  # 97
-    None,  # 98
-    None,  # 99
-    None,  # 100
-    None,  # 101
-    None,  # 102
-    None,  # 103
-    None,  # 104
-    None,  # 105
-    None,  # 106
-    None,  # 107
-    None,  # 108
-    None,  # 109
-    None,  # 110
-    None,  # 111
-    None,  # 112
-    None,  # 113
-    None,  # 114
-    None,  # 115
-    None,  # 116
-    None,  # 117
-    None,  # 118
-    None,  # 119
-    None,  # 120
-    None,  # 121
-    None,  # 122
-    None,  # 123
-    None,  # 124
-    None,  # 125
-    None,  # 126
-    None,  # 127
-    None,  # 128
-    None,  # 129
-    None,  # 130
-    None,  # 131
-    None,  # 132
-    None,  # 133
-    None,  # 134
-    None,  # 135
-    None,  # 136
-    None,  # 137
-    None,  # 138
-    None,  # 139
-    None,  # 140
-    None,  # 141
-    None,  # 142
-    None,  # 143
-    None,  # 144
-    None,  # 145
-    None,  # 146
-    None,  # 147
-    None,  # 148
-    None,  # 149
-    None,  # 150
-    None,  # 151
-    None,  # 152
-    None,  # 153
-    None,  # 154
-    None,  # 155
-    None,  # 156
-    None,  # 157
-    None,  # 158
-    None,  # 159
-    None,  # 160
-    None,  # 161
-    None,  # 162
-    None,  # 163
-    None,  # 164
-    None,  # 165
-    None,  # 166
-    None,  # 167
-    None,  # 168
-    None,  # 169
-    None,  # 170
-    None,  # 171
-    None,  # 172
-    None,  # 173
-    None,  # 174
-    None,  # 175
-    None,  # 176
-    None,  # 177
-    None,  # 178
-    None,  # 179
-    None,  # 180
-    None,  # 181
-    None,  # 182
-    None,  # 183
-    None,  # 184
-    None,  # 185
-    None,  # 186
-    None,  # 187
-    None,  # 188
-    None,  # 189
-    None,  # 190
-    None,  # 191
-    None,  # 192
-    None,  # 193
-    None,  # 194
-    None,  # 195
-    None,  # 196
-    None,  # 197
-    None,  # 198
-    None,  # 199
-    None,  # 200
-    None,  # 201
-    None,  # 202
-    None,  # 203
-    None,  # 204
-    None,  # 205
-    None,  # 206
-    None,  # 207
-    None,  # 208
-    None,  # 209
-    None,  # 210
-    None,  # 211
-    None,  # 212
-    None,  # 213
-    None,  # 214
-    None,  # 215
-    None,  # 216
-    None,  # 217
-    None,  # 218
-    None,  # 219
-    None,  # 220
-    None,  # 221
-    None,  # 222
-    None,  # 223
-    None,  # 224
-    None,  # 225
-    None,  # 226
-    None,  # 227
-    None,  # 228
-    None,  # 229
-    None,  # 230
-    None,  # 231
-    None,  # 232
-    None,  # 233
-    None,  # 234
-    None,  # 235
-    None,  # 236
-    None,  # 237
-    None,  # 238
-    None,  # 239
-    None,  # 240
-    None,  # 241
-    None,  # 242
-    None,  # 243
-    None,  # 244
-    None,  # 245
-    None,  # 246
-    None,  # 247
-    None,  # 248
-    None,  # 249
-    None,  # 250
-    None,  # 251
-    None,  # 252
-    None,  # 253
-    None,  # 254
-    None,  # 255
-    None,  # 256
-    None,  # 257
-    None,  # 258
-    None,  # 259
-    None,  # 260
-    None,  # 261
-    None,  # 262
-    None,  # 263
-    None,  # 264
-    None,  # 265
-    None,  # 266
-    None,  # 267
-    None,  # 268
-    None,  # 269
-    None,  # 270
-    None,  # 271
-    None,  # 272
-    None,  # 273
-    None,  # 274
-    None,  # 275
-    None,  # 276
-    None,  # 277
-    None,  # 278
-    None,  # 279
-    None,  # 280
-    None,  # 281
-    None,  # 282
-    None,  # 283
-    None,  # 284
-    None,  # 285
-    None,  # 286
-    None,  # 287
-    None,  # 288
-    None,  # 289
-    None,  # 290
-    None,  # 291
-    None,  # 292
-    None,  # 293
-    None,  # 294
-    None,  # 295
-    None,  # 296
-    None,  # 297
-    None,  # 298
-    None,  # 299
-    None,  # 300
-    None,  # 301
-    None,  # 302
-    None,  # 303
-    None,  # 304
-    None,  # 305
-    None,  # 306
-    None,  # 307
-    None,  # 308
-    None,  # 309
-    None,  # 310
-    None,  # 311
-    None,  # 312
-    None,  # 313
-    None,  # 314
-    None,  # 315
-    None,  # 316
-    None,  # 317
-    None,  # 318
-    None,  # 319
-    None,  # 320
-    None,  # 321
-    None,  # 322
-    None,  # 323
-    None,  # 324
-    None,  # 325
-    None,  # 326
-    None,  # 327
-    None,  # 328
-    None,  # 329
-    None,  # 330
-    None,  # 331
-    None,  # 332
-    None,  # 333
-    None,  # 334
-    None,  # 335
-    None,  # 336
-    None,  # 337
-    None,  # 338
-    None,  # 339
-    None,  # 340
-    None,  # 341
-    None,  # 342
-    None,  # 343
-    None,  # 344
-    None,  # 345
-    None,  # 346
-    None,  # 347
-    None,  # 348
-    None,  # 349
-    None,  # 350
-    None,  # 351
-    None,  # 352
-    None,  # 353
-    None,  # 354
-    None,  # 355
-    None,  # 356
-    None,  # 357
-    None,  # 358
-    None,  # 359
-    None,  # 360
-    None,  # 361
-    None,  # 362
-    None,  # 363
-    None,  # 364
-    None,  # 365
-    None,  # 366
-    None,  # 367
-    None,  # 368
-    None,  # 369
-    None,  # 370
-    None,  # 371
-    None,  # 372
-    None,  # 373
-    None,  # 374
-    None,  # 375
-    None,  # 376
-    None,  # 377
-    None,  # 378
-    None,  # 379
-    None,  # 380
-    None,  # 381
-    None,  # 382
-    None,  # 383
-    None,  # 384
-    None,  # 385
-    None,  # 386
-    None,  # 387
-    None,  # 388
-    None,  # 389
-    None,  # 390
-    None,  # 391
-    None,  # 392
-    None,  # 393
-    None,  # 394
-    None,  # 395
-    None,  # 396
-    None,  # 397
-    None,  # 398
-    None,  # 399
-    None,  # 400
-    None,  # 401
-    None,  # 402
-    None,  # 403
-    None,  # 404
-    None,  # 405
-    None,  # 406
-    None,  # 407
-    None,  # 408
-    None,  # 409
-    None,  # 410
-    None,  # 411
-    None,  # 412
-    None,  # 413
-    None,  # 414
-    None,  # 415
-    None,  # 416
-    None,  # 417
-    None,  # 418
-    None,  # 419
-    None,  # 420
-    None,  # 421
-    None,  # 422
-    None,  # 423
-    None,  # 424
-    None,  # 425
-    None,  # 426
-    None,  # 427
-    None,  # 428
-    None,  # 429
-    None,  # 430
-    None,  # 431
-    None,  # 432
-    None,  # 433
-    None,  # 434
-    None,  # 435
-    None,  # 436
-    None,  # 437
-    None,  # 438
-    None,  # 439
-    None,  # 440
-    None,  # 441
-    None,  # 442
-    None,  # 443
-    None,  # 444
-    None,  # 445
-    None,  # 446
-    None,  # 447
-    None,  # 448
-    None,  # 449
-    None,  # 450
-    None,  # 451
-    None,  # 452
-    None,  # 453
-    None,  # 454
-    None,  # 455
-    None,  # 456
-    None,  # 457
-    None,  # 458
-    None,  # 459
-    None,  # 460
-    None,  # 461
-    None,  # 462
-    None,  # 463
-    None,  # 464
-    None,  # 465
-    None,  # 466
-    None,  # 467
-    None,  # 468
-    None,  # 469
-    None,  # 470
-    None,  # 471
-    None,  # 472
-    None,  # 473
-    None,  # 474
-    None,  # 475
-    None,  # 476
-    None,  # 477
-    None,  # 478
-    None,  # 479
-    None,  # 480
-    None,  # 481
-    None,  # 482
-    None,  # 483
-    None,  # 484
-    None,  # 485
-    None,  # 486
-    None,  # 487
-    None,  # 488
-    None,  # 489
-    None,  # 490
-    None,  # 491
-    None,  # 492
-    None,  # 493
-    None,  # 494
-    None,  # 495
-    None,  # 496
-    None,  # 497
-    None,  # 498
-    None,  # 499
-    None,  # 500
-    None,  # 501
-    None,  # 502
-    None,  # 503
-    None,  # 504
-    None,  # 505
-    None,  # 506
-    None,  # 507
-    None,  # 508
-    None,  # 509
-    None,  # 510
-    None,  # 511
-    None,  # 512
-    None,  # 513
-    None,  # 514
-    None,  # 515
-    None,  # 516
-    None,  # 517
-    None,  # 518
-    None,  # 519
-    None,  # 520
-    None,  # 521
-    None,  # 522
-    None,  # 523
-    None,  # 524
-    None,  # 525
-    None,  # 526
-    None,  # 527
-    None,  # 528
-    None,  # 529
-    None,  # 530
-    None,  # 531
-    None,  # 532
-    None,  # 533
-    None,  # 534
-    None,  # 535
-    None,  # 536
-    None,  # 537
-    None,  # 538
-    None,  # 539
-    None,  # 540
-    None,  # 541
-    None,  # 542
-    None,  # 543
-    None,  # 544
-    None,  # 545
-    None,  # 546
-    None,  # 547
-    None,  # 548
-    None,  # 549
-    None,  # 550
-    None,  # 551
-    None,  # 552
-    None,  # 553
-    None,  # 554
-    None,  # 555
-    None,  # 556
-    None,  # 557
-    None,  # 558
-    None,  # 559
-    None,  # 560
-    None,  # 561
-    None,  # 562
-    None,  # 563
-    None,  # 564
-    None,  # 565
-    None,  # 566
-    None,  # 567
-    None,  # 568
-    None,  # 569
-    None,  # 570
-    None,  # 571
-    None,  # 572
-    None,  # 573
-    None,  # 574
-    None,  # 575
-    None,  # 576
-    None,  # 577
-    None,  # 578
-    None,  # 579
-    None,  # 580
-    None,  # 581
-    None,  # 582
-    None,  # 583
-    None,  # 584
-    None,  # 585
-    None,  # 586
-    None,  # 587
-    None,  # 588
-    None,  # 589
-    None,  # 590
-    None,  # 591
-    None,  # 592
-    None,  # 593
-    None,  # 594
-    None,  # 595
-    None,  # 596
-    None,  # 597
-    None,  # 598
-    None,  # 599
-    None,  # 600
-    None,  # 601
-    None,  # 602
-    None,  # 603
-    None,  # 604
-    None,  # 605
-    None,  # 606
-    None,  # 607
-    None,  # 608
-    None,  # 609
-    None,  # 610
-    None,  # 611
-    None,  # 612
-    None,  # 613
-    None,  # 614
-    None,  # 615
-    None,  # 616
-    None,  # 617
-    None,  # 618
-    None,  # 619
-    None,  # 620
-    None,  # 621
-    None,  # 622
-    None,  # 623
-    None,  # 624
-    None,  # 625
-    None,  # 626
-    None,  # 627
-    None,  # 628
-    None,  # 629
-    None,  # 630
-    None,  # 631
-    None,  # 632
-    None,  # 633
-    None,  # 634
-    None,  # 635
-    None,  # 636
-    None,  # 637
-    None,  # 638
-    None,  # 639
-    None,  # 640
-    None,  # 641
-    None,  # 642
-    None,  # 643
-    None,  # 644
-    None,  # 645
-    None,  # 646
-    None,  # 647
-    None,  # 648
-    None,  # 649
-    None,  # 650
-    None,  # 651
-    None,  # 652
-    None,  # 653
-    None,  # 654
-    None,  # 655
-    None,  # 656
-    None,  # 657
-    None,  # 658
-    None,  # 659
-    None,  # 660
-    None,  # 661
-    None,  # 662
-    None,  # 663
-    None,  # 664
-    None,  # 665
-    None,  # 666
-    None,  # 667
-    None,  # 668
-    None,  # 669
-    None,  # 670
-    None,  # 671
-    None,  # 672
-    None,  # 673
-    None,  # 674
-    None,  # 675
-    None,  # 676
-    None,  # 677
-    None,  # 678
-    None,  # 679
-    None,  # 680
-    None,  # 681
-    None,  # 682
-    None,  # 683
-    None,  # 684
-    None,  # 685
-    None,  # 686
-    None,  # 687
-    None,  # 688
-    None,  # 689
-    None,  # 690
-    None,  # 691
-    None,  # 692
-    None,  # 693
-    None,  # 694
-    None,  # 695
-    None,  # 696
-    None,  # 697
-    None,  # 698
-    None,  # 699
-    None,  # 700
-    None,  # 701
-    None,  # 702
-    None,  # 703
-    None,  # 704
-    None,  # 705
-    None,  # 706
-    None,  # 707
-    None,  # 708
-    None,  # 709
-    None,  # 710
-    None,  # 711
-    None,  # 712
-    None,  # 713
-    None,  # 714
-    None,  # 715
-    None,  # 716
-    None,  # 717
-    None,  # 718
-    None,  # 719
-    None,  # 720
-    None,  # 721
-    None,  # 722
-    None,  # 723
-    None,  # 724
-    None,  # 725
-    None,  # 726
-    None,  # 727
-    None,  # 728
-    None,  # 729
-    None,  # 730
-    None,  # 731
-    None,  # 732
-    None,  # 733
-    None,  # 734
-    None,  # 735
-    None,  # 736
-    None,  # 737
-    None,  # 738
-    None,  # 739
-    None,  # 740
-    None,  # 741
-    None,  # 742
-    None,  # 743
-    None,  # 744
-    None,  # 745
-    None,  # 746
-    None,  # 747
-    None,  # 748
-    None,  # 749
-    None,  # 750
-    None,  # 751
-    None,  # 752
-    None,  # 753
-    None,  # 754
-    None,  # 755
-    None,  # 756
-    None,  # 757
-    None,  # 758
-    None,  # 759
-    None,  # 760
-    None,  # 761
-    None,  # 762
-    None,  # 763
-    None,  # 764
-    None,  # 765
-    None,  # 766
-    None,  # 767
-    None,  # 768
-    None,  # 769
-    None,  # 770
-    None,  # 771
-    None,  # 772
-    None,  # 773
-    None,  # 774
-    None,  # 775
-    None,  # 776
-    None,  # 777
-    None,  # 778
-    None,  # 779
-    None,  # 780
-    None,  # 781
-    None,  # 782
-    None,  # 783
-    None,  # 784
-    None,  # 785
-    None,  # 786
-    None,  # 787
-    None,  # 788
-    None,  # 789
-    None,  # 790
-    None,  # 791
-    None,  # 792
-    None,  # 793
-    None,  # 794
-    None,  # 795
-    None,  # 796
-    None,  # 797
-    None,  # 798
-    None,  # 799
-    None,  # 800
-    None,  # 801
-    None,  # 802
-    None,  # 803
-    None,  # 804
-    None,  # 805
-    None,  # 806
-    None,  # 807
-    None,  # 808
-    None,  # 809
-    None,  # 810
-    None,  # 811
-    None,  # 812
-    None,  # 813
-    None,  # 814
-    None,  # 815
-    None,  # 816
-    None,  # 817
-    None,  # 818
-    None,  # 819
-    None,  # 820
-    None,  # 821
-    None,  # 822
-    None,  # 823
-    None,  # 824
-    None,  # 825
-    None,  # 826
-    None,  # 827
-    None,  # 828
-    None,  # 829
-    None,  # 830
-    None,  # 831
-    None,  # 832
-    None,  # 833
-    None,  # 834
-    None,  # 835
-    None,  # 836
-    None,  # 837
-    None,  # 838
-    None,  # 839
-    None,  # 840
-    None,  # 841
-    None,  # 842
-    None,  # 843
-    None,  # 844
-    None,  # 845
-    None,  # 846
-    None,  # 847
-    None,  # 848
-    None,  # 849
-    None,  # 850
-    None,  # 851
-    None,  # 852
-    None,  # 853
-    None,  # 854
-    None,  # 855
-    None,  # 856
-    None,  # 857
-    None,  # 858
-    None,  # 859
-    None,  # 860
-    None,  # 861
-    None,  # 862
-    None,  # 863
-    None,  # 864
-    None,  # 865
-    None,  # 866
-    None,  # 867
-    None,  # 868
-    None,  # 869
-    None,  # 870
-    None,  # 871
-    None,  # 872
-    None,  # 873
-    None,  # 874
-    None,  # 875
-    None,  # 876
-    None,  # 877
-    None,  # 878
-    None,  # 879
-    None,  # 880
-    None,  # 881
-    None,  # 882
-    None,  # 883
-    None,  # 884
-    None,  # 885
-    None,  # 886
-    None,  # 887
-    None,  # 888
-    None,  # 889
-    None,  # 890
-    None,  # 891
-    None,  # 892
-    None,  # 893
-    None,  # 894
-    None,  # 895
-    None,  # 896
-    None,  # 897
-    None,  # 898
-    None,  # 899
-    None,  # 900
-    None,  # 901
-    None,  # 902
-    None,  # 903
-    None,  # 904
-    None,  # 905
-    None,  # 906
-    None,  # 907
-    None,  # 908
-    None,  # 909
-    None,  # 910
-    None,  # 911
-    None,  # 912
-    None,  # 913
-    None,  # 914
-    None,  # 915
-    None,  # 916
-    None,  # 917
-    None,  # 918
-    None,  # 919
-    None,  # 920
-    None,  # 921
-    None,  # 922
-    None,  # 923
-    None,  # 924
-    None,  # 925
-    None,  # 926
-    None,  # 927
-    None,  # 928
-    None,  # 929
-    None,  # 930
-    None,  # 931
-    None,  # 932
-    None,  # 933
-    None,  # 934
-    None,  # 935
-    None,  # 936
-    None,  # 937
-    None,  # 938
-    None,  # 939
-    None,  # 940
-    None,  # 941
-    None,  # 942
-    None,  # 943
-    None,  # 944
-    None,  # 945
-    None,  # 946
-    None,  # 947
-    None,  # 948
-    None,  # 949
-    None,  # 950
-    None,  # 951
-    None,  # 952
-    None,  # 953
-    None,  # 954
-    None,  # 955
-    None,  # 956
-    None,  # 957
-    None,  # 958
-    None,  # 959
-    None,  # 960
-    None,  # 961
-    None,  # 962
-    None,  # 963
-    None,  # 964
-    None,  # 965
-    None,  # 966
-    None,  # 967
-    None,  # 968
-    None,  # 969
-    None,  # 970
-    None,  # 971
-    None,  # 972
-    None,  # 973
-    None,  # 974
-    None,  # 975
-    None,  # 976
-    None,  # 977
-    None,  # 978
-    None,  # 979
-    None,  # 980
-    None,  # 981
-    None,  # 982
-    None,  # 983
-    None,  # 984
-    None,  # 985
-    None,  # 986
-    None,  # 987
-    None,  # 988
-    None,  # 989
-    None,  # 990
-    None,  # 991
-    None,  # 992
-    None,  # 993
-    None,  # 994
-    None,  # 995
-    None,  # 996
-    None,  # 997
-    None,  # 998
-    None,  # 999
-    None,  # 1000
-    None,  # 1001
-    None,  # 1002
-    None,  # 1003
-    None,  # 1004
-    None,  # 1005
-    None,  # 1006
-    None,  # 1007
-    None,  # 1008
-    None,  # 1009
-    None,  # 1010
-    None,  # 1011
-    None,  # 1012
-    None,  # 1013
-    None,  # 1014
-    None,  # 1015
-    None,  # 1016
-    None,  # 1017
-    None,  # 1018
-    None,  # 1019
-    None,  # 1020
-    None,  # 1021
-    None,  # 1022
-    None,  # 1023
-    None,  # 1024
-    None,  # 1025
-    None,  # 1026
-    None,  # 1027
-    None,  # 1028
-    None,  # 1029
-    None,  # 1030
-    None,  # 1031
-    None,  # 1032
-    None,  # 1033
-    None,  # 1034
-    None,  # 1035
-    None,  # 1036
-    None,  # 1037
-    None,  # 1038
-    None,  # 1039
-    None,  # 1040
-    None,  # 1041
-    None,  # 1042
-    None,  # 1043
-    None,  # 1044
-    None,  # 1045
-    None,  # 1046
-    None,  # 1047
-    None,  # 1048
-    None,  # 1049
-    None,  # 1050
-    None,  # 1051
-    None,  # 1052
-    None,  # 1053
-    None,  # 1054
-    None,  # 1055
-    None,  # 1056
-    None,  # 1057
-    None,  # 1058
-    None,  # 1059
-    None,  # 1060
-    None,  # 1061
-    None,  # 1062
-    None,  # 1063
-    None,  # 1064
-    None,  # 1065
-    None,  # 1066
-    None,  # 1067
-    None,  # 1068
-    None,  # 1069
-    None,  # 1070
-    None,  # 1071
-    None,  # 1072
-    None,  # 1073
-    None,  # 1074
-    None,  # 1075
-    None,  # 1076
-    None,  # 1077
-    None,  # 1078
-    None,  # 1079
-    None,  # 1080
-    None,  # 1081
-    None,  # 1082
-    None,  # 1083
-    None,  # 1084
-    None,  # 1085
-    None,  # 1086
-    None,  # 1087
-    None,  # 1088
-    None,  # 1089
-    None,  # 1090
-    None,  # 1091
-    None,  # 1092
-    None,  # 1093
-    None,  # 1094
-    None,  # 1095
-    None,  # 1096
-    None,  # 1097
-    None,  # 1098
-    None,  # 1099
-    None,  # 1100
-    None,  # 1101
-    None,  # 1102
-    None,  # 1103
-    None,  # 1104
-    None,  # 1105
-    None,  # 1106
-    None,  # 1107
-    None,  # 1108
-    None,  # 1109
-    None,  # 1110
-    None,  # 1111
-    None,  # 1112
-    None,  # 1113
-    None,  # 1114
-    None,  # 1115
-    None,  # 1116
-    None,  # 1117
-    None,  # 1118
-    None,  # 1119
-    None,  # 1120
-    None,  # 1121
-    None,  # 1122
-    None,  # 1123
-    None,  # 1124
-    None,  # 1125
-    None,  # 1126
-    None,  # 1127
-    None,  # 1128
-    None,  # 1129
-    None,  # 1130
-    None,  # 1131
-    None,  # 1132
-    None,  # 1133
-    None,  # 1134
-    None,  # 1135
-    None,  # 1136
-    None,  # 1137
-    None,  # 1138
-    None,  # 1139
-    None,  # 1140
-    None,  # 1141
-    None,  # 1142
-    None,  # 1143
-    None,  # 1144
-    None,  # 1145
-    None,  # 1146
-    None,  # 1147
-    None,  # 1148
-    None,  # 1149
-    None,  # 1150
-    None,  # 1151
-    None,  # 1152
-    None,  # 1153
-    None,  # 1154
-    None,  # 1155
-    None,  # 1156
-    None,  # 1157
-    None,  # 1158
-    None,  # 1159
-    None,  # 1160
-    None,  # 1161
-    None,  # 1162
-    None,  # 1163
-    None,  # 1164
-    None,  # 1165
-    None,  # 1166
-    None,  # 1167
-    None,  # 1168
-    None,  # 1169
-    None,  # 1170
-    None,  # 1171
-    None,  # 1172
-    None,  # 1173
-    None,  # 1174
-    None,  # 1175
-    None,  # 1176
-    None,  # 1177
-    None,  # 1178
-    None,  # 1179
-    None,  # 1180
-    None,  # 1181
-    None,  # 1182
-    None,  # 1183
-    None,  # 1184
-    None,  # 1185
-    None,  # 1186
-    None,  # 1187
-    None,  # 1188
-    None,  # 1189
-    None,  # 1190
-    None,  # 1191
-    None,  # 1192
-    None,  # 1193
-    None,  # 1194
-    None,  # 1195
-    None,  # 1196
-    None,  # 1197
-    None,  # 1198
-    None,  # 1199
-    None,  # 1200
-    None,  # 1201
-    None,  # 1202
-    None,  # 1203
-    None,  # 1204
-    None,  # 1205
-    None,  # 1206
-    None,  # 1207
-    None,  # 1208
-    None,  # 1209
-    None,  # 1210
-    None,  # 1211
-    None,  # 1212
-    None,  # 1213
-    None,  # 1214
-    None,  # 1215
-    None,  # 1216
-    None,  # 1217
-    None,  # 1218
-    None,  # 1219
-    None,  # 1220
-    None,  # 1221
-    None,  # 1222
-    None,  # 1223
-    None,  # 1224
-    None,  # 1225
-    None,  # 1226
-    None,  # 1227
-    None,  # 1228
-    None,  # 1229
-    None,  # 1230
-    None,  # 1231
-    None,  # 1232
-    None,  # 1233
-    None,  # 1234
-    None,  # 1235
-    None,  # 1236
-    None,  # 1237
-    None,  # 1238
-    None,  # 1239
-    None,  # 1240
-    None,  # 1241
-    None,  # 1242
-    None,  # 1243
-    None,  # 1244
-    None,  # 1245
-    None,  # 1246
-    None,  # 1247
-    None,  # 1248
-    None,  # 1249
-    None,  # 1250
-    None,  # 1251
-    None,  # 1252
-    None,  # 1253
-    None,  # 1254
-    None,  # 1255
-    None,  # 1256
-    None,  # 1257
-    None,  # 1258
-    None,  # 1259
-    None,  # 1260
-    None,  # 1261
-    None,  # 1262
-    None,  # 1263
-    None,  # 1264
-    None,  # 1265
-    None,  # 1266
-    None,  # 1267
-    None,  # 1268
-    None,  # 1269
-    None,  # 1270
-    None,  # 1271
-    None,  # 1272
-    None,  # 1273
-    None,  # 1274
-    None,  # 1275
-    None,  # 1276
-    None,  # 1277
-    None,  # 1278
-    None,  # 1279
-    None,  # 1280
-    None,  # 1281
-    None,  # 1282
-    None,  # 1283
-    None,  # 1284
-    None,  # 1285
-    None,  # 1286
-    None,  # 1287
-    None,  # 1288
-    None,  # 1289
-    None,  # 1290
-    None,  # 1291
-    None,  # 1292
-    None,  # 1293
-    None,  # 1294
-    None,  # 1295
-    None,  # 1296
-    None,  # 1297
-    None,  # 1298
-    None,  # 1299
-    None,  # 1300
-    None,  # 1301
-    None,  # 1302
-    None,  # 1303
-    None,  # 1304
-    None,  # 1305
-    None,  # 1306
-    None,  # 1307
-    None,  # 1308
-    None,  # 1309
-    None,  # 1310
-    None,  # 1311
-    None,  # 1312
-    None,  # 1313
-    None,  # 1314
-    None,  # 1315
-    None,  # 1316
-    None,  # 1317
-    None,  # 1318
-    None,  # 1319
-    None,  # 1320
-    None,  # 1321
-    None,  # 1322
-    None,  # 1323
-    None,  # 1324
-    None,  # 1325
-    None,  # 1326
-    None,  # 1327
-    None,  # 1328
-    None,  # 1329
-    None,  # 1330
-    None,  # 1331
-    None,  # 1332
-    None,  # 1333
-    None,  # 1334
-    None,  # 1335
-    None,  # 1336
-    None,  # 1337
-    None,  # 1338
-    None,  # 1339
-    None,  # 1340
-    None,  # 1341
-    None,  # 1342
-    None,  # 1343
-    None,  # 1344
-    None,  # 1345
-    None,  # 1346
-    None,  # 1347
-    None,  # 1348
-    None,  # 1349
-    None,  # 1350
-    None,  # 1351
-    None,  # 1352
-    None,  # 1353
-    None,  # 1354
-    None,  # 1355
-    None,  # 1356
-    None,  # 1357
-    None,  # 1358
-    None,  # 1359
-    None,  # 1360
-    None,  # 1361
-    None,  # 1362
-    None,  # 1363
-    None,  # 1364
-    None,  # 1365
-    None,  # 1366
-    None,  # 1367
-    None,  # 1368
-    None,  # 1369
-    None,  # 1370
-    None,  # 1371
-    None,  # 1372
-    None,  # 1373
-    None,  # 1374
-    None,  # 1375
-    None,  # 1376
-    None,  # 1377
-    None,  # 1378
-    None,  # 1379
-    None,  # 1380
-    None,  # 1381
-    None,  # 1382
-    None,  # 1383
-    None,  # 1384
-    None,  # 1385
-    None,  # 1386
-    None,  # 1387
-    None,  # 1388
-    None,  # 1389
-    None,  # 1390
-    None,  # 1391
-    None,  # 1392
-    None,  # 1393
-    None,  # 1394
-    None,  # 1395
-    None,  # 1396
-    None,  # 1397
-    None,  # 1398
-    None,  # 1399
-    None,  # 1400
-    None,  # 1401
-    None,  # 1402
-    None,  # 1403
-    None,  # 1404
-    None,  # 1405
-    None,  # 1406
-    None,  # 1407
-    None,  # 1408
-    None,  # 1409
-    None,  # 1410
-    None,  # 1411
-    None,  # 1412
-    None,  # 1413
-    None,  # 1414
-    None,  # 1415
-    None,  # 1416
-    None,  # 1417
-    None,  # 1418
-    None,  # 1419
-    None,  # 1420
-    None,  # 1421
-    None,  # 1422
-    None,  # 1423
-    None,  # 1424
-    None,  # 1425
-    None,  # 1426
-    None,  # 1427
-    None,  # 1428
-    None,  # 1429
-    None,  # 1430
-    None,  # 1431
-    None,  # 1432
-    None,  # 1433
-    None,  # 1434
-    None,  # 1435
-    None,  # 1436
-    None,  # 1437
-    None,  # 1438
-    None,  # 1439
-    None,  # 1440
-    None,  # 1441
-    None,  # 1442
-    None,  # 1443
-    None,  # 1444
-    None,  # 1445
-    None,  # 1446
-    None,  # 1447
-    None,  # 1448
-    None,  # 1449
-    None,  # 1450
-    None,  # 1451
-    None,  # 1452
-    None,  # 1453
-    None,  # 1454
-    None,  # 1455
-    None,  # 1456
-    None,  # 1457
-    None,  # 1458
-    None,  # 1459
-    None,  # 1460
-    None,  # 1461
-    None,  # 1462
-    None,  # 1463
-    None,  # 1464
-    None,  # 1465
-    None,  # 1466
-    None,  # 1467
-    None,  # 1468
-    None,  # 1469
-    None,  # 1470
-    None,  # 1471
-    None,  # 1472
-    None,  # 1473
-    None,  # 1474
-    None,  # 1475
-    None,  # 1476
-    None,  # 1477
-    None,  # 1478
-    None,  # 1479
-    None,  # 1480
-    None,  # 1481
-    None,  # 1482
-    None,  # 1483
-    None,  # 1484
-    None,  # 1485
-    None,  # 1486
-    None,  # 1487
-    None,  # 1488
-    None,  # 1489
-    None,  # 1490
-    None,  # 1491
-    None,  # 1492
-    None,  # 1493
-    None,  # 1494
-    None,  # 1495
-    None,  # 1496
-    None,  # 1497
-    None,  # 1498
-    None,  # 1499
-    None,  # 1500
-    None,  # 1501
-    None,  # 1502
-    None,  # 1503
-    None,  # 1504
-    None,  # 1505
-    None,  # 1506
-    None,  # 1507
-    None,  # 1508
-    None,  # 1509
-    None,  # 1510
-    None,  # 1511
-    None,  # 1512
-    None,  # 1513
-    None,  # 1514
-    None,  # 1515
-    None,  # 1516
-    None,  # 1517
-    None,  # 1518
-    None,  # 1519
-    None,  # 1520
-    None,  # 1521
-    None,  # 1522
-    None,  # 1523
-    None,  # 1524
-    None,  # 1525
-    None,  # 1526
-    None,  # 1527
-    None,  # 1528
-    None,  # 1529
-    None,  # 1530
-    None,  # 1531
-    None,  # 1532
-    None,  # 1533
-    None,  # 1534
-    None,  # 1535
-    None,  # 1536
-    None,  # 1537
-    None,  # 1538
-    None,  # 1539
-    None,  # 1540
-    None,  # 1541
-    None,  # 1542
-    None,  # 1543
-    None,  # 1544
-    None,  # 1545
-    None,  # 1546
-    None,  # 1547
-    None,  # 1548
-    None,  # 1549
-    None,  # 1550
-    None,  # 1551
-    None,  # 1552
-    None,  # 1553
-    None,  # 1554
-    None,  # 1555
-    None,  # 1556
-    None,  # 1557
-    None,  # 1558
-    None,  # 1559
-    None,  # 1560
-    None,  # 1561
-    None,  # 1562
-    None,  # 1563
-    None,  # 1564
-    None,  # 1565
-    None,  # 1566
-    None,  # 1567
-    None,  # 1568
-    None,  # 1569
-    None,  # 1570
-    None,  # 1571
-    None,  # 1572
-    None,  # 1573
-    None,  # 1574
-    None,  # 1575
-    None,  # 1576
-    None,  # 1577
-    None,  # 1578
-    None,  # 1579
-    None,  # 1580
-    None,  # 1581
-    None,  # 1582
-    None,  # 1583
-    None,  # 1584
-    None,  # 1585
-    None,  # 1586
-    None,  # 1587
-    None,  # 1588
-    None,  # 1589
-    None,  # 1590
-    None,  # 1591
-    None,  # 1592
-    None,  # 1593
-    None,  # 1594
-    None,  # 1595
-    None,  # 1596
-    None,  # 1597
-    None,  # 1598
-    None,  # 1599
-    None,  # 1600
-    None,  # 1601
-    None,  # 1602
-    None,  # 1603
-    None,  # 1604
-    None,  # 1605
-    None,  # 1606
-    None,  # 1607
-    None,  # 1608
-    None,  # 1609
-    None,  # 1610
-    None,  # 1611
-    None,  # 1612
-    None,  # 1613
-    None,  # 1614
-    None,  # 1615
-    None,  # 1616
-    None,  # 1617
-    None,  # 1618
-    None,  # 1619
-    None,  # 1620
-    None,  # 1621
-    None,  # 1622
-    None,  # 1623
-    None,  # 1624
-    None,  # 1625
-    None,  # 1626
-    None,  # 1627
-    None,  # 1628
-    None,  # 1629
-    None,  # 1630
-    None,  # 1631
-    None,  # 1632
-    None,  # 1633
-    None,  # 1634
-    None,  # 1635
-    None,  # 1636
-    None,  # 1637
-    None,  # 1638
-    None,  # 1639
-    None,  # 1640
-    None,  # 1641
-    None,  # 1642
-    None,  # 1643
-    None,  # 1644
-    None,  # 1645
-    None,  # 1646
-    None,  # 1647
-    None,  # 1648
-    None,  # 1649
-    None,  # 1650
-    None,  # 1651
-    None,  # 1652
-    None,  # 1653
-    None,  # 1654
-    None,  # 1655
-    None,  # 1656
-    None,  # 1657
-    None,  # 1658
-    None,  # 1659
-    None,  # 1660
-    None,  # 1661
-    None,  # 1662
-    None,  # 1663
-    None,  # 1664
-    None,  # 1665
-    None,  # 1666
-    None,  # 1667
-    None,  # 1668
-    None,  # 1669
-    None,  # 1670
-    None,  # 1671
-    None,  # 1672
-    None,  # 1673
-    None,  # 1674
-    None,  # 1675
-    None,  # 1676
-    None,  # 1677
-    None,  # 1678
-    None,  # 1679
-    None,  # 1680
-    None,  # 1681
-    None,  # 1682
-    None,  # 1683
-    None,  # 1684
-    None,  # 1685
-    None,  # 1686
-    None,  # 1687
-    None,  # 1688
-    None,  # 1689
-    None,  # 1690
-    None,  # 1691
-    None,  # 1692
-    None,  # 1693
-    None,  # 1694
-    None,  # 1695
-    None,  # 1696
-    None,  # 1697
-    None,  # 1698
-    None,  # 1699
-    None,  # 1700
-    None,  # 1701
-    None,  # 1702
-    None,  # 1703
-    None,  # 1704
-    None,  # 1705
-    None,  # 1706
-    None,  # 1707
-    None,  # 1708
-    None,  # 1709
-    None,  # 1710
-    None,  # 1711
-    None,  # 1712
-    None,  # 1713
-    None,  # 1714
-    None,  # 1715
-    None,  # 1716
-    None,  # 1717
-    None,  # 1718
-    None,  # 1719
-    None,  # 1720
-    None,  # 1721
-    None,  # 1722
-    None,  # 1723
-    None,  # 1724
-    None,  # 1725
-    None,  # 1726
-    None,  # 1727
-    None,  # 1728
-    None,  # 1729
-    None,  # 1730
-    None,  # 1731
-    None,  # 1732
-    None,  # 1733
-    None,  # 1734
-    None,  # 1735
-    None,  # 1736
-    None,  # 1737
-    None,  # 1738
-    None,  # 1739
-    None,  # 1740
-    None,  # 1741
-    None,  # 1742
-    None,  # 1743
-    None,  # 1744
-    None,  # 1745
-    None,  # 1746
-    None,  # 1747
-    None,  # 1748
-    None,  # 1749
-    None,  # 1750
-    None,  # 1751
-    None,  # 1752
-    None,  # 1753
-    None,  # 1754
-    None,  # 1755
-    None,  # 1756
-    None,  # 1757
-    None,  # 1758
-    None,  # 1759
-    None,  # 1760
-    None,  # 1761
-    None,  # 1762
-    None,  # 1763
-    None,  # 1764
-    None,  # 1765
-    None,  # 1766
-    None,  # 1767
-    None,  # 1768
-    None,  # 1769
-    None,  # 1770
-    None,  # 1771
-    None,  # 1772
-    None,  # 1773
-    None,  # 1774
-    None,  # 1775
-    None,  # 1776
-    None,  # 1777
-    None,  # 1778
-    None,  # 1779
-    None,  # 1780
-    None,  # 1781
-    None,  # 1782
-    None,  # 1783
-    None,  # 1784
-    None,  # 1785
-    None,  # 1786
-    None,  # 1787
-    None,  # 1788
-    None,  # 1789
-    None,  # 1790
-    None,  # 1791
-    None,  # 1792
-    None,  # 1793
-    None,  # 1794
-    None,  # 1795
-    None,  # 1796
-    None,  # 1797
-    None,  # 1798
-    None,  # 1799
-    None,  # 1800
-    None,  # 1801
-    None,  # 1802
-    None,  # 1803
-    None,  # 1804
-    None,  # 1805
-    None,  # 1806
-    None,  # 1807
-    None,  # 1808
-    None,  # 1809
-    None,  # 1810
-    None,  # 1811
-    None,  # 1812
-    None,  # 1813
-    None,  # 1814
-    None,  # 1815
-    None,  # 1816
-    None,  # 1817
-    None,  # 1818
-    None,  # 1819
-    None,  # 1820
-    None,  # 1821
-    None,  # 1822
-    None,  # 1823
-    None,  # 1824
-    None,  # 1825
-    None,  # 1826
-    None,  # 1827
-    None,  # 1828
-    None,  # 1829
-    None,  # 1830
-    None,  # 1831
-    None,  # 1832
-    None,  # 1833
-    None,  # 1834
-    None,  # 1835
-    None,  # 1836
-    None,  # 1837
-    None,  # 1838
-    None,  # 1839
-    None,  # 1840
-    None,  # 1841
-    None,  # 1842
-    None,  # 1843
-    None,  # 1844
-    None,  # 1845
-    None,  # 1846
-    None,  # 1847
-    None,  # 1848
-    None,  # 1849
-    None,  # 1850
-    None,  # 1851
-    None,  # 1852
-    None,  # 1853
-    None,  # 1854
-    None,  # 1855
-    None,  # 1856
-    None,  # 1857
-    None,  # 1858
-    None,  # 1859
-    None,  # 1860
-    None,  # 1861
-    None,  # 1862
-    None,  # 1863
-    None,  # 1864
-    None,  # 1865
-    None,  # 1866
-    None,  # 1867
-    None,  # 1868
-    None,  # 1869
-    None,  # 1870
-    None,  # 1871
-    None,  # 1872
-    None,  # 1873
-    None,  # 1874
-    None,  # 1875
-    None,  # 1876
-    None,  # 1877
-    None,  # 1878
-    None,  # 1879
-    None,  # 1880
-    None,  # 1881
-    None,  # 1882
-    None,  # 1883
-    None,  # 1884
-    None,  # 1885
-    None,  # 1886
-    None,  # 1887
-    None,  # 1888
-    None,  # 1889
-    None,  # 1890
-    None,  # 1891
-    None,  # 1892
-    None,  # 1893
-    None,  # 1894
-    None,  # 1895
-    None,  # 1896
-    None,  # 1897
-    None,  # 1898
-    None,  # 1899
-    None,  # 1900
-    None,  # 1901
-    None,  # 1902
-    None,  # 1903
-    None,  # 1904
-    None,  # 1905
-    None,  # 1906
-    None,  # 1907
-    None,  # 1908
-    None,  # 1909
-    None,  # 1910
-    None,  # 1911
-    None,  # 1912
-    None,  # 1913
-    None,  # 1914
-    None,  # 1915
-    None,  # 1916
-    None,  # 1917
-    None,  # 1918
-    None,  # 1919
-    None,  # 1920
-    None,  # 1921
-    None,  # 1922
-    None,  # 1923
-    None,  # 1924
-    None,  # 1925
-    None,  # 1926
-    None,  # 1927
-    None,  # 1928
-    None,  # 1929
-    None,  # 1930
-    None,  # 1931
-    None,  # 1932
-    None,  # 1933
-    None,  # 1934
-    None,  # 1935
-    None,  # 1936
-    None,  # 1937
-    None,  # 1938
-    None,  # 1939
-    None,  # 1940
-    None,  # 1941
-    None,  # 1942
-    None,  # 1943
-    None,  # 1944
-    None,  # 1945
-    None,  # 1946
-    None,  # 1947
-    None,  # 1948
-    None,  # 1949
-    None,  # 1950
-    None,  # 1951
-    None,  # 1952
-    None,  # 1953
-    None,  # 1954
-    None,  # 1955
-    None,  # 1956
-    None,  # 1957
-    None,  # 1958
-    None,  # 1959
-    None,  # 1960
-    None,  # 1961
-    None,  # 1962
-    None,  # 1963
-    None,  # 1964
-    None,  # 1965
-    None,  # 1966
-    None,  # 1967
-    None,  # 1968
-    None,  # 1969
-    None,  # 1970
-    None,  # 1971
-    None,  # 1972
-    None,  # 1973
-    None,  # 1974
-    None,  # 1975
-    None,  # 1976
-    None,  # 1977
-    None,  # 1978
-    None,  # 1979
-    None,  # 1980
-    None,  # 1981
-    None,  # 1982
-    None,  # 1983
-    None,  # 1984
-    None,  # 1985
-    None,  # 1986
-    None,  # 1987
-    None,  # 1988
-    None,  # 1989
-    None,  # 1990
-    None,  # 1991
-    None,  # 1992
-    None,  # 1993
-    None,  # 1994
-    None,  # 1995
-    None,  # 1996
-    None,  # 1997
-    None,  # 1998
-    None,  # 1999
-    None,  # 2000
-    None,  # 2001
-    None,  # 2002
-    None,  # 2003
-    None,  # 2004
-    None,  # 2005
-    None,  # 2006
-    None,  # 2007
-    None,  # 2008
-    None,  # 2009
-    None,  # 2010
-    None,  # 2011
-    None,  # 2012
-    None,  # 2013
-    None,  # 2014
-    None,  # 2015
-    None,  # 2016
-    None,  # 2017
-    None,  # 2018
-    None,  # 2019
-    None,  # 2020
-    None,  # 2021
-    None,  # 2022
-    None,  # 2023
-    None,  # 2024
-    None,  # 2025
-    None,  # 2026
-    None,  # 2027
-    None,  # 2028
-    None,  # 2029
-    None,  # 2030
-    None,  # 2031
-    None,  # 2032
-    None,  # 2033
-    None,  # 2034
-    None,  # 2035
-    None,  # 2036
-    None,  # 2037
-    None,  # 2038
-    None,  # 2039
-    None,  # 2040
-    None,  # 2041
-    None,  # 2042
-    None,  # 2043
-    None,  # 2044
-    None,  # 2045
-    None,  # 2046
-    None,  # 2047
-    None,  # 2048
-    None,  # 2049
-    None,  # 2050
-    None,  # 2051
-    None,  # 2052
-    None,  # 2053
-    None,  # 2054
-    None,  # 2055
-    None,  # 2056
-    None,  # 2057
-    None,  # 2058
-    None,  # 2059
-    None,  # 2060
-    None,  # 2061
-    None,  # 2062
-    None,  # 2063
-    None,  # 2064
-    None,  # 2065
-    None,  # 2066
-    None,  # 2067
-    None,  # 2068
-    None,  # 2069
-    None,  # 2070
-    None,  # 2071
-    None,  # 2072
-    None,  # 2073
-    None,  # 2074
-    None,  # 2075
-    None,  # 2076
-    None,  # 2077
-    None,  # 2078
-    None,  # 2079
-    None,  # 2080
-    None,  # 2081
-    None,  # 2082
-    None,  # 2083
-    None,  # 2084
-    None,  # 2085
-    None,  # 2086
-    None,  # 2087
-    None,  # 2088
-    None,  # 2089
-    None,  # 2090
-    None,  # 2091
-    None,  # 2092
-    None,  # 2093
-    None,  # 2094
-    None,  # 2095
-    None,  # 2096
-    None,  # 2097
-    None,  # 2098
-    None,  # 2099
-    None,  # 2100
-    None,  # 2101
-    None,  # 2102
-    None,  # 2103
-    None,  # 2104
-    None,  # 2105
-    None,  # 2106
-    None,  # 2107
-    None,  # 2108
-    None,  # 2109
-    None,  # 2110
-    None,  # 2111
-    None,  # 2112
-    None,  # 2113
-    None,  # 2114
-    None,  # 2115
-    None,  # 2116
-    None,  # 2117
-    None,  # 2118
-    None,  # 2119
-    None,  # 2120
-    None,  # 2121
-    None,  # 2122
-    None,  # 2123
-    None,  # 2124
-    None,  # 2125
-    None,  # 2126
-    None,  # 2127
-    None,  # 2128
-    None,  # 2129
-    None,  # 2130
-    None,  # 2131
-    None,  # 2132
-    None,  # 2133
-    None,  # 2134
-    None,  # 2135
-    None,  # 2136
-    None,  # 2137
-    None,  # 2138
-    None,  # 2139
-    None,  # 2140
-    None,  # 2141
-    None,  # 2142
-    None,  # 2143
-    None,  # 2144
-    None,  # 2145
-    None,  # 2146
-    None,  # 2147
-    None,  # 2148
-    None,  # 2149
-    None,  # 2150
-    None,  # 2151
-    None,  # 2152
-    None,  # 2153
-    None,  # 2154
-    None,  # 2155
-    None,  # 2156
-    None,  # 2157
-    None,  # 2158
-    None,  # 2159
-    None,  # 2160
-    None,  # 2161
-    None,  # 2162
-    None,  # 2163
-    None,  # 2164
-    None,  # 2165
-    None,  # 2166
-    None,  # 2167
-    None,  # 2168
-    None,  # 2169
-    None,  # 2170
-    None,  # 2171
-    None,  # 2172
-    None,  # 2173
-    None,  # 2174
-    None,  # 2175
-    None,  # 2176
-    None,  # 2177
-    None,  # 2178
-    None,  # 2179
-    None,  # 2180
-    None,  # 2181
-    None,  # 2182
-    None,  # 2183
-    None,  # 2184
-    None,  # 2185
-    None,  # 2186
-    None,  # 2187
-    None,  # 2188
-    None,  # 2189
-    None,  # 2190
-    None,  # 2191
-    None,  # 2192
-    None,  # 2193
-    None,  # 2194
-    None,  # 2195
-    None,  # 2196
-    None,  # 2197
-    None,  # 2198
-    None,  # 2199
-    None,  # 2200
-    None,  # 2201
-    None,  # 2202
-    None,  # 2203
-    None,  # 2204
-    None,  # 2205
-    None,  # 2206
-    None,  # 2207
-    None,  # 2208
-    None,  # 2209
-    None,  # 2210
-    None,  # 2211
-    None,  # 2212
-    None,  # 2213
-    None,  # 2214
-    None,  # 2215
-    None,  # 2216
-    None,  # 2217
-    None,  # 2218
-    None,  # 2219
-    None,  # 2220
-    None,  # 2221
-    None,  # 2222
-    None,  # 2223
-    None,  # 2224
-    None,  # 2225
-    None,  # 2226
-    None,  # 2227
-    None,  # 2228
-    None,  # 2229
-    None,  # 2230
-    None,  # 2231
-    None,  # 2232
-    None,  # 2233
-    None,  # 2234
-    None,  # 2235
-    None,  # 2236
-    None,  # 2237
-    None,  # 2238
-    None,  # 2239
-    None,  # 2240
-    None,  # 2241
-    None,  # 2242
-    None,  # 2243
-    None,  # 2244
-    None,  # 2245
-    None,  # 2246
-    None,  # 2247
-    None,  # 2248
-    None,  # 2249
-    None,  # 2250
-    None,  # 2251
-    None,  # 2252
-    None,  # 2253
-    None,  # 2254
-    None,  # 2255
-    None,  # 2256
-    None,  # 2257
-    None,  # 2258
-    None,  # 2259
-    None,  # 2260
-    None,  # 2261
-    None,  # 2262
-    None,  # 2263
-    None,  # 2264
-    None,  # 2265
-    None,  # 2266
-    None,  # 2267
-    None,  # 2268
-    None,  # 2269
-    None,  # 2270
-    None,  # 2271
-    None,  # 2272
-    None,  # 2273
-    None,  # 2274
-    None,  # 2275
-    None,  # 2276
-    None,  # 2277
-    None,  # 2278
-    None,  # 2279
-    None,  # 2280
-    None,  # 2281
-    None,  # 2282
-    None,  # 2283
-    None,  # 2284
-    None,  # 2285
-    None,  # 2286
-    None,  # 2287
-    None,  # 2288
-    None,  # 2289
-    None,  # 2290
-    None,  # 2291
-    None,  # 2292
-    None,  # 2293
-    None,  # 2294
-    None,  # 2295
-    None,  # 2296
-    None,  # 2297
-    None,  # 2298
-    None,  # 2299
-    None,  # 2300
-    None,  # 2301
-    None,  # 2302
-    None,  # 2303
-    None,  # 2304
-    None,  # 2305
-    None,  # 2306
-    None,  # 2307
-    None,  # 2308
-    None,  # 2309
-    None,  # 2310
-    None,  # 2311
-    None,  # 2312
-    None,  # 2313
-    None,  # 2314
-    None,  # 2315
-    None,  # 2316
-    None,  # 2317
-    None,  # 2318
-    None,  # 2319
-    None,  # 2320
-    None,  # 2321
-    None,  # 2322
-    None,  # 2323
-    None,  # 2324
-    None,  # 2325
-    None,  # 2326
-    None,  # 2327
-    None,  # 2328
-    None,  # 2329
-    None,  # 2330
-    None,  # 2331
-    None,  # 2332
-    None,  # 2333
-    None,  # 2334
-    None,  # 2335
-    None,  # 2336
-    None,  # 2337
-    None,  # 2338
-    None,  # 2339
-    None,  # 2340
-    None,  # 2341
-    None,  # 2342
-    None,  # 2343
-    None,  # 2344
-    None,  # 2345
-    None,  # 2346
-    None,  # 2347
-    None,  # 2348
-    None,  # 2349
-    None,  # 2350
-    None,  # 2351
-    None,  # 2352
-    None,  # 2353
-    None,  # 2354
-    None,  # 2355
-    None,  # 2356
-    None,  # 2357
-    None,  # 2358
-    None,  # 2359
-    None,  # 2360
-    None,  # 2361
-    None,  # 2362
-    None,  # 2363
-    None,  # 2364
-    None,  # 2365
-    None,  # 2366
-    None,  # 2367
-    None,  # 2368
-    None,  # 2369
-    None,  # 2370
-    None,  # 2371
-    None,  # 2372
-    None,  # 2373
-    None,  # 2374
-    None,  # 2375
-    None,  # 2376
-    None,  # 2377
-    None,  # 2378
-    None,  # 2379
-    None,  # 2380
-    None,  # 2381
-    None,  # 2382
-    None,  # 2383
-    None,  # 2384
-    None,  # 2385
-    None,  # 2386
-    None,  # 2387
-    None,  # 2388
-    None,  # 2389
-    None,  # 2390
-    None,  # 2391
-    None,  # 2392
-    None,  # 2393
-    None,  # 2394
-    None,  # 2395
-    None,  # 2396
-    None,  # 2397
-    None,  # 2398
-    None,  # 2399
-    None,  # 2400
-    None,  # 2401
-    None,  # 2402
-    None,  # 2403
-    None,  # 2404
-    None,  # 2405
-    None,  # 2406
-    None,  # 2407
-    None,  # 2408
-    None,  # 2409
-    None,  # 2410
-    None,  # 2411
-    None,  # 2412
-    None,  # 2413
-    None,  # 2414
-    None,  # 2415
-    None,  # 2416
-    None,  # 2417
-    None,  # 2418
-    None,  # 2419
-    None,  # 2420
-    None,  # 2421
-    None,  # 2422
-    None,  # 2423
-    None,  # 2424
-    None,  # 2425
-    None,  # 2426
-    None,  # 2427
-    None,  # 2428
-    None,  # 2429
-    None,  # 2430
-    None,  # 2431
-    None,  # 2432
-    None,  # 2433
-    None,  # 2434
-    None,  # 2435
-    None,  # 2436
-    None,  # 2437
-    None,  # 2438
-    None,  # 2439
-    None,  # 2440
-    None,  # 2441
-    None,  # 2442
-    None,  # 2443
-    None,  # 2444
-    None,  # 2445
-    None,  # 2446
-    None,  # 2447
-    None,  # 2448
-    None,  # 2449
-    None,  # 2450
-    None,  # 2451
-    None,  # 2452
-    None,  # 2453
-    None,  # 2454
-    None,  # 2455
-    None,  # 2456
-    None,  # 2457
-    None,  # 2458
-    None,  # 2459
-    None,  # 2460
-    None,  # 2461
-    None,  # 2462
-    None,  # 2463
-    None,  # 2464
-    None,  # 2465
-    None,  # 2466
-    None,  # 2467
-    None,  # 2468
-    None,  # 2469
-    None,  # 2470
-    None,  # 2471
-    None,  # 2472
-    None,  # 2473
-    None,  # 2474
-    None,  # 2475
-    None,  # 2476
-    None,  # 2477
-    None,  # 2478
-    None,  # 2479
-    None,  # 2480
-    None,  # 2481
-    None,  # 2482
-    None,  # 2483
-    None,  # 2484
-    None,  # 2485
-    None,  # 2486
-    None,  # 2487
-    None,  # 2488
-    None,  # 2489
-    None,  # 2490
-    None,  # 2491
-    None,  # 2492
-    None,  # 2493
-    None,  # 2494
-    None,  # 2495
-    None,  # 2496
-    None,  # 2497
-    None,  # 2498
-    None,  # 2499
-    None,  # 2500
-    None,  # 2501
-    None,  # 2502
-    None,  # 2503
-    None,  # 2504
-    None,  # 2505
-    None,  # 2506
-    None,  # 2507
-    None,  # 2508
-    None,  # 2509
-    None,  # 2510
-    None,  # 2511
-    None,  # 2512
-    None,  # 2513
-    None,  # 2514
-    None,  # 2515
-    None,  # 2516
-    None,  # 2517
-    None,  # 2518
-    None,  # 2519
-    None,  # 2520
-    None,  # 2521
-    None,  # 2522
-    None,  # 2523
-    None,  # 2524
-    None,  # 2525
-    None,  # 2526
-    None,  # 2527
-    None,  # 2528
-    None,  # 2529
-    None,  # 2530
-    None,  # 2531
-    None,  # 2532
-    None,  # 2533
-    None,  # 2534
-    None,  # 2535
-    None,  # 2536
-    None,  # 2537
-    None,  # 2538
-    None,  # 2539
-    None,  # 2540
-    None,  # 2541
-    None,  # 2542
-    None,  # 2543
-    None,  # 2544
-    None,  # 2545
-    None,  # 2546
-    None,  # 2547
-    None,  # 2548
-    None,  # 2549
-    None,  # 2550
-    None,  # 2551
-    None,  # 2552
-    None,  # 2553
-    None,  # 2554
-    None,  # 2555
-    None,  # 2556
-    None,  # 2557
-    None,  # 2558
-    None,  # 2559
-    None,  # 2560
-    None,  # 2561
-    None,  # 2562
-    None,  # 2563
-    None,  # 2564
-    None,  # 2565
-    None,  # 2566
-    None,  # 2567
-    None,  # 2568
-    None,  # 2569
-    None,  # 2570
-    None,  # 2571
-    None,  # 2572
-    None,  # 2573
-    None,  # 2574
-    None,  # 2575
-    None,  # 2576
-    None,  # 2577
-    None,  # 2578
-    None,  # 2579
-    None,  # 2580
-    None,  # 2581
-    None,  # 2582
-    None,  # 2583
-    None,  # 2584
-    None,  # 2585
-    None,  # 2586
-    None,  # 2587
-    None,  # 2588
-    None,  # 2589
-    None,  # 2590
-    None,  # 2591
-    None,  # 2592
-    None,  # 2593
-    None,  # 2594
-    None,  # 2595
-    None,  # 2596
-    None,  # 2597
-    None,  # 2598
-    None,  # 2599
-    None,  # 2600
-    None,  # 2601
-    None,  # 2602
-    None,  # 2603
-    None,  # 2604
-    None,  # 2605
-    None,  # 2606
-    None,  # 2607
-    None,  # 2608
-    None,  # 2609
-    None,  # 2610
-    None,  # 2611
-    None,  # 2612
-    None,  # 2613
-    None,  # 2614
-    None,  # 2615
-    None,  # 2616
-    None,  # 2617
-    None,  # 2618
-    None,  # 2619
-    None,  # 2620
-    None,  # 2621
-    None,  # 2622
-    None,  # 2623
-    None,  # 2624
-    None,  # 2625
-    None,  # 2626
-    None,  # 2627
-    None,  # 2628
-    None,  # 2629
-    None,  # 2630
-    None,  # 2631
-    None,  # 2632
-    None,  # 2633
-    None,  # 2634
-    None,  # 2635
-    None,  # 2636
-    None,  # 2637
-    None,  # 2638
-    None,  # 2639
-    None,  # 2640
-    None,  # 2641
-    None,  # 2642
-    None,  # 2643
-    None,  # 2644
-    None,  # 2645
-    None,  # 2646
-    None,  # 2647
-    None,  # 2648
-    None,  # 2649
-    None,  # 2650
-    None,  # 2651
-    None,  # 2652
-    None,  # 2653
-    None,  # 2654
-    None,  # 2655
-    None,  # 2656
-    None,  # 2657
-    None,  # 2658
-    None,  # 2659
-    None,  # 2660
-    None,  # 2661
-    None,  # 2662
-    None,  # 2663
-    None,  # 2664
-    None,  # 2665
-    None,  # 2666
-    None,  # 2667
-    None,  # 2668
-    None,  # 2669
-    None,  # 2670
-    None,  # 2671
-    None,  # 2672
-    None,  # 2673
-    None,  # 2674
-    None,  # 2675
-    None,  # 2676
-    None,  # 2677
-    None,  # 2678
-    None,  # 2679
-    None,  # 2680
-    None,  # 2681
-    None,  # 2682
-    None,  # 2683
-    None,  # 2684
-    None,  # 2685
-    None,  # 2686
-    None,  # 2687
-    None,  # 2688
-    None,  # 2689
-    None,  # 2690
-    None,  # 2691
-    None,  # 2692
-    None,  # 2693
-    None,  # 2694
-    None,  # 2695
-    None,  # 2696
-    None,  # 2697
-    None,  # 2698
-    None,  # 2699
-    None,  # 2700
-    None,  # 2701
-    None,  # 2702
-    None,  # 2703
-    None,  # 2704
-    None,  # 2705
-    None,  # 2706
-    None,  # 2707
-    None,  # 2708
-    None,  # 2709
-    None,  # 2710
-    None,  # 2711
-    None,  # 2712
-    None,  # 2713
-    None,  # 2714
-    None,  # 2715
-    None,  # 2716
-    None,  # 2717
-    None,  # 2718
-    None,  # 2719
-    None,  # 2720
-    None,  # 2721
-    None,  # 2722
-    None,  # 2723
-    None,  # 2724
-    None,  # 2725
-    None,  # 2726
-    None,  # 2727
-    None,  # 2728
-    None,  # 2729
-    None,  # 2730
-    None,  # 2731
-    None,  # 2732
-    None,  # 2733
-    None,  # 2734
-    None,  # 2735
-    None,  # 2736
-    None,  # 2737
-    None,  # 2738
-    None,  # 2739
-    None,  # 2740
-    None,  # 2741
-    None,  # 2742
-    None,  # 2743
-    None,  # 2744
-    None,  # 2745
-    None,  # 2746
-    None,  # 2747
-    None,  # 2748
-    None,  # 2749
-    None,  # 2750
-    None,  # 2751
-    None,  # 2752
-    None,  # 2753
-    None,  # 2754
-    None,  # 2755
-    None,  # 2756
-    None,  # 2757
-    None,  # 2758
-    None,  # 2759
-    None,  # 2760
-    None,  # 2761
-    None,  # 2762
-    None,  # 2763
-    None,  # 2764
-    None,  # 2765
-    None,  # 2766
-    None,  # 2767
-    None,  # 2768
-    None,  # 2769
-    None,  # 2770
-    None,  # 2771
-    None,  # 2772
-    None,  # 2773
-    None,  # 2774
-    None,  # 2775
-    None,  # 2776
-    None,  # 2777
-    None,  # 2778
-    None,  # 2779
-    None,  # 2780
-    None,  # 2781
-    None,  # 2782
-    None,  # 2783
-    None,  # 2784
-    None,  # 2785
-    None,  # 2786
-    None,  # 2787
-    None,  # 2788
-    None,  # 2789
-    None,  # 2790
-    None,  # 2791
-    None,  # 2792
-    None,  # 2793
-    None,  # 2794
-    None,  # 2795
-    None,  # 2796
-    None,  # 2797
-    None,  # 2798
-    None,  # 2799
-    None,  # 2800
-    None,  # 2801
-    None,  # 2802
-    None,  # 2803
-    None,  # 2804
-    None,  # 2805
-    None,  # 2806
-    None,  # 2807
-    None,  # 2808
-    None,  # 2809
-    None,  # 2810
-    None,  # 2811
-    None,  # 2812
-    None,  # 2813
-    None,  # 2814
-    None,  # 2815
-    None,  # 2816
-    None,  # 2817
-    None,  # 2818
-    None,  # 2819
-    None,  # 2820
-    None,  # 2821
-    None,  # 2822
-    None,  # 2823
-    None,  # 2824
-    None,  # 2825
-    None,  # 2826
-    None,  # 2827
-    None,  # 2828
-    None,  # 2829
-    None,  # 2830
-    None,  # 2831
-    None,  # 2832
-    None,  # 2833
-    None,  # 2834
-    None,  # 2835
-    None,  # 2836
-    None,  # 2837
-    None,  # 2838
-    None,  # 2839
-    None,  # 2840
-    None,  # 2841
-    None,  # 2842
-    None,  # 2843
-    None,  # 2844
-    None,  # 2845
-    None,  # 2846
-    None,  # 2847
-    None,  # 2848
-    None,  # 2849
-    None,  # 2850
-    None,  # 2851
-    None,  # 2852
-    None,  # 2853
-    None,  # 2854
-    None,  # 2855
-    None,  # 2856
-    None,  # 2857
-    None,  # 2858
-    None,  # 2859
-    None,  # 2860
-    None,  # 2861
-    None,  # 2862
-    None,  # 2863
-    None,  # 2864
-    None,  # 2865
-    None,  # 2866
-    None,  # 2867
-    None,  # 2868
-    None,  # 2869
-    None,  # 2870
-    None,  # 2871
-    None,  # 2872
-    None,  # 2873
-    None,  # 2874
-    None,  # 2875
-    None,  # 2876
-    None,  # 2877
-    None,  # 2878
-    None,  # 2879
-    None,  # 2880
-    None,  # 2881
-    None,  # 2882
-    None,  # 2883
-    None,  # 2884
-    None,  # 2885
-    None,  # 2886
-    None,  # 2887
-    None,  # 2888
-    None,  # 2889
-    None,  # 2890
-    None,  # 2891
-    None,  # 2892
-    None,  # 2893
-    None,  # 2894
-    None,  # 2895
-    None,  # 2896
-    None,  # 2897
-    None,  # 2898
-    None,  # 2899
-    None,  # 2900
-    None,  # 2901
-    None,  # 2902
-    None,  # 2903
-    None,  # 2904
-    None,  # 2905
-    None,  # 2906
-    None,  # 2907
-    None,  # 2908
-    None,  # 2909
-    None,  # 2910
-    None,  # 2911
-    None,  # 2912
-    None,  # 2913
-    None,  # 2914
-    None,  # 2915
-    None,  # 2916
-    None,  # 2917
-    None,  # 2918
-    None,  # 2919
-    None,  # 2920
-    None,  # 2921
-    None,  # 2922
-    None,  # 2923
-    None,  # 2924
-    None,  # 2925
-    None,  # 2926
-    None,  # 2927
-    None,  # 2928
-    None,  # 2929
-    None,  # 2930
-    None,  # 2931
-    None,  # 2932
-    None,  # 2933
-    None,  # 2934
-    None,  # 2935
-    None,  # 2936
-    None,  # 2937
-    None,  # 2938
-    None,  # 2939
-    None,  # 2940
-    None,  # 2941
-    None,  # 2942
-    None,  # 2943
-    None,  # 2944
-    None,  # 2945
-    None,  # 2946
-    None,  # 2947
-    None,  # 2948
-    None,  # 2949
-    None,  # 2950
-    None,  # 2951
-    None,  # 2952
-    None,  # 2953
-    None,  # 2954
-    None,  # 2955
-    None,  # 2956
-    None,  # 2957
-    None,  # 2958
-    None,  # 2959
-    None,  # 2960
-    None,  # 2961
-    None,  # 2962
-    None,  # 2963
-    None,  # 2964
-    None,  # 2965
-    None,  # 2966
-    None,  # 2967
-    None,  # 2968
-    None,  # 2969
-    None,  # 2970
-    None,  # 2971
-    None,  # 2972
-    None,  # 2973
-    None,  # 2974
-    None,  # 2975
-    None,  # 2976
-    None,  # 2977
-    None,  # 2978
-    None,  # 2979
-    None,  # 2980
-    None,  # 2981
-    None,  # 2982
-    None,  # 2983
-    None,  # 2984
-    None,  # 2985
-    None,  # 2986
-    None,  # 2987
-    None,  # 2988
-    None,  # 2989
-    None,  # 2990
-    None,  # 2991
-    None,  # 2992
-    None,  # 2993
-    None,  # 2994
-    None,  # 2995
-    None,  # 2996
-    None,  # 2997
-    None,  # 2998
-    None,  # 2999
-    None,  # 3000
-    None,  # 3001
-    None,  # 3002
-    None,  # 3003
-    None,  # 3004
-    None,  # 3005
-    None,  # 3006
-    None,  # 3007
-    None,  # 3008
-    None,  # 3009
-    None,  # 3010
-    None,  # 3011
-    None,  # 3012
-    None,  # 3013
-    None,  # 3014
-    None,  # 3015
-    None,  # 3016
-    None,  # 3017
-    None,  # 3018
-    None,  # 3019
-    None,  # 3020
-    None,  # 3021
-    None,  # 3022
-    None,  # 3023
-    None,  # 3024
-    None,  # 3025
-    None,  # 3026
-    None,  # 3027
-    None,  # 3028
-    None,  # 3029
-    None,  # 3030
-    None,  # 3031
-    None,  # 3032
-    None,  # 3033
-    None,  # 3034
-    None,  # 3035
-    None,  # 3036
-    None,  # 3037
-    None,  # 3038
-    None,  # 3039
-    None,  # 3040
-    None,  # 3041
-    None,  # 3042
-    None,  # 3043
-    None,  # 3044
-    None,  # 3045
-    None,  # 3046
-    None,  # 3047
-    None,  # 3048
-    None,  # 3049
-    None,  # 3050
-    None,  # 3051
-    None,  # 3052
-    None,  # 3053
-    None,  # 3054
-    None,  # 3055
-    None,  # 3056
-    None,  # 3057
-    None,  # 3058
-    None,  # 3059
-    None,  # 3060
-    None,  # 3061
-    None,  # 3062
-    None,  # 3063
-    None,  # 3064
-    None,  # 3065
-    None,  # 3066
-    None,  # 3067
-    None,  # 3068
-    None,  # 3069
-    None,  # 3070
-    None,  # 3071
-    None,  # 3072
-    None,  # 3073
-    None,  # 3074
-    None,  # 3075
-    None,  # 3076
-    None,  # 3077
-    None,  # 3078
-    None,  # 3079
-    None,  # 3080
-    None,  # 3081
-    None,  # 3082
-    None,  # 3083
-    None,  # 3084
-    None,  # 3085
-    None,  # 3086
-    None,  # 3087
-    None,  # 3088
-    None,  # 3089
-    None,  # 3090
-    None,  # 3091
-    None,  # 3092
-    None,  # 3093
-    None,  # 3094
-    None,  # 3095
-    None,  # 3096
-    None,  # 3097
-    None,  # 3098
-    None,  # 3099
-    None,  # 3100
-    None,  # 3101
-    None,  # 3102
-    None,  # 3103
-    None,  # 3104
-    None,  # 3105
-    None,  # 3106
-    None,  # 3107
-    None,  # 3108
-    None,  # 3109
-    None,  # 3110
-    None,  # 3111
-    None,  # 3112
-    None,  # 3113
-    None,  # 3114
-    None,  # 3115
-    None,  # 3116
-    None,  # 3117
-    None,  # 3118
-    None,  # 3119
-    None,  # 3120
-    None,  # 3121
-    None,  # 3122
-    None,  # 3123
-    None,  # 3124
-    None,  # 3125
-    None,  # 3126
-    None,  # 3127
-    None,  # 3128
-    None,  # 3129
-    None,  # 3130
-    None,  # 3131
-    None,  # 3132
-    None,  # 3133
-    None,  # 3134
-    None,  # 3135
-    None,  # 3136
-    None,  # 3137
-    None,  # 3138
-    None,  # 3139
-    None,  # 3140
-    None,  # 3141
-    None,  # 3142
-    None,  # 3143
-    None,  # 3144
-    None,  # 3145
-    None,  # 3146
-    None,  # 3147
-    None,  # 3148
-    None,  # 3149
-    None,  # 3150
-    None,  # 3151
-    None,  # 3152
-    None,  # 3153
-    None,  # 3154
-    None,  # 3155
-    None,  # 3156
-    None,  # 3157
-    None,  # 3158
-    None,  # 3159
-    None,  # 3160
-    None,  # 3161
-    None,  # 3162
-    None,  # 3163
-    None,  # 3164
-    None,  # 3165
-    None,  # 3166
-    None,  # 3167
-    None,  # 3168
-    None,  # 3169
-    None,  # 3170
-    None,  # 3171
-    None,  # 3172
-    None,  # 3173
-    None,  # 3174
-    None,  # 3175
-    None,  # 3176
-    None,  # 3177
-    None,  # 3178
-    None,  # 3179
-    None,  # 3180
-    None,  # 3181
-    None,  # 3182
-    None,  # 3183
-    None,  # 3184
-    None,  # 3185
-    None,  # 3186
-    None,  # 3187
-    None,  # 3188
-    None,  # 3189
-    None,  # 3190
-    None,  # 3191
-    None,  # 3192
-    None,  # 3193
-    None,  # 3194
-    None,  # 3195
-    None,  # 3196
-    None,  # 3197
-    None,  # 3198
-    None,  # 3199
-    None,  # 3200
-    None,  # 3201
-    None,  # 3202
-    None,  # 3203
-    None,  # 3204
-    None,  # 3205
-    None,  # 3206
-    None,  # 3207
-    None,  # 3208
-    None,  # 3209
-    None,  # 3210
-    None,  # 3211
-    None,  # 3212
-    None,  # 3213
-    None,  # 3214
-    None,  # 3215
-    None,  # 3216
-    None,  # 3217
-    None,  # 3218
-    None,  # 3219
-    None,  # 3220
-    None,  # 3221
-    None,  # 3222
-    None,  # 3223
-    None,  # 3224
-    None,  # 3225
-    None,  # 3226
-    None,  # 3227
-    None,  # 3228
-    None,  # 3229
-    None,  # 3230
-    None,  # 3231
-    None,  # 3232
-    None,  # 3233
-    None,  # 3234
-    None,  # 3235
-    None,  # 3236
-    None,  # 3237
-    None,  # 3238
-    None,  # 3239
-    None,  # 3240
-    None,  # 3241
-    None,  # 3242
-    None,  # 3243
-    None,  # 3244
-    None,  # 3245
-    None,  # 3246
-    None,  # 3247
-    None,  # 3248
-    None,  # 3249
-    None,  # 3250
-    None,  # 3251
-    None,  # 3252
-    None,  # 3253
-    None,  # 3254
-    None,  # 3255
-    None,  # 3256
-    None,  # 3257
-    None,  # 3258
-    None,  # 3259
-    None,  # 3260
-    None,  # 3261
-    None,  # 3262
-    None,  # 3263
-    None,  # 3264
-    None,  # 3265
-    None,  # 3266
-    None,  # 3267
-    None,  # 3268
-    None,  # 3269
-    None,  # 3270
-    None,  # 3271
-    None,  # 3272
-    None,  # 3273
-    None,  # 3274
-    None,  # 3275
-    None,  # 3276
-    None,  # 3277
-    None,  # 3278
-    None,  # 3279
-    None,  # 3280
-    None,  # 3281
-    None,  # 3282
-    None,  # 3283
-    None,  # 3284
-    None,  # 3285
-    None,  # 3286
-    None,  # 3287
-    None,  # 3288
-    None,  # 3289
-    None,  # 3290
-    None,  # 3291
-    None,  # 3292
-    None,  # 3293
-    None,  # 3294
-    None,  # 3295
-    None,  # 3296
-    None,  # 3297
-    None,  # 3298
-    None,  # 3299
-    None,  # 3300
-    None,  # 3301
-    None,  # 3302
-    None,  # 3303
-    None,  # 3304
-    None,  # 3305
-    None,  # 3306
-    None,  # 3307
-    None,  # 3308
-    None,  # 3309
-    None,  # 3310
-    None,  # 3311
-    None,  # 3312
-    None,  # 3313
-    None,  # 3314
-    None,  # 3315
-    None,  # 3316
-    None,  # 3317
-    None,  # 3318
-    None,  # 3319
-    None,  # 3320
-    None,  # 3321
-    None,  # 3322
-    None,  # 3323
-    None,  # 3324
-    None,  # 3325
-    None,  # 3326
-    None,  # 3327
-    None,  # 3328
-    (3329, TType.I32, 'closeReason', None,     0, ),  # 3329
 )
 all_structs.append(TCloseOperationResp)
 TCloseOperationResp.thrift_spec = (
@@ -97123,8 +93501,7 @@ TGetResultSetMetadataResp.thrift_spec = (
     None,  # 3342
     None,  # 3343
     (3344, TType.STRUCT, 'resultDataFormat', [TDBSqlResultFormat, None], None, ),  # 3344
-    (3345, TType.BOOL, 'truncatedByThriftLimit', None, None, ),  # 3345
-    (3346, TType.I64, 'resultByteLimit', None, None, ),  # 3346
+    (3345, TType.BOOL, 'truncatedByLimit', None, None, ),  # 3345
 )
 all_structs.append(TFetchResultsReq)
 TFetchResultsReq.thrift_spec = (

--- a/src/databricks/sql/thrift_backend.py
+++ b/src/databricks/sql/thrift_backend.py
@@ -545,7 +545,7 @@ class ThriftBackend:
                 initial_namespace = None
 
             open_session_req = ttypes.TOpenSessionReq(
-                client_protocol_i64=ttypes.TProtocolVersion.SPARK_CLI_SERVICE_PROTOCOL_V8,
+                client_protocol_i64=ttypes.TProtocolVersion.SPARK_CLI_SERVICE_PROTOCOL_V7,
                 client_protocol=None,
                 initialNamespace=initial_namespace,
                 canUseMultipleCatalogs=True,
@@ -1002,10 +1002,6 @@ class ThriftBackend:
     @staticmethod
     def handle_to_id(session_handle):
         return session_handle.sessionId.guid
-
-    @staticmethod
-    def extract_protocol_version_from_handle(session_handle):
-        return session_handle.serverProtocolVersion
 
     @staticmethod
     def handle_to_hex_id(session_handle: TCLIService.TSessionHandle):


### PR DESCRIPTION
Reverts databricks/databricks-sql-python#229 as it causes all of our e2e tests to fail on some versions of DBR.