### PR TITLE
Add README and updated example for SQLAlchemy usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,19 @@
 
 ## 3.0.0 (Unreleased)
 
-- Other: Introduce SQLAlchemy dialect compliance test suite and enumerate all excluded tests
+- Completely rewritten SQLAlchemy dialect
+  - Adds support for SQLAlchemy >= 2.0 and drops support for SQLAlchemy 1.x
+  - Full e2e test coverage of all supported features
+  - Detailed usage notes in `README.sqlalchemy.md`
+  - Adds support for:
+    - New types: `TIME`, `TIMESTAMP`, `TIMESTAMP_NTZ`, `TINYINT`
+    - `Numeric` type scale and precision, like `Numeric(10,2)`
+    - Reading and writing `PrimaryKeyConstraint` and `ForeignKeyConstraint`
+    - Reading and writing composite keys
+    - Reading and writing from views
+    - Writing `Identity` to tables (i.e. autoincrementing primary keys)
+    - `LIMIT` and `OFFSET` for paging through results
+    - Caching metadata calls
 - Add integration tests for Databricks UC Volumes ingestion queries
 - Add `_retry_max_redirects` config
 - Enable cloud fetch by default. To disable, set `use_cloud_fetch=False` when building `databricks.sql.client`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 3.0.0 (Unreleased)
 
+- Remove support for Python 3.7
+- Enable cloud fetch by default. To disable, set `use_cloud_fetch=False` when building `databricks.sql.client`.
 - Completely rewritten SQLAlchemy dialect
   - Adds support for SQLAlchemy >= 2.0 and drops support for SQLAlchemy 1.x
   - Full e2e test coverage of all supported features
@@ -17,8 +19,6 @@
     - Caching metadata calls
 - Add integration tests for Databricks UC Volumes ingestion queries
 - Add `_retry_max_redirects` config
-- Enable cloud fetch by default. To disable, set `use_cloud_fetch=False` when building `databricks.sql.client`.
-- Remove support for Python 3.7
 
 ## 2.9.3 (2023-08-24)
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -38,6 +38,6 @@ To run all of these examples you can clone the entire repository to your disk. O
 - **`set_user_agent.py`** shows how to customize the user agent header used for Thrift commands. In
 this example the string `ExamplePartnerTag` will be added to the the user agent on every request.
 - **`staging_ingestion.py`** shows how the connector handles Databricks' experimental staging ingestion commands `GET`, `PUT`, and `REMOVE`.
-- **`sqlalchemy.py`** shows a basic example of connecting to Databricks with [SQLAlchemy](https://www.sqlalchemy.org/). 
+- **`sqlalchemy.py`** shows a basic example of connecting to Databricks with [SQLAlchemy 2.0](https://www.sqlalchemy.org/). 
 - **`custom_cred_provider.py`** shows how to pass a custom credential provider to bypass connector authentication. Please install databricks-sdk prior to running this example.
 - **`v3_retries_query_execute.py`** shows how to enable v3 retries in connector version 2.9.x including how to enable retries for non-default retry cases.

--- a/examples/sqlalchemy.py
+++ b/examples/sqlalchemy.py
@@ -1,6 +1,6 @@
 """
 databricks-sql-connector includes a SQLAlchemy 2.0 dialect compatible with Databricks SQL. To install
-it's dependencies you can run `pip install databricks-sql-connector[sqlalchemy]`.
+its dependencies you can run `pip install databricks-sql-connector[sqlalchemy]`.
 
 The expected connection string format which you can pass to create_engine() is:
 

--- a/examples/sqlalchemy.py
+++ b/examples/sqlalchemy.py
@@ -1,55 +1,45 @@
 """
-databricks-sql-connector includes a SQLAlchemy dialect compatible with Databricks SQL.
-It aims to be a drop-in replacement for the crflynn/sqlalchemy-databricks project, that implements
-more of the Databricks API, particularly around table reflection, Alembic usage, and data
-ingestion with pandas.
+databricks-sql-connector includes a SQLAlchemy 2.0 dialect compatible with Databricks SQL. To install
+it's dependencies you can run `pip install databricks-sql-connector[sqlalchemy]`.
 
-Expected URI format is: databricks+thrift://token:dapi***@***.cloud.databricks.com?http_path=/sql/***
+The expected connection string format which you can pass to create_engine() is:
 
-Because of the extent of SQLAlchemy's capabilities it isn't feasible to provide examples of every
-usage in a single script, so we only provide a basic one here. More examples are found in our test
-suite at tests/e2e/sqlalchemy/test_basic.py and in the PR that implements this change: 
+databricks://token:dapi***@***.cloud.databricks.com?http_path=/sql/***&catalog=**&schema=**
 
-https://github.com/databricks/databricks-sql-python/pull/57
-
-# What's already supported
-
-Most of the functionality is demonstrated in the e2e tests mentioned above. The below list we
-derived from those test method names:
-
-    - Create and drop tables with SQLAlchemy Core
-    - Create and drop tables with SQLAlchemy ORM
-    - Read created tables via reflection
-    - Modify column nullability
-    - Insert records manually
-    - Insert records with pandas.to_sql (note that this does not work for DataFrames with indexes)
-
-This connector also aims to support Alembic for programmatic delta table schema maintenance. This
-behaviour is not yet backed by integration tests, which will follow in a subsequent PR as we learn
-more about customer use cases there. That said, the following behaviours have been tested manually:
-
-    - Autogenerate revisions with alembic revision --autogenerate
-    - Upgrade and downgrade between revisions with `alembic upgrade <revision hash>` and
-      `alembic downgrade <revision hash>`
-
-# Known Gaps
-    - MAP, ARRAY, and STRUCT types: this dialect can read these types out as strings. But you cannot
-      define a SQLAlchemy model with databricks.sqlalchemy.types.DatabricksMap (e.g.) because
-      we haven't implemented them yet.
-    - Constraints: with the addition of information_schema to Unity Catalog, Databricks SQL supports
-      foreign key and primary key constraints. This dialect can write these constraints but the ability
-      for alembic to reflect and modify them programmatically has not been tested.
+Our dialect implements the majority of SQLAlchemy 2.0's API. Because of the extent of SQLAlchemy's
+capabilities it isn't feasible to provide examples of every usage in a single script, so we only
+provide a basic one here. Learn more about usage in README.sqlalchemy.md in this repo. 
 """
 
-import os
-import sqlalchemy
-from sqlalchemy.orm import Session
-from sqlalchemy import Column, String, Integer, BOOLEAN, create_engine, select
+# fmt: off
 
-try:
-    from sqlalchemy.orm import declarative_base
-except ImportError:
-    from sqlalchemy.ext.declarative import declarative_base
+import os
+from datetime import date, datetime, time, timedelta, timezone
+from decimal import Decimal
+from uuid import UUID
+
+# By convention, backend-specific SQLA types are defined in uppercase
+# This dialect exposes Databricks SQL's TIMESTAMP and TINYINT types
+# as these are not covered by the generic, camelcase types shown below
+from databricks.sqlalchemy import TIMESTAMP, TINYINT
+
+# Beside the CamelCase types shown below, line comments reflect
+# the underlying Databricks SQL / Delta table type
+from sqlalchemy import (
+    BigInteger,      # BIGINT
+    Boolean,         # BOOLEAN
+    Column,
+    Date,            # DATE
+    DateTime,        # TIMESTAMP_NTZ
+    Integer,         # INTEGER
+    Numeric,         # DECIMAL
+    String,          # STRING
+    Time,            # STRING
+    Uuid,            # STRING
+    create_engine,
+    select,
+)
+from sqlalchemy.orm import DeclarativeBase, Session
 
 host = os.getenv("DATABRICKS_SERVER_HOSTNAME")
 http_path = os.getenv("DATABRICKS_HTTP_PATH")
@@ -58,58 +48,127 @@ catalog = os.getenv("DATABRICKS_CATALOG")
 schema = os.getenv("DATABRICKS_SCHEMA")
 
 
-# Extra arguments are passed untouched to the driver
-# See thrift_backend.py for complete list
+# Extra arguments are passed untouched to databricks-sql-connector
+# See src/databricks/sql/thrift_backend.py for complete list
 extra_connect_args = {
     "_tls_verify_hostname": True,
     "_user_agent_entry": "PySQL Example Script",
 }
 
-if sqlalchemy.__version__.startswith("1.3"):
-    # SQLAlchemy 1.3.x fails to parse the http_path, catalog, and schema from our connection string
-    # Pass these in as connect_args instead
 
-    conn_string = f"databricks://token:{access_token}@{host}"
-    connect_args = dict(catalog=catalog, schema=schema, http_path=http_path)
-    all_connect_args = {**extra_connect_args, **connect_args}
-    engine = create_engine(conn_string, connect_args=all_connect_args)
-else:
-    engine = create_engine(
-        f"databricks://token:{access_token}@{host}?http_path={http_path}&catalog={catalog}&schema={schema}",
-        connect_args=extra_connect_args,
-    )
-
-session = Session(bind=engine)
-base = declarative_base(bind=engine)
+engine = create_engine(
+    f"databricks://token:{access_token}@{host}?http_path={http_path}&catalog={catalog}&schema={schema}",
+    connect_args=extra_connect_args, echo=True,
+)
 
 
-class SampleObject(base):
-
-    __tablename__ = "mySampleTable"
-
-    name = Column(String(255), primary_key=True)
-    episodes = Column(Integer)
-    some_bool = Column(BOOLEAN)
+class Base(DeclarativeBase):
+    pass
 
 
-base.metadata.create_all()
+# This object gives a usage example for each supported type
+# for more details on these, see README.sqlalchemy.md
+class SampleObject(Base):
+    __tablename__ = "pysql_sqlalchemy_example_table"
 
-sample_object_1 = SampleObject(name="Bim Adewunmi", episodes=6, some_bool=True)
-sample_object_2 = SampleObject(name="Miki Meek", episodes=12, some_bool=False)
+    bigint_col = Column(BigInteger, primary_key=True)
+    string_col = Column(String)
+    tinyint_col = Column(TINYINT)
+    int_col = Column(Integer)
+    numeric_col = Column(Numeric(10, 2))
+    boolean_col = Column(Boolean)
+    date_col = Column(Date)
+    datetime_col = Column(TIMESTAMP)
+    datetime_col_ntz = Column(DateTime)
+    time_col = Column(Time)
+    uuid_col = Column(Uuid)
 
-session.add(sample_object_1)
-session.add(sample_object_2)
+# This generates a CREATE TABLE statement against the catalog and schema
+# specified in the connection string
+Base.metadata.create_all(engine)
 
+# Output SQL is:
+# CREATE TABLE pysql_sqlalchemy_example_table (
+#         bigint_col BIGINT NOT NULL, 
+#         string_col STRING, 
+#         tinyint_col SMALLINT, 
+#         int_col INT, 
+#         numeric_col DECIMAL(10, 2), 
+#         boolean_col BOOLEAN, 
+#         date_col DATE, 
+#         datetime_col TIMESTAMP, 
+#         datetime_col_ntz TIMESTAMP_NTZ, 
+#         time_col STRING, 
+#         uuid_col STRING, 
+#         PRIMARY KEY (bigint_col)
+# ) USING DELTA
+
+# The code that follows will INSERT a record using SQLAlchemy ORM containing these values
+# and then SELECT it back out. The output is compared to the input to demonstrate that
+# all type information is preserved.
+sample_object = {
+    "bigint_col": 1234567890123456789,
+    "string_col": "foo",
+    "tinyint_col": -100,
+    "int_col": 5280,
+    "numeric_col": Decimal("525600.01"),
+    "boolean_col": True,
+    "date_col": date(2020, 12, 25),
+    "datetime_col": datetime(
+        1991, 8, 3, 21, 30, 5, tzinfo=timezone(timedelta(hours=-8))
+    ),
+    "datetime_col_ntz": datetime(1990, 12, 4, 6, 33, 41),
+    "time_col": time(23, 59, 59),
+    "uuid_col": UUID(int=255),
+}
+sa_obj = SampleObject(**sample_object)
+
+session = Session(engine)
+session.add(sa_obj)
 session.commit()
 
-# SQLAlchemy 1.3 has slightly different methods
-if sqlalchemy.__version__.startswith("1.3"):
-    stmt = select([SampleObject]).where(SampleObject.name.in_(["Bim Adewunmi", "Miki Meek"]))
-    output = [i for i in session.execute(stmt)]
-else:
-    stmt = select(SampleObject).where(SampleObject.name.in_(["Bim Adewunmi", "Miki Meek"]))
-    output = [i for i in session.scalars(stmt)]
+# Output SQL is:
+# INSERT INTO
+#   pysql_sqlalchemy_example_table (
+#     bigint_col,
+#     string_col,
+#     tinyint_col,
+#     int_col,
+#     numeric_col,
+#     boolean_col,
+#     date_col,
+#     datetime_col,
+#     datetime_col_ntz,
+#     time_col,
+#     uuid_col
+#   )
+# VALUES
+#   (
+#     :bigint_col,
+#     :string_col,
+#     :tinyint_col,
+#     :int_col,
+#     :numeric_col,
+#     :boolean_col,
+#     :date_col,
+#     :datetime_col,
+#     :datetime_col_ntz,
+#     :time_col,
+#     :uuid_col
+#   )
 
-assert len(output) == 2
+# Here we build a SELECT query using ORM
+stmt = select(SampleObject).where(SampleObject.int_col == 5280)
 
-base.metadata.drop_all()
+# Then fetch one result with session.scalar()
+result = session.scalar(stmt)
+
+# Finally, we read out the input data and compare it to the output
+compare = {key: getattr(result, key) for key in sample_object.keys()}
+assert compare == sample_object
+
+# Then we drop the demonstration table
+Base.metadata.drop_all(engine)
+
+# Output SQL is:
+# DROP TABLE pysql_sqlalchemy_example_table

--- a/src/databricks/sqlalchemy/README.sqlalchemy.md
+++ b/src/databricks/sqlalchemy/README.sqlalchemy.md
@@ -1,0 +1,204 @@
+## Databricks dialect for SQLALchemy 2.0
+
+The Databricks dialect for SQLAlchemy serves as bridge between [SQLAlchemy](https://www.sqlalchemy.org/) and the Databricks SQL Python driver. The dialect is included with `databricks-sql-connector==3.0.0` and above. A working example demonstrating usage can be found in `examples/sqlalchemy.py`.
+
+## Usage with SQLAlchemy <= 2.0
+A SQLAlchemy 1.4 compatible dialect was first released in connector [version 2.4](https://github.com/databricks/databricks-sql-python/releases/tag/v2.4.0). Support for SQLAlchemy 1.4 was dropped from the dialect as part of `databricks-sql-connector==3.0.0`. To continue using the dialect with SQLAlchemy 1.x, you can use `databricks-sql-connector^2.4.0`.
+
+
+## Installation
+
+To install the dialect and its dependencies:
+
+```shell
+pip install databricks-sql-connector[sqlalchemy]
+```
+
+If you also plan to use `alembic` you can alternatively run:
+
+```shell
+pip install databricks-sql-connector[alembic]
+```
+
+## Connection String
+
+Every SQLAlchemy application that connects to a database needs to use an [Engine](https://docs.sqlalchemy.org/en/20/tutorial/engine.html#tutorial-engine), which you can create by passing a connection string to `create_engine`. The connection string must include these components:
+
+1. Host
+2. HTTP Path for a compute resource
+3. API access token
+4. Initial catalog for the connection
+5. Initial schema for the connection
+
+**Note: Our dialect is built and tested on workspaces with Unity Catalog enabled. Support for the `hive_metastore` catalog is untested.**
+
+For example:
+
+```python
+import os
+from sqlalchemy import create_engine
+
+host = os.getenv("DATABRICKS_SERVER_HOSTNAME")
+http_path = os.getenv("DATABRICKS_HTTP_PATH")
+access_token = os.getenv("DATABRICKS_TOKEN")
+catalog = os.getenv("DATABRICKS_CATALOG")
+schema = os.getenv("DATABRICKS_SCHEMA")
+
+engine = create_engine(
+    f"databricks://token:{access_token}@{host}?http_path={http_path}&catalog={catalog}&schema={schema}"
+    )
+```
+
+## Types
+
+The [SQLAlchemy type hierarchy](https://docs.sqlalchemy.org/en/20/core/type_basics.html) contains backend-agnostic type implementations (represented in CamelCase) and backend-specific types (represented in UPPERCASE). The majority of SQLAlchemy's [CamelCase](https://docs.sqlalchemy.org/en/20/core/type_basics.html#the-camelcase-datatypes) types are supported. This means that a SQLAlchemy application using these types should "just work" with Databricks.
+
+|SQLAlchemy Type|Databricks SQL Type|
+|-|-|
+[`BigInteger`](https://docs.sqlalchemy.org/en/20/core/type_basics.html#sqlalchemy.types.BigInteger)| [`BIGINT`](https://docs.databricks.com/en/sql/language-manual/data-types/bigint-type.html)
+[`LargeBinary`](https://docs.sqlalchemy.org/en/20/core/type_basics.html#sqlalchemy.types.LargeBinary)| (not supported)|
+[`Boolean`](https://docs.sqlalchemy.org/en/20/core/type_basics.html#sqlalchemy.types.Boolean)| [`BOOLEAN`](https://docs.databricks.com/en/sql/language-manual/data-types/boolean-type.html)
+[`Date`](https://docs.sqlalchemy.org/en/20/core/type_basics.html#sqlalchemy.types.Date)| [`DATE`](https://docs.databricks.com/en/sql/language-manual/data-types/date-type.html)
+[`DateTime`](https://docs.sqlalchemy.org/en/20/core/type_basics.html#sqlalchemy.types.DateTime)| [`TIMESTAMP_NTZ`](https://docs.databricks.com/en/sql/language-manual/data-types/timestamp-ntz-type.html)|
+[`Double`](https://docs.sqlalchemy.org/en/20/core/type_basics.html#sqlalchemy.types.Double)| [`DOUBLE`](https://docs.databricks.com/en/sql/language-manual/data-types/double-type.html)
+[`Enum`](https://docs.sqlalchemy.org/en/20/core/type_basics.html#sqlalchemy.types.Enum)| (not supported)|
+[`Float`](https://docs.sqlalchemy.org/en/20/core/type_basics.html#sqlalchemy.types.Float)| [`FLOAT`](https://docs.databricks.com/en/sql/language-manual/data-types/float-type.html)
+[`Integer`](https://docs.sqlalchemy.org/en/20/core/type_basics.html#sqlalchemy.types.Integer)| [`INT`](https://docs.databricks.com/en/sql/language-manual/data-types/int-type.html)
+[`Numeric`](https://docs.sqlalchemy.org/en/20/core/type_basics.html#sqlalchemy.types.Numeric)| [`DECIMAL`](https://docs.databricks.com/en/sql/language-manual/data-types/decimal-type.html)|
+[`PickleType`](https://docs.sqlalchemy.org/en/20/core/type_basics.html#sqlalchemy.types.PickleType)| (not supported)|
+[`SmallInteger`](https://docs.sqlalchemy.org/en/20/core/type_basics.html#sqlalchemy.types.SmallInteger)| [`SMALLINT`](https://docs.databricks.com/en/sql/language-manual/data-types/smallint-type.html)
+[`String`](https://docs.sqlalchemy.org/en/20/core/type_basics.html#sqlalchemy.types.String)| [`STRING`](https://docs.databricks.com/en/sql/language-manual/data-types/string-type.html)|
+[`Text`](https://docs.sqlalchemy.org/en/20/core/type_basics.html#sqlalchemy.types.Text)| [`STRING`](https://docs.databricks.com/en/sql/language-manual/data-types/string-type.html)|
+[`Time`](https://docs.sqlalchemy.org/en/20/core/type_basics.html#sqlalchemy.types.Time)| [`STRING`](https://docs.databricks.com/en/sql/language-manual/data-types/string-type.html)|
+[`Unicode`](https://docs.sqlalchemy.org/en/20/core/type_basics.html#sqlalchemy.types.Unicode)| [`STRING`](https://docs.databricks.com/en/sql/language-manual/data-types/string-type.html)|
+[`UnicodeText`](https://docs.sqlalchemy.org/en/20/core/type_basics.html#sqlalchemy.types.UnicodeText)| [`STRING`](https://docs.databricks.com/en/sql/language-manual/data-types/string-type.html)|
+[`Uuid`](https://docs.sqlalchemy.org/en/20/core/type_basics.html#sqlalchemy.types.Uuid)| [`STRING`](https://docs.databricks.com/en/sql/language-manual/data-types/string-type.html)
+
+In addition, the dialect exposes three UPPERCASE SQLAlchemy types which are specific to Databricks:
+
+- [`databricks.sqlalchemy.TINYINT`](https://docs.databricks.com/en/sql/language-manual/data-types/tinyint-type.html)
+- [`databricks.sqlalchemy.TIMESTAMP`](https://docs.databricks.com/en/sql/language-manual/data-types/timestamp-type.html)
+- [`databricks.sqlalchemy.TIMESTAMP_NTZ`](https://docs.databricks.com/en/sql/language-manual/data-types/timestamp-ntz-type.html)
+
+
+### `LargeBinary()` and `PickleType()`
+
+Databricks Runtime doesn't currently support binding of binary values in SQL queries, which is a pre-requisite for this functionality in SQLAlchemy.
+
+## `Enum()` and `CHECK` constraints
+
+Support for `CHECK` constraints is not implemented in this dialect. Support is planned for a future release.
+
+SQLAlchemy's `Enum()` type depends on `CHECK` constraints and is therefore not yet supported.
+
+### `DateTime()`, `TIMESTAMP_NTZ()`, and `TIMESTAMP()`
+
+Databricks Runtime provides two datetime-like types: `TIMESTAMP` which is always timezone-aware and `TIMESTAMP_NTZ` which is timezone agnostic. Both types can be imported from `databricks.sqlalchemy` and used in your models.
+
+The SQLAlchemy documentation indicates that `DateTime()` is not timezone-aware by default. So our dialect maps this type to `TIMESTAMP_NTZ()`. In practice, you should never need to use `TIMESTAMP_NTZ()` directly. Just use `DateTime()`.
+
+If you need your field to be timezone-aware, you can import `TIMESTAMP()` and use it instead.
+
+_Note that SQLAlchemy documentation suggests that you can declare a `DateTime()` with `timezone=True` on supported backends. However, if you do this with the Databricks dialect, the `timezone` argument will be ignored._
+
+```python
+from sqlalchemy import DateTime
+from databricks.sqlalchemy import TIMESTAMP
+
+class SomeModel(Base):
+    some_date_without_timezone  = DateTime()
+    some_date_with_timezone     = TIMESTAMP()
+```
+
+### `String()`, `Text()`, `Unicode()`, and `UnicodeText()`
+
+Databricks Runtime doesn't support length limitations for `STRING` fields. Therefore `String()` or `String(1)` or `String(255)` will all produce identical DDL. Since `Text()`, `Unicode()`, `UnicodeText()` all use the same underlying type in Databricks SQL, they will generate equivalent DDL.
+
+### `Time()`
+
+Databricks Runtime doesn't have a native time-like data type. To implement this type in SQLAlchemy, our dialect stores SQLAlchemy `Time()` values in a `STRING` field. Unlike `DateTime` above, this type can optionally support timezone awareness (since the dialect is in complete control of the strings that we write to the Delta table).
+
+```python
+from sqlalchemy import Time
+
+class SomeModel(Base):
+    time_tz     = Time(timezone=True)
+    time_ntz    = Time()
+```
+
+
+# Usage Notes
+
+## `Identity()` and `autoincrement`
+
+Identity and generated value support is currently limited in this dialect.
+
+When defining models, SQLAlchemy types can accept an [`autoincrement`](https://docs.sqlalchemy.org/en/20/core/metadata.html#sqlalchemy.schema.Column.params.autoincrement) argument. In our dialect, this argument is currently ignored. To create an auto-incrementing field in your model you can pass in an explicit [`Identity()`](https://docs.sqlalchemy.org/en/20/core/defaults.html#identity-ddl) instead.
+
+Furthermore, in Databricks Runtime, only `BIGINT` fields can be configured to auto-increment. So in SQLAlchemy, you must use the `BigInteger()` type.
+
+```python
+from sqlalchemy import Identity, String
+
+class SomeModel(Base):
+    id      = BigInteger(Identity())
+    value   = String()
+```
+
+When calling `Base.metadata.create_all()`, the executed DDL will include `GENERATED ALWAYS AS IDENTITY` for the `id` column. This is useful when using SQLAlchemy to generate tables. However, as of this writing, `Identity()` constructs are not captured when SQLAlchemy reflects a table's metadata (support for this is planned).
+
+## Parameters
+
+`databricks-sql-connector` supports two approaches to parameterizing SQL queries: native and inline. Our SQLAlchemy 2.0 dialect always uses the native approach and is therefore limited to DBR 14.1 and above. If you are writing parameterized queries to be executed by SQLAlchemy, you must use the "named" paramstyle (`:param`). Read more about parameterization in `README.parameters.md`.
+
+## Usage with pandas
+
+Use [`pandas.DataFrame.to_sql`](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.to_sql.html) and [`pandas.read_sql`](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_sql.html#pandas.read_sql) to write and read from Databricks SQL. These methods both accept a SQLAlchemy connection to interact with Databricks.
+
+### Read from Databricks SQL into pandas
+```python
+from sqlalchemy import create_engine
+import pandas as pd
+
+engine = create_engine("databricks://token:dapi***@***.cloud.databricks.com?http_path=***&catalog=main&schema=test")
+with engine.connect() as conn:
+    # This will read the contents of `main.test.some_table`
+    df = pd.read_sql("some_table", conn)
+```
+
+### Write to Databricks SQL from pandas
+
+```python
+from sqlalchemy import create_engine
+import pandas as pd
+
+engine = create_engine("databricks://token:dapi***@***.cloud.databricks.com?http_path=***&catalog=main&schema=test")
+squares = [(i, i * i) for i in range(100)]
+df = pd.DataFrame(data=squares,columns=['x','x_squared'])
+
+with engine.connect() as conn:
+    # This will write the contents of `df` to `main.test.squares`
+    df.to_sql('squares',conn)
+```
+
+## [`PrimaryKey()`](https://docs.sqlalchemy.org/en/20/core/constraints.html#sqlalchemy.schema.PrimaryKeyConstraint) and [`ForeignKey()`](https://docs.sqlalchemy.org/en/20/core/constraints.html#defining-foreign-keys) 
+
+Unity Catalog workspaces in Databricks support PRIMARY KEY and FOREIGN KEY constraints. _Note that Databricks Runtime does not enforce the integrity of FOREIGN KEY constraints_. You can establish a primary key by setting `primary_key=True` when defining a column.
+
+When building `ForeignKey` or `ForeignKeyConstraint` objects, you must specify a `name` for the constraint.
+
+If your model definition requires a self-referential FOREIGN KEY constraint, you must include `use_alter=True` when defining the relationship.
+
+```python
+from sqlalchemy import Table, Column, ForeignKey, BigInteger, String
+
+users = Table(
+    "users",
+    metadata_obj,
+    Column("id", BigInteger, primary_key=True),
+    Column("name", String(), ForeignKey("user.user_id"), nullable=False),
+    Column("email", String()),
+    Column("manager_id", ForeignKey("users.id", name="fk_users_manager_id_x_users_id", use_alter=True))
+)
+```
+

--- a/src/databricks/sqlalchemy/README.sqlalchemy.md
+++ b/src/databricks/sqlalchemy/README.sqlalchemy.md
@@ -196,7 +196,7 @@ users = Table(
     "users",
     metadata_obj,
     Column("id", BigInteger, primary_key=True),
-    Column("name", String(), ForeignKey("user.user_id"), nullable=False),
+    Column("name", String(), nullable=False),
     Column("email", String()),
     Column("manager_id", ForeignKey("users.id", name="fk_users_manager_id_x_users_id", use_alter=True))
 )

--- a/src/databricks/sqlalchemy/README.sqlalchemy.md
+++ b/src/databricks/sqlalchemy/README.sqlalchemy.md
@@ -149,7 +149,7 @@ When calling `Base.metadata.create_all()`, the executed DDL will include `GENERA
 
 ## Parameters
 
-`databricks-sql-connector` supports two approaches to parameterizing SQL queries: native and inline. Our SQLAlchemy 2.0 dialect always uses the native approach and is therefore limited to DBR 14.1 and above. If you are writing parameterized queries to be executed by SQLAlchemy, you must use the "named" paramstyle (`:param`). Read more about parameterization in `README.parameters.md`.
+`databricks-sql-connector` supports two approaches to parameterizing SQL queries: native and inline. Our SQLAlchemy 2.0 dialect always uses the native approach and is therefore limited to DBR 14.2 and above. If you are writing parameterized queries to be executed by SQLAlchemy, you must use the "named" paramstyle (`:param`). Read more about parameterization in `docs/parameters.md`.
 
 ## Usage with pandas
 


### PR DESCRIPTION
## Description

This is strictly a documentation update for our SQLAlchemy 2.0 compliant dialect. The revised example is runnable.