### PR TITLE
Remove block on running queries if protocol seems to low

### DIFF
--- a/src/databricks/sql/client.py
+++ b/src/databricks/sql/client.py
@@ -413,12 +413,8 @@ class Cursor:
                 )
             return ParameterApproach.INLINE
 
-        elif server_supports_native_approach:
-            return ParameterApproach.NATIVE
         else:
-            raise NotSupportedError(
-                "Parameterized operations are not supported by this server. DBR 14.1 is required."
-            )
+            return ParameterApproach.NATIVE
 
     def _prepare_inline_parameters(
         self, stmt: str, params: Optional[Union[List, Dict[str, Any]]]

--- a/src/databricks/sqlalchemy/test/test_suite.py
+++ b/src/databricks/sqlalchemy/test/test_suite.py
@@ -4,19 +4,6 @@ then are overridden by our local skip markers in _regression, _unsupported, and 
 """
 
 
-def start_protocol_patch():
-    """See tests/test_parameterized_queries.py for more information about this patch."""
-    from unittest.mock import patch
-
-    native_support_patcher = patch(
-        "databricks.sql.client.Connection.server_parameterized_queries_enabled",
-        return_value=True,
-    )
-    native_support_patcher.start()
-
-
-start_protocol_patch()
-
 # type: ignore
 # fmt: off
 from sqlalchemy.testing.suite import *

--- a/src/databricks/sqlalchemy/test_local/e2e/test_basic.py
+++ b/src/databricks/sqlalchemy/test_local/e2e/test_basic.py
@@ -22,10 +22,6 @@ try:
 except ImportError:
     from sqlalchemy.ext.declarative import declarative_base
 
-from databricks.sqlalchemy.test.test_suite import start_protocol_patch
-
-start_protocol_patch()
-
 
 USER_AGENT_TOKEN = "PySQL e2e Tests"
 

--- a/tests/e2e/test_parameterized_queries.py
+++ b/tests/e2e/test_parameterized_queries.py
@@ -130,15 +130,13 @@ class TestParameterizedQueries(PySQLPytestTestCase):
 
         return to_return
 
-    def _native_roundtrip(
-        self, parameters: Union[Dict, List[Dict]], bypass_patch=False
-    ):
+    def _native_roundtrip(self, parameters: Union[Dict, List[Dict]]):
         with self.connection(extra_params={"use_inline_params": False}) as conn:
             with conn.cursor() as cursor:
                 cursor.execute(self.NATIVE_QUERY, parameters=parameters)
                 return cursor.fetchone()
 
-    def _get_one_result(self, approach: ParameterApproach, params, bypass_patch=False):
+    def _get_one_result(self, approach: ParameterApproach, params):
         """When approach is INLINE then we use %(param)s paramstyle and a connection with use_inline_params=True
         When approach is NATIVE then we use :param paramstyle and a connection with use_inline_params=False
         """
@@ -146,7 +144,7 @@ class TestParameterizedQueries(PySQLPytestTestCase):
         if approach == ParameterApproach.INLINE:
             return self._inline_roundtrip(params)
         elif approach == ParameterApproach.NATIVE:
-            return self._native_roundtrip(params, bypass_patch)
+            return self._native_roundtrip(params)
 
     def _quantize(self, input: Union[float, int], place_value=2) -> Decimal:
         return Decimal(str(input)).quantize(Decimal("0." + "0" * place_value))


### PR DESCRIPTION
## Description

This PR accomplishes two things:
1. It stops pysql from abandoning a parameterised query run with `ParameterApproach.NATIVE`  if it thinks that DBR doesn't support it.
2. It removes the patch from our test fixtures that was required prior to implementing part 1.

This PR hits a staging branch so I can group all the forthcoming parameter approach changes and documentation into a single commit on `main`.