### PR TITLE
Enable cloud fetch by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Other: Introduce SQLAlchemy dialect compliance test suite and enumerate all excluded tests
 - Add integration tests for Databricks UC Volumes ingestion queries
 - Add `_retry_max_redirects` config
+- Enable cloud fetch by default. To disable, set `use_cloud_fetch=False` when building `databricks.sql.client`.
 
 ## 2.9.3 (2023-08-24)
 

--- a/src/databricks/sql/client.py
+++ b/src/databricks/sql/client.py
@@ -199,7 +199,7 @@ class Connection:
         self._session_handle = self.thrift_backend.open_session(
             session_configuration, catalog, schema
         )
-        self.use_cloud_fetch = kwargs.get("use_cloud_fetch", False)
+        self.use_cloud_fetch = kwargs.get("use_cloud_fetch", True)
         self.open = True
         logger.info("Successfully opened session " + str(self.get_session_id_hex()))
         self._cursors = []  # type: List[Cursor]

--- a/src/databricks/sql/thrift_backend.py
+++ b/src/databricks/sql/thrift_backend.py
@@ -826,7 +826,7 @@ class ThriftBackend:
         max_bytes,
         lz4_compression,
         cursor,
-        use_cloud_fetch=False,
+        use_cloud_fetch=True,
         parameters=[],
     ):
         assert session_handle is not None


### PR DESCRIPTION
In advance of the forthcoming 3.0.0 release, we are enabling cloud fetch by default. Users can still disable it as needed.

e2e and unit tests pass with this change.