### PR TITLE
SQLAlchemy 2: Finish implementing all of ComponentReflectionTest

### DIFF
--- a/src/databricks/sqlalchemy/_ddl.py
+++ b/src/databricks/sqlalchemy/_ddl.py
@@ -23,7 +23,7 @@ class DatabricksDDLCompiler(compiler.DDLCompiler):
         pass
 
     def visit_check_constraint(self, constraint, **kw):
-        logger.warn("Databricks does not support check constraints")
+        logger.warning("This dialect does not support check constraints")
         pass
 
     def visit_identity_column(self, identity, **kw):

--- a/src/databricks/sqlalchemy/_ddl.py
+++ b/src/databricks/sqlalchemy/_ddl.py
@@ -19,7 +19,7 @@ class DatabricksDDLCompiler(compiler.DDLCompiler):
         return " USING DELTA"
 
     def visit_unique_constraint(self, constraint, **kw):
-        logger.warn("Databricks does not support unique constraints")
+        logger.warning("Databricks does not support unique constraints")
         pass
 
     def visit_check_constraint(self, constraint, **kw):

--- a/src/databricks/sqlalchemy/_parse.py
+++ b/src/databricks/sqlalchemy/_parse.py
@@ -1,13 +1,16 @@
 from typing import List, Optional, Dict
 import re
 
+import sqlalchemy
 from sqlalchemy.engine import CursorResult
+from sqlalchemy.engine.interfaces import ReflectedColumn
 
 """
 This module contains helper functions that can parse the contents
 of metadata and exceptions received from DBR. These are mostly just
 wrappers around regexes.
 """
+
 
 def _match_table_not_found_string(message: str) -> bool:
     """Return True if the message contains a substring indicating that a table was not found"""
@@ -22,9 +25,10 @@ def _match_table_not_found_string(message: str) -> bool:
     )
 
 
-def _describe_table_extended_result_to_dict_list(result: CursorResult) -> List[Dict[str, str]]:
-    """Transform the CursorResult of DESCRIBE TABLE EXTENDED into a list of Dictionaries
-    """
+def _describe_table_extended_result_to_dict_list(
+    result: CursorResult,
+) -> List[Dict[str, str]]:
+    """Transform the CursorResult of DESCRIBE TABLE EXTENDED into a list of Dictionaries"""
 
     rows_to_return = []
     for row in result:
@@ -68,21 +72,22 @@ def extract_three_level_identifier_from_constraint_string(input_str: str) -> dic
     """
     pat = re.compile(r"REFERENCES\s+(.*?)\s*\(")
     matches = pat.findall(input_str)
-    
+
     if not matches:
         return None
-    
+
     first_match = matches[0]
     parts = first_match.split(".")
 
-    def strip_backticks(input:str):
+    def strip_backticks(input: str):
         return input.replace("`", "")
-    
+
     return {
-        "catalog": strip_backticks(parts[0]),  
+        "catalog": strip_backticks(parts[0]),
         "schema": strip_backticks(parts[1]),
-        "table": strip_backticks(parts[2])
+        "table": strip_backticks(parts[2]),
     }
+
 
 def _parse_fk_from_constraint_string(constraint_str: str) -> dict:
     """Build a dictionary of foreign key constraint information from a constraint string.
@@ -133,6 +138,7 @@ def _parse_fk_from_constraint_string(constraint_str: str) -> dict:
         "referred_schema": referred_schema,
     }
 
+
 def build_fk_dict(
     fk_name: str, fk_constraint_string: str, schema_name: Optional[str]
 ) -> dict:
@@ -172,6 +178,7 @@ def build_fk_dict(
 
     return complete_foreign_key_dict
 
+
 def _parse_pk_columns_from_constraint_string(constraint_str: str) -> List[str]:
     """Build a list of constrained columns from a constraint string returned by DESCRIBE TABLE EXTENDED
 
@@ -188,21 +195,23 @@ def _parse_pk_columns_from_constraint_string(constraint_str: str) -> List[str]:
 
     return _extracted
 
+
 def build_pk_dict(pk_name: str, pk_constraint_string: str) -> dict:
     """Given a primary key name and a primary key constraint string, return a dictionary
     with the following keys:
-    
+
     constrained_columns
       A list of string column names that make up the primary key
 
     name
       The name of the primary key constraint
     """
-    
+
     constrained_columns = _parse_pk_columns_from_constraint_string(pk_constraint_string)
 
     return {"constrained_columns": constrained_columns, "name": pk_name}
-    
+
+
 def match_dte_rows_by_value(dte_output: List[Dict[str, str]], match: str) -> List[dict]:
     """Return a list of dictionaries containing only the col_name:data_type pairs where the `data_type`
     value contains the match argument.
@@ -221,8 +230,9 @@ def match_dte_rows_by_value(dte_output: List[Dict[str, str]], match: str) -> Lis
     for row_dict in dte_output:
         if match in row_dict["data_type"]:
             output_rows.append(row_dict)
-        
+
     return output_rows
+
 
 def get_fk_strings_from_dte_output(dte_output: List[List]) -> List[dict]:
     """If the DESCRIBE TABLE EXTENDED output contains foreign key constraints, return a list of dictionaries,
@@ -233,8 +243,10 @@ def get_fk_strings_from_dte_output(dte_output: List[List]) -> List[dict]:
 
     return output
 
-    
-def get_pk_strings_from_dte_output(dte_output: List[Dict[str, str]]) -> Optional[List[dict]]:
+
+def get_pk_strings_from_dte_output(
+    dte_output: List[Dict[str, str]]
+) -> Optional[List[dict]]:
     """If the DESCRIBE TABLE EXTENDED output contains primary key constraints, return a list of dictionaries,
     one dictionary per defined constraint.
 
@@ -244,3 +256,59 @@ def get_pk_strings_from_dte_output(dte_output: List[Dict[str, str]]) -> Optional
     output = match_dte_rows_by_value(dte_output, "PRIMARY KEY")
 
     return output
+
+
+# The keys of this dictionary are the values we expect to see in a 
+# TGetColumnsRequest's .TYPE_NAME attribute.
+# These are enumerated in ttypes.py as class TTypeId.
+# TODO: confirm that all types in TTypeId are included here.
+GET_COLUMNS_TYPE_MAP = {
+    "boolean": sqlalchemy.types.Boolean,
+    "smallint": sqlalchemy.types.SmallInteger,
+    "int": sqlalchemy.types.Integer,
+    "bigint": sqlalchemy.types.BigInteger,
+    "float": sqlalchemy.types.Float,
+    "double": sqlalchemy.types.Float,
+    "string": sqlalchemy.types.String,
+    "varchar": sqlalchemy.types.String,
+    "char": sqlalchemy.types.String,
+    "binary": sqlalchemy.types.String,
+    "array": sqlalchemy.types.String,
+    "map": sqlalchemy.types.String,
+    "struct": sqlalchemy.types.String,
+    "uniontype": sqlalchemy.types.String,
+    "decimal": sqlalchemy.types.Numeric,
+    "timestamp": sqlalchemy.types.DateTime,
+    "date": sqlalchemy.types.Date,
+}
+
+
+def parse_column_info_from_tgetcolumnsresponse(thrift_resp_row) -> ReflectedColumn:
+    """Returns a dictionary of the ReflectedColumn schema parsed from
+    a single of the result of a TGetColumnsRequest thrift RPC
+
+    Currently doesn't preserve decimal precision
+    """
+
+    pat = re.compile(r"^\w+")
+    _raw_col_type = re.search(pat, thrift_resp_row.TYPE_NAME).group(0).lower()
+    _col_type = GET_COLUMNS_TYPE_MAP[_raw_col_type]
+
+    # See comments about autoincrement in test_suite.py
+    # Since Databricks SQL doesn't currently support inline AUTOINCREMENT declarations
+    # the autoincrement must be manually declared with an Identity() construct in SQLAlchemy
+    # Other dialects can perform this extra Identity() step automatically. But that is not
+    # implemented in the Databricks dialect right now. So autoincrement is currently always False.
+    # It's not clear what IS_AUTO_INCREMENT in the thrift response actually reflects or whether
+    # it ever returns a `YES`.
+
+    # Per the guidance in SQLAlchemy's docstrings, we prefer to not even include an autoincrement
+    # key in this dictionary.
+    this_column = {
+        "name": thrift_resp_row.COLUMN_NAME,
+        "type": _col_type,
+        "nullable": bool(thrift_resp_row.NULLABLE),
+        "default": thrift_resp_row.COLUMN_DEF,
+    }
+
+    return this_column

--- a/src/databricks/sqlalchemy/base.py
+++ b/src/databricks/sqlalchemy/base.py
@@ -228,6 +228,7 @@ class DatabricksDialect(default.DefaultDialect):
         """SQLAlchemy requires this method. Databricks doesn't support indexes."""
         return self.EMPTY_INDEX
 
+    @reflection.cache
     def get_table_names(self, connection: Connection, schema=None, **kwargs):
         """Return a list of tables in the current schema."""
 
@@ -248,6 +249,7 @@ class DatabricksDialect(default.DefaultDialect):
 
         return tables_minus_views
 
+    @reflection.cache
     def get_view_names(self, connection, schema=None, **kwargs):
         """Returns a list of string view names contained in the schema, if any."""
 

--- a/src/databricks/sqlalchemy/base.py
+++ b/src/databricks/sqlalchemy/base.py
@@ -11,6 +11,7 @@ from databricks.sqlalchemy._parse import (
     build_pk_dict,
     get_fk_strings_from_dte_output,
     get_pk_strings_from_dte_output,
+    parse_column_info_from_tgetcolumnsresponse,
 )
 
 import sqlalchemy
@@ -19,6 +20,7 @@ from sqlalchemy.engine import Connection, Engine, default, reflection
 from sqlalchemy.engine.interfaces import (
     ReflectedForeignKeyConstraint,
     ReflectedPrimaryKeyConstraint,
+    ReflectedColumn,
 )
 from sqlalchemy.exc import DatabaseError, SQLAlchemyError
 
@@ -36,27 +38,6 @@ else:
 import logging
 
 logger = logging.getLogger(__name__)
-
-
-COLUMN_TYPE_MAP = {
-    "boolean": sqlalchemy.types.Boolean,
-    "smallint": sqlalchemy.types.SmallInteger,
-    "int": sqlalchemy.types.Integer,
-    "bigint": sqlalchemy.types.BigInteger,
-    "float": sqlalchemy.types.Float,
-    "double": sqlalchemy.types.Float,
-    "string": sqlalchemy.types.String,
-    "varchar": sqlalchemy.types.String,
-    "char": sqlalchemy.types.String,
-    "binary": sqlalchemy.types.String,
-    "array": sqlalchemy.types.String,
-    "map": sqlalchemy.types.String,
-    "struct": sqlalchemy.types.String,
-    "uniontype": sqlalchemy.types.String,
-    "decimal": sqlalchemy.types.Numeric,
-    "timestamp": sqlalchemy.types.DateTime,
-    "date": sqlalchemy.types.Date,
-}
 
 
 class DatabricksDialect(default.DefaultDialect):
@@ -113,36 +94,10 @@ class DatabricksDialect(default.DefaultDialect):
 
         return [], kwargs
 
-    def get_columns(self, connection, table_name, schema=None, **kwargs):
-        """Return information about columns in `table_name`.
-
-        Given a :class:`_engine.Connection`, a string
-        `table_name`, and an optional string `schema`, return column
-        information as a list of dictionaries with these keys:
-
-        name
-          the column's name
-
-        type
-          [sqlalchemy.types#TypeEngine]
-
-        nullable
-          boolean
-
-        default
-          the column's default value
-
-        autoincrement
-          boolean
-
-        sequence
-          a dictionary of the form
-              {'name' : str, 'start' :int, 'increment': int, 'minvalue': int,
-               'maxvalue': int, 'nominvalue': bool, 'nomaxvalue': bool,
-               'cycle': bool, 'cache': int, 'order': bool}
-
-        Additional column attributes may be present.
-        """
+    def get_columns(
+        self, connection, table_name, schema=None, **kwargs
+    ) -> List[ReflectedColumn]:
+        """Return information about columns in `table_name`."""
 
         with self.get_connection_cursor(connection) as cur:
             resp = cur.columns(
@@ -154,18 +109,9 @@ class DatabricksDialect(default.DefaultDialect):
         if not resp:
             raise sqlalchemy.exc.NoSuchTableError(table_name)
         columns = []
-
         for col in resp:
-            # Taken from PyHive. This removes added type info from decimals and maps
-            _col_type = re.search(r"^\w+", col.TYPE_NAME).group(0)
-            this_column = {
-                "name": col.COLUMN_NAME,
-                "type": COLUMN_TYPE_MAP[_col_type.lower()],
-                "nullable": bool(col.NULLABLE),
-                "default": col.COLUMN_DEF,
-                "autoincrement": False if col.IS_AUTO_INCREMENT == "NO" else True,
-            }
-            columns.append(this_column)
+            row_dict = parse_column_info_from_tgetcolumnsresponse(col)
+            columns.append(row_dict)
 
         return columns
 

--- a/src/databricks/sqlalchemy/requirements.py
+++ b/src/databricks/sqlalchemy/requirements.py
@@ -155,6 +155,11 @@ class Requirements(sqlalchemy.testing.requirements.SuiteRequirements):
         return sqlalchemy.testing.exclusions.closed()
 
     @property
+    def table_reflection(self):
+        """target database has general support for table reflection"""
+        return sqlalchemy.testing.exclusions.open()
+    
+    @property
     def temp_table_reflection(self):
         """ComponentReflection test is intricate and simply cannot function without this exclusion being defined here.
         This happens because we cannot skip individual combinations used in ComponentReflection test.

--- a/src/databricks/sqlalchemy/requirements.py
+++ b/src/databricks/sqlalchemy/requirements.py
@@ -173,7 +173,7 @@ class Requirements(sqlalchemy.testing.requirements.SuiteRequirements):
         """ComponentReflection test is intricate and simply cannot function without this exclusion being defined here.
         This happens because we cannot skip individual combinations used in ComponentReflection test.
 
-        Databricks supports unique constraints but they are not implemented in this dialect.
+        Databricks doesn't support UNIQUE constraints.
         """
         return sqlalchemy.testing.exclusions.closed()
     

--- a/src/databricks/sqlalchemy/test/test_suite.py
+++ b/src/databricks/sqlalchemy/test/test_suite.py
@@ -419,6 +419,22 @@ class ComponentReflectionTest(ComponentReflectionTest):
     # test_get_schema_names
     # test_not_existing_table
 
+    @pytest.mark.skip(reason="Comment reflection is possible but not enabled in this dialect")
+    def test_get_multi_table_comment(self):
+        """There are 84 permutations of this test that are skipped.
+        """
+        pass
+
+    @pytest.mark.skip(reason="Databricks doesn't support UNIQUE constraints")
+    def test_get_multi_unique_constraints(self):
+        pass
+
+    @pytest.mark.skip(reason="This dialect doesn't support get_table_options. See comment in test_suite.py")
+    def test_multi_get_table_options_tables(self):
+        """It's not clear what the expected ouput from this method would even _be_. Requires research.
+        """
+        pass
+
     @pytest.mark.skip("This dialect doesn't implement get_view_definition")
     def test_get_view_definition(self):
         pass

--- a/src/databricks/sqlalchemy/test/test_suite.py
+++ b/src/databricks/sqlalchemy/test/test_suite.py
@@ -330,23 +330,19 @@ class CompositeKeyReflectionTest(CompositeKeyReflectionTest):
     pass
 
 
+@pytest.mark.reviewed
 class ComponentReflectionTestExtra(ComponentReflectionTestExtra):
-    @pytest.mark.skip(reason="Test setup needs adjustment.")
-    def test_varchar_reflection(self):
-        """
-        Exception:
-            databricks.sql.exc.ServerOperationError: [TABLE_OR_VIEW_ALREADY_EXISTS] Cannot create table or view `pysql_sqlalchemy`.`t` because it already exists.
-            Choose a different name, drop or replace the existing object, add the IF NOT EXISTS clause to tolerate pre-existing objects, or add the OR REFRESH clause to refresh the existing streaming table.
-        """
+    @pytest.mark.skip(reason="This dialect does not support check constraints")
+    def test_get_check_constraints(self):
+        pass
 
-    @pytest.mark.skip(reason="Test setup appears broken")
-    def test_numeric_reflection(self):
-        """
-        Exception:
-            databricks.sql.exc.ServerOperationError: [SCHEMA_NOT_FOUND] The schema `main.test_schema` cannot be found. Verify the spelling and correctness of the schema and catalog.
-            If you did not qualify the name with a catalog, verify the current_schema() output, or qualify the name with the correct catalog.
-            To tolerate the error on drop use DROP SCHEMA IF EXISTS.
-        """
+    @pytest.mark.skip(reason="Databricks does not support indexes.")
+    def test_reflect_covering_index(self):
+        pass
+
+    @pytest.mark.skip(reason="Databricks does not support indexes.")
+    def test_reflect_expression_based_indexes(self):
+        pass
 
 
 class DifficultParametersTest(DifficultParametersTest):
@@ -415,24 +411,22 @@ class ComponentReflectionTest(ComponentReflectionTest):
     Note that test_get_multi_foreign keys is flaky because DBR does not guarantee the order of data returned in DESCRIBE TABLE EXTENDED
     """
 
-    # We've reviewed these tests:
-    # test_get_schema_names
-    # test_not_existing_table
-
-    @pytest.mark.skip(reason="Comment reflection is possible but not enabled in this dialect")
+    @pytest.mark.skip(
+        reason="Comment reflection is possible but not enabled in this dialect"
+    )
     def test_get_multi_table_comment(self):
-        """There are 84 permutations of this test that are skipped.
-        """
+        """There are 84 permutations of this test that are skipped."""
         pass
 
     @pytest.mark.skip(reason="Databricks doesn't support UNIQUE constraints")
     def test_get_multi_unique_constraints(self):
         pass
 
-    @pytest.mark.skip(reason="This dialect doesn't support get_table_options. See comment in test_suite.py")
+    @pytest.mark.skip(
+        reason="This dialect doesn't support get_table_options. See comment in test_suite.py"
+    )
     def test_multi_get_table_options_tables(self):
-        """It's not clear what the expected ouput from this method would even _be_. Requires research.
-        """
+        """It's not clear what the expected ouput from this method would even _be_. Requires research."""
         pass
 
     @pytest.mark.skip("This dialect doesn't implement get_view_definition")
@@ -450,7 +444,6 @@ class ComponentReflectionTest(ComponentReflectionTest):
         """
         pass
 
-    
     @pytest.mark.skip("This dialect doesn't implement get_multi_pk_constraint")
     def test_get_multi_pk_constraint(self):
         pass

--- a/src/databricks/sqlalchemy/test/test_suite.py
+++ b/src/databricks/sqlalchemy/test/test_suite.py
@@ -344,16 +344,18 @@ class ComponentReflectionTestExtra(ComponentReflectionTestExtra):
     def test_reflect_expression_based_indexes(self):
         pass
 
-    @pytest.mark.skip(reason="Databricks doesn't enforce String or VARCHAR length limitations.")
+    @pytest.mark.skip(
+        reason="Databricks doesn't enforce String or VARCHAR length limitations."
+    )
     def test_varchar_reflection(self):
-        """Even if a user specifies String(52), Databricks won't enforce that limit.
-        """
+        """Even if a user specifies String(52), Databricks won't enforce that limit."""
         pass
 
-    @pytest.mark.skip(reason="This dialect doesn't implement foreign key options checks.")
+    @pytest.mark.skip(
+        reason="This dialect doesn't implement foreign key options checks."
+    )
     def test_get_foreign_key_options(self):
-        """It's not clear from the test code what the expected output is here. Further research required.
-        """
+        """It's not clear from the test code what the expected output is here. Further research required."""
         pass
 
 
@@ -527,4 +529,22 @@ class QuotedNameArgumentTest(QuotedNameArgumentTest):
     which will never work on Databricks because table names can't contains spaces. But QuotedNamedArgumentTest
     also checks the behaviour of DDL identifier preparation process. We need to override some of IdentifierPreparer
     methods because these are the ultimate control for whether or not CHECK and UNIQUE constraints are emitted.
+    """
+
+
+@pytest.mark.reviewed
+@pytest.mark.skip(reason="Implementation deferred. See test_suite.py")
+class BizarroCharacterFKResolutionTest:
+    """Some of the combinations in this test pass. Others fail. Given the esoteric nature of these failures,
+    we have opted to defer implementing fixes to a later time, guided by customer feedback. Passage of
+    these tests is not an acceptance criteria for our dialect.
+    """
+
+
+@pytest.mark.reviewed
+@pytest.mark.skip(reason="Implementation deferred. See test_suite.py")
+class DifficultParametersTest:
+    """Some of the combinations in this test pass. Others fail. Given the esoteric nature of these failures,
+    we have opted to defer implementing fixes to a later time, guided by customer feedback. Passage of
+    these tests is not an acceptance criteria for our dialect.
     """

--- a/src/databricks/sqlalchemy/test/test_suite.py
+++ b/src/databricks/sqlalchemy/test/test_suite.py
@@ -425,10 +425,6 @@ class ComponentReflectionTest(ComponentReflectionTest):
     def test_get_multi_pk_constraint(self):
         pass
 
-    @pytest.mark.skip("This dialect doesn't implement get_multi_columns")
-    def test_get_multi_columns(self):
-        pass
-
     @pytest.mark.skip("This dialect doesn't implement get_multi_foreign_keys")
     def test_get_multi_foreign_keys(self):
         pass

--- a/src/databricks/sqlalchemy/test/test_suite.py
+++ b/src/databricks/sqlalchemy/test/test_suite.py
@@ -417,6 +417,19 @@ class ComponentReflectionTest(ComponentReflectionTest):
     # test_get_schema_names
     # test_not_existing_table
 
+    @pytest.mark.skip("This dialect doesn't implement get_multi_pk_constraint")
+    def test_get_multi_pk_constraint(self):
+        pass
+
+    @pytest.mark.skip("This dialect doesn't implement get_multi_columns")
+    def test_get_multi_columns(self):
+        pass
+
+    @pytest.mark.skip("This dialect doesn't implement get_multi_foreign_keys")
+    def test_get_multi_foreign_keys(self):
+        pass
+
+
     @pytest.mark.skip(reason="Databricks doesn't support temp tables.")
     def test_get_temp_table_columns(self):
         pass

--- a/src/databricks/sqlalchemy/test/test_suite.py
+++ b/src/databricks/sqlalchemy/test/test_suite.py
@@ -411,24 +411,33 @@ class ComponentReflectionTest(ComponentReflectionTest):
     """This test requires two schemas be present in the target Databricks workspace:
     - The schema set in --dburi
     - A second schema named "test_schema"
+
+    Note that test_get_multi_foreign keys is flaky because DBR does not guarantee the order of data returned in DESCRIBE TABLE EXTENDED
     """
 
     # We've reviewed these tests:
     # test_get_schema_names
     # test_not_existing_table
 
-    @pytest.mark.skip("This dialect doesn't implement test_get_view_definition")
+    @pytest.mark.skip("This dialect doesn't implement get_view_definition")
     def test_get_view_definition(self):
         pass
+
+    @pytest.mark.skip(reason="This dialect doesn't implement get_view_definition")
+    def test_get_view_definition_does_not_exist(self):
+        pass
+
+    @pytest.mark.skip(reason="Strange test design. See test_suite.py")
+    def test_get_temp_view_names(self):
+        """While Databricks supports temporary views, this test creates a temp view aimed at a temp table.
+        Databricks doesn't support temp tables. So the test can never pass.
+        """
+        pass
+
     
     @pytest.mark.skip("This dialect doesn't implement get_multi_pk_constraint")
     def test_get_multi_pk_constraint(self):
         pass
-
-    @pytest.mark.skip("This dialect doesn't implement get_multi_foreign_keys")
-    def test_get_multi_foreign_keys(self):
-        pass
-
 
     @pytest.mark.skip(reason="Databricks doesn't support temp tables.")
     def test_get_temp_table_columns(self):

--- a/src/databricks/sqlalchemy/test/test_suite.py
+++ b/src/databricks/sqlalchemy/test/test_suite.py
@@ -344,6 +344,18 @@ class ComponentReflectionTestExtra(ComponentReflectionTestExtra):
     def test_reflect_expression_based_indexes(self):
         pass
 
+    @pytest.mark.skip(reason="Databricks doesn't enforce String or VARCHAR length limitations.")
+    def test_varchar_reflection(self):
+        """Even if a user specifies String(52), Databricks won't enforce that limit.
+        """
+        pass
+
+    @pytest.mark.skip(reason="This dialect doesn't implement foreign key options checks.")
+    def test_get_foreign_key_options(self):
+        """It's not clear from the test code what the expected output is here. Further research required.
+        """
+        pass
+
 
 class DifficultParametersTest(DifficultParametersTest):
     @pytest.mark.skip(reason="Error during execution. Requires investigation.")

--- a/src/databricks/sqlalchemy/test/test_suite.py
+++ b/src/databricks/sqlalchemy/test/test_suite.py
@@ -417,6 +417,10 @@ class ComponentReflectionTest(ComponentReflectionTest):
     # test_get_schema_names
     # test_not_existing_table
 
+    @pytest.mark.skip("This dialect doesn't implement test_get_view_definition")
+    def test_get_view_definition(self):
+        pass
+    
     @pytest.mark.skip("This dialect doesn't implement get_multi_pk_constraint")
     def test_get_multi_pk_constraint(self):
         pass


### PR DESCRIPTION
This is the final pull request implementing our support for component reflection of SQLAlchemy. As with other PR's towards this feature, the specifics of the implementation are esoteric and what matters most is that the tests pass.

For context, the `ComponentReflection` test is the largest block of tests in SQLAlchemy's dialect compliance test suite. It comprises roughly 50% of the test cases. As of this PR, every test in this suite is either passing or skipped with good reason (feature not supported by Databricks or simply not prioritised for implementation).

After this PR will come one more which clears out the remaining test cases that need to be called out in `test_suite.py`. After that I'll update the documentation for users and the new-and-improved dialect will be ready for release.

**note for reviewers**: This is based on the changes in #250 which will be reviewed separately. Once that PR merges I will merge `main` into this PR. But if you feel like reviewing before that happens, just look at the commits beginning with [66497ca](https://github.com/databricks/databricks-sql-python/pull/251/commits/66497cad4ae794a5d4480f277b21034ab76aa3c2)