### PR TITLE
[PECO-1117] Allow legacy codepath for parameterized queries to be used.

### DIFF
--- a/src/databricks/sql/client.py
+++ b/src/databricks/sql/client.py
@@ -18,6 +18,7 @@ from databricks.sql.utils import (
     ExecuteResponse,
     ParamEscaper,
     named_parameters_to_tsparkparams,
+    inject_parameters
 )
 from databricks.sql.types import Row
 from databricks.sql.auth.auth import get_python_sql_connector_auth_provider
@@ -500,6 +501,11 @@ class Cursor:
         :returns self
         """
         if parameters is None:
+            parameters = []
+        elif self.thrift_backend._use_legacy_parameters:
+            operation = inject_parameters(
+                operation, self.escaper.escape_args(parameters)
+            )
             parameters = []
         else:
             parameters = named_parameters_to_tsparkparams(parameters)

--- a/src/databricks/sql/client.py
+++ b/src/databricks/sql/client.py
@@ -502,7 +502,7 @@ class Cursor:
         """
         if parameters is None:
             parameters = []
-        elif self.thrift_backend._use_legacy_parameters:
+        elif self.thrift_backend._use_inline_parameters:
             operation = inject_parameters(
                 operation, self.escaper.escape_args(parameters)
             )

--- a/src/databricks/sql/thrift_backend.py
+++ b/src/databricks/sql/thrift_backend.py
@@ -152,6 +152,9 @@ class ThriftBackend:
         self._use_arrow_native_timestamps = kwargs.get(
             "_use_arrow_native_timestamps", True
         )
+        self._use_legacy_parameters= kwargs.get(
+            "_use_legacy_parameters", False
+        )
 
         # Cloud fetch
         self.max_download_threads = kwargs.get("max_download_threads", 10)

--- a/src/databricks/sql/thrift_backend.py
+++ b/src/databricks/sql/thrift_backend.py
@@ -152,8 +152,8 @@ class ThriftBackend:
         self._use_arrow_native_timestamps = kwargs.get(
             "_use_arrow_native_timestamps", True
         )
-        self._use_legacy_parameters= kwargs.get(
-            "_use_legacy_parameters", False
+        self._use_inline_parameters= kwargs.get(
+            "_use_inline_parameters", False
         )
 
         # Cloud fetch


### PR DESCRIPTION
We need to allow for parameterized queries to be used in a legacy matter.