### PR TITLE
Add GovCloud domain into AWS domains

### DIFF
--- a/src/databricks/sql/auth/endpoint.py
+++ b/src/databricks/sql/auth/endpoint.py
@@ -23,7 +23,11 @@ class CloudType(Enum):
     AZURE = "azure"
 
 
-DATABRICKS_AWS_DOMAINS = [".cloud.databricks.com", ".dev.databricks.com", ".cloud.databricks.us"]
+DATABRICKS_AWS_DOMAINS = [
+    ".cloud.databricks.com",
+    ".dev.databricks.com",
+    ".cloud.databricks.us",
+]
 DATABRICKS_AZURE_DOMAINS = [
     ".azuredatabricks.net",
     ".databricks.azure.cn",

--- a/src/databricks/sql/auth/endpoint.py
+++ b/src/databricks/sql/auth/endpoint.py
@@ -25,9 +25,10 @@ class CloudType(Enum):
 
 DATABRICKS_AWS_DOMAINS = [
     ".cloud.databricks.com",
-    ".dev.databricks.com",
     ".cloud.databricks.us",
+    ".dev.databricks.com",
 ]
+
 DATABRICKS_AZURE_DOMAINS = [
     ".azuredatabricks.net",
     ".databricks.azure.cn",

--- a/src/databricks/sql/auth/endpoint.py
+++ b/src/databricks/sql/auth/endpoint.py
@@ -23,7 +23,7 @@ class CloudType(Enum):
     AZURE = "azure"
 
 
-DATABRICKS_AWS_DOMAINS = [".cloud.databricks.com", ".dev.databricks.com"]
+DATABRICKS_AWS_DOMAINS = [".cloud.databricks.com", ".dev.databricks.com", ".cloud.databricks.us"]
 DATABRICKS_AZURE_DOMAINS = [
     ".azuredatabricks.net",
     ".databricks.azure.cn",


### PR DESCRIPTION
Add GovCloud domain `cloud.databricks.us` into AWS domain list.