### PR TITLE
[PECO-1134] v3 Retries: allow users to bound the number of redirects to follow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Other: Introduce SQLAlchemy dialect compliance test suite and enumerate all excluded tests
 - Add integration tests for Databricks UC Volumes ingestion queries
+- Add `_retry_max_redirects` config
 
 ## 2.9.3 (2023-08-24)
 

--- a/examples/v3_retries_query_execute.py
+++ b/examples/v3_retries_query_execute.py
@@ -20,12 +20,20 @@ import os
 # for 502 (Bad Gateway) codes etc. In these cases, there is a possibility that the initial command _did_ reach
 # Databricks compute and retrying it could result in additional executions. Retrying under these conditions uses
 # an exponential back-off since a Retry-After header is not present.
+#
+# This new retry behaviour allows you to configure the maximum number of redirects that the connector will follow.
+# Just set `_retry_max_redirects` to the integer number of redirects you want to allow. The default is None,
+# which means all redirects will be followed. In this case, a redirect will count toward the
+# _retry_stop_after_attempts_count which means that by default the connector will not enter an endless retry loop.
+#
+# For complete information about configuring retries, see the docstring for databricks.sql.thrift_backend.ThriftBackend
 
 with sql.connect(server_hostname = os.getenv("DATABRICKS_SERVER_HOSTNAME"),
                  http_path       = os.getenv("DATABRICKS_HTTP_PATH"),
                  access_token    = os.getenv("DATABRICKS_TOKEN"),
                  _enable_v3_retries = True,
-                 _retry_dangerous_codes=[502,400]) as connection:
+                 _retry_dangerous_codes=[502,400],
+                 _retry_max_redirects=2) as connection:
 
   with connection.cursor() as cursor:
     cursor.execute("SELECT * FROM default.diamonds LIMIT 2")

--- a/src/databricks/sql/thrift_backend.py
+++ b/src/databricks/sql/thrift_backend.py
@@ -628,10 +628,7 @@ class ThriftBackend:
                 num_rows,
             ) = convert_column_based_set_to_arrow_table(t_row_set.columns, description)
         elif t_row_set.arrowBatches is not None:
-            (
-                arrow_table,
-                num_rows,
-            ) = convert_arrow_based_set_to_arrow_table(
+            (arrow_table, num_rows,) = convert_arrow_based_set_to_arrow_table(
                 t_row_set.arrowBatches, lz4_compressed, schema_bytes
             )
         else:

--- a/src/databricks/sql/thrift_backend.py
+++ b/src/databricks/sql/thrift_backend.py
@@ -132,6 +132,8 @@ class ThriftBackend:
         # (defaults to False)
         # _retry_max_redirects
         #  An integer representing the maximum number of redirects to follow for a request.
+        #  This number must be <= _retry_stop_after_attempts_count.
+        #  (defaults to None)
         # max_download_threads
         #  Number of threads for handling cloud fetch downloads. Defaults to 10
 

--- a/src/databricks/sql/thrift_backend.py
+++ b/src/databricks/sql/thrift_backend.py
@@ -189,7 +189,7 @@ class ThriftBackend:
         self.force_dangerous_codes = kwargs.get("_retry_dangerous_codes", [])
 
         additional_transport_args = {}
-        _max_redirects: int = kwargs.get("_retry_max_redirects", {})
+        _max_redirects: int = kwargs.get("_retry_max_redirects")
         if _max_redirects:
             urllib3_kwargs = {"redirect": _max_redirects}
         else:

--- a/src/databricks/sql/thrift_backend.py
+++ b/src/databricks/sql/thrift_backend.py
@@ -130,6 +130,8 @@ class ThriftBackend:
         # _enable_v3_retries
         # Whether to use the DatabricksRetryPolicy implemented in urllib3
         # (defaults to False)
+        # _retry_max_redirects
+        #  An integer representing the maximum number of redirects to follow for a request.
         # max_download_threads
         #  Number of threads for handling cloud fetch downloads. Defaults to 10
 
@@ -185,6 +187,11 @@ class ThriftBackend:
         self.force_dangerous_codes = kwargs.get("_retry_dangerous_codes", [])
 
         additional_transport_args = {}
+        _max_redirects: int = kwargs.get("_retry_max_redirects", {})
+        if _max_redirects:
+            urllib3_kwargs = {"redirect": _max_redirects}
+        else:
+            urllib3_kwargs = {}
         if self.enable_v3_retries:
             self.retry_policy = databricks.sql.auth.thrift_http_client.DatabricksRetryPolicy(
                 delay_min=self._retry_delay_min,
@@ -193,6 +200,7 @@ class ThriftBackend:
                 stop_after_attempts_duration=self._retry_stop_after_attempts_duration,
                 delay_default=self._retry_delay_default,
                 force_dangerous_codes=self.force_dangerous_codes,
+                urllib3_kwargs=urllib3_kwargs,
             )
 
             additional_transport_args["retry_policy"] = self.retry_policy

--- a/src/databricks/sql/thrift_backend.py
+++ b/src/databricks/sql/thrift_backend.py
@@ -190,7 +190,12 @@ class ThriftBackend:
 
         additional_transport_args = {}
         _max_redirects: int = kwargs.get("_retry_max_redirects")
+
         if _max_redirects:
+            if _max_redirects > self._retry_stop_after_attempts_count:
+                logger.warn(
+                    "_retry_max_redirects > _retry_stop_after_attempts_count so it will have no affect!"
+                )
             urllib3_kwargs = {"redirect": _max_redirects}
         else:
             urllib3_kwargs = {}
@@ -623,7 +628,10 @@ class ThriftBackend:
                 num_rows,
             ) = convert_column_based_set_to_arrow_table(t_row_set.columns, description)
         elif t_row_set.arrowBatches is not None:
-            (arrow_table, num_rows,) = convert_arrow_based_set_to_arrow_table(
+            (
+                arrow_table,
+                num_rows,
+            ) = convert_arrow_based_set_to_arrow_table(
                 t_row_set.arrowBatches, lz4_compressed, schema_bytes
             )
         else:

--- a/src/databricks/sql/thrift_backend.py
+++ b/src/databricks/sql/thrift_backend.py
@@ -189,7 +189,7 @@ class ThriftBackend:
         self.force_dangerous_codes = kwargs.get("_retry_dangerous_codes", [])
 
         additional_transport_args = {}
-        _max_redirects: int = kwargs.get("_retry_max_redirects")
+        _max_redirects: Union[None, int] = kwargs.get("_retry_max_redirects")
 
         if _max_redirects:
             if _max_redirects > self._retry_stop_after_attempts_count:

--- a/tests/e2e/common/retry_test_mixins.py
+++ b/tests/e2e/common/retry_test_mixins.py
@@ -220,7 +220,7 @@ class PySQLRetryTestsMixin:
         with self.connection(extra_params={**self._retry_policy}) as conn:
             with conn.cursor() as cursor:
                 for dangerous_code in DANGEROUS_CODES:
-                    with mocked_server_response(status=dangerous_code) as mock_obj:
+                    with mocked_server_response(status=dangerous_code):
                         with self.assertRaises(RequestError) as cm:
                             cursor.execute("Not a real query")
                             assert isinstance(cm.exception.args[1], UnsafeToRetryError)
@@ -231,7 +231,7 @@ class PySQLRetryTestsMixin:
         ) as conn:
             with conn.cursor() as cursor:
                 for dangerous_code in DANGEROUS_CODES:
-                    with mocked_server_response(status=dangerous_code) as mock_obj:
+                    with mocked_server_response(status=dangerous_code):
                         with pytest.raises(MaxRetryError) as cm:
                             cursor.execute("Not a real query")
 

--- a/tests/e2e/common/retry_test_mixins.py
+++ b/tests/e2e/common/retry_test_mixins.py
@@ -58,7 +58,9 @@ class Client503ResponseMixin:
 
 
 @contextmanager
-def mocked_server_response(status: int = 200, headers: dict = {}, redirect_location: str = None):
+def mocked_server_response(
+    status: int = 200, headers: dict = {}, redirect_location: str = None
+):
     """Context manager for patching urllib3 responses"""
 
     # When mocking mocking a BaseHTTPResponse for urllib3 the mock must include
@@ -68,7 +70,9 @@ def mocked_server_response(status: int = 200, headers: dict = {}, redirect_locat
 
     # `msg` is included for testing when urllib3~=1.0.0 is installed
     mock_response = MagicMock(headers=headers, msg=headers, status=status)
-    mock_response.get_redirect_location.return_value = False if redirect_location is None else redirect_location
+    mock_response.get_redirect_location.return_value = (
+        False if redirect_location is None else redirect_location
+    )
 
     with patch("urllib3.connectionpool.HTTPSConnectionPool._get_conn") as getconn_mock:
         getconn_mock.return_value.getresponse.return_value = mock_response
@@ -324,7 +328,7 @@ class PySQLRetryTestsMixin:
                     expected_message_was_found, "Did not find expected log messages"
                 )
 
-    # I really want to use pytest.mark.parametrize here but it doesn't work for tests defined in a 
+    # I really want to use pytest.mark.parametrize here but it doesn't work for tests defined in a
     # unittest.TestCase. Our test suite needs some reorganisation anyway, since right now all of the
     # tests are blended into the PySQLCoreTestSuite. I'll leave this as-is for now.
 
@@ -335,27 +339,32 @@ class PySQLRetryTestsMixin:
         THEN the connector raises a MaxRedirectsError if that number is exceeded
         """
         # Code 302 is a redirect
-        with mocked_server_response(status=302, redirect_location="/foo.bar/") as mock_obj:
+        with mocked_server_response(
+            status=302, redirect_location="/foo.bar/"
+        ) as mock_obj:
             with self.assertRaises(MaxRetryError) as cm:
-                with self.connection(extra_params={**self._retry_policy, "_retry_max_redirects": max_redirects}) as conn:
+                with self.connection(
+                    extra_params={
+                        **self._retry_policy,
+                        "_retry_max_redirects": max_redirects,
+                    }
+                ) as conn:
                     pass
-            
+
             # Total call count should be 3 (original + 2 retries)
             assert mock_obj.return_value.getresponse.call_count == expected_call_count
-    
+
     def test_retry_max_redirects_raises_1_2(self):
-        return self._base_retry_max_redirect_raises(1,2)
-    
+        return self._base_retry_max_redirect_raises(1, 2)
+
     def test_retry_max_redirects_raises_2_3(self):
-        return self._base_retry_max_redirect_raises(2,3)
-    
+        return self._base_retry_max_redirect_raises(2, 3)
+
     def test_retry_max_redirects_raises_3_4(self):
-        return self._base_retry_max_redirect_raises(3,4)
-    
+        return self._base_retry_max_redirect_raises(3, 4)
+
     def test_retry_max_redirects_raises_4_5(self):
-        return self._base_retry_max_redirect_raises(4,5)
+        return self._base_retry_max_redirect_raises(4, 5)
+
     def test_retry_max_redirects_raises_5_6(self):
-        return self._base_retry_max_redirect_raises(5,6)
-
-        
-
+        return self._base_retry_max_redirect_raises(5, 6)


### PR DESCRIPTION
## Background

Some dbt users have found a spike in the number of redirect responses sent from sql gateway. In pysql, following redirect response consumes one attempt against the configured `_stop_after_attempts_count`. If the number of redirects for a given thrift command exceeds this limit, a `MaxRetryError` is raised.

Users can order the connector to follow more redirects by increasing the `_stop_after_attempts_count`.

## Description

This PR introduces the `_retry_max_redirects` configuration for users of the new v3 retry behaviour (which will become the default in the `3.0.0` release). The behaviour of this setting is well-tested in this PR. The critical piece of info is that on its own, `_retry_max_redirects` can only ever *decrease* the number of attempts pysql makes. It would require a significant change to our retry logic to trick the HTTP transport (`urrlib3` at the moment) to not decrement its internal `_attempts_remaining` in the case of redirects.

Outside of debugging, most users will not need to set `_retry_max_redirects`.

For Databricks users reading this PR: if you observe an unusually high number of redirect responses, please report this to Databricks support. This isn't an exact science, but the default `_retry_stop_after_attempts_count` of 30 should be more than enough to receive an actionable response from Databricks runtime. If the number of redirects leads you to increase this count above, say, `100` we should investigate the root cause of those redirects.