### PR TITLE
GH Workflows: remove Python 3.7 from the matrix for _all_ workflows

### DIFF
--- a/.github/workflows/code-quality-checks.yml
+++ b/.github/workflows/code-quality-checks.yml
@@ -62,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.8, 3.9, "3.10"]
     steps:
       #----------------------------------------------
       #       check-out repo and set-up python
@@ -114,7 +114,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.8, 3.9, "3.10"]
     steps:
       #----------------------------------------------
       #       check-out repo and set-up python


### PR DESCRIPTION
This was missed in #270