### PR TITLE
Merge native parameter rewrite into main

### DIFF
--- a/.github/workflows/code-quality-checks.yml
+++ b/.github/workflows/code-quality-checks.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
+        python-version: [3.8, 3.9, "3.10", "3.11"]
     steps:
       #----------------------------------------------
       #       check-out repo and set-up python
@@ -29,7 +29,6 @@ jobs:
       - name: Install Poetry
         uses: snok/install-poetry@v1
         with:
-          version: ${{ matrix.python-version == 3.7 && '1.5.1' || 'latest'  }}
           virtualenvs-create: true
           virtualenvs-in-project: true
           installer-parallel: true
@@ -81,7 +80,6 @@ jobs:
       - name: Install Poetry
         uses: snok/install-poetry@v1
         with:
-          version: ${{ matrix.python-version == 3.7 && '1.5.1' || 'latest'  }}
           virtualenvs-create: true
           virtualenvs-in-project: true
           installer-parallel: true
@@ -134,7 +132,6 @@ jobs:
       - name: Install Poetry
         uses: snok/install-poetry@v1
         with:
-          version: ${{ matrix.python-version == 3.7 && '1.5.1' || 'latest'  }}
           virtualenvs-create: true
           virtualenvs-in-project: true
           installer-parallel: true

--- a/.github/workflows/code-quality-checks.yml
+++ b/.github/workflows/code-quality-checks.yml
@@ -62,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.8, 3.9, "3.10"]
     steps:
       #----------------------------------------------
       #       check-out repo and set-up python
@@ -114,7 +114,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.8, 3.9, "3.10"]
     steps:
       #----------------------------------------------
       #       check-out repo and set-up python

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 3.0.0 (Unreleased)
 
+- Add support for native parameterized SQL queries. Requires DBR 14.2 and above. See docs/parameters.md for more info.
 - Other: Introduce SQLAlchemy dialect compliance test suite and enumerate all excluded tests
 - Add integration tests for Databricks UC Volumes ingestion queries
 - Add `_retry_max_redirects` config

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
 # Release History
 
-## 2.9.4 (Unreleased)
+## 3.0.0 (Unreleased)
 
 - Other: Introduce SQLAlchemy dialect compliance test suite and enumerate all excluded tests
 - Add integration tests for Databricks UC Volumes ingestion queries
 - Add `_retry_max_redirects` config
 - Enable cloud fetch by default. To disable, set `use_cloud_fetch=False` when building `databricks.sql.client`.
+- Remove support for Python 3.7
 
 ## 2.9.3 (2023-08-24)
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ You are welcome to file an issue here for general use cases. You can also contac
 
 ## Requirements
 
-Python 3.7 or above is required.
+Python 3.8 or above is required.
 
 ## Documentation
 
@@ -47,8 +47,7 @@ connection = sql.connect(
   access_token=access_token)
 
 cursor = connection.cursor()
-
-cursor.execute('SELECT * FROM RANGE(10)')
+cursor.execute('SELECT :param `p`, * FROM RANGE(10)', {"param": "foo"})
 result = cursor.fetchall()
 for row in result:
   print(row)

--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -1,1 +1,255 @@
-`<placeholder>`
+# Using Native Parameters
+
+This connector supports native parameterized query execution. When you execute a query that includes variable markers, then you can pass a collection of parameters which are sent separately to Databricks Runtime for safe execution. This prevents SQL injection and can improve query performance.
+
+This behaviour is distinct from legacy "inline" parameterized execution in versions below 3.0.0. The legacy behavior is preserved behind a flag called `use_inline_params`, which will be removed in a future release. See [Using Inline Parameters](#using-inline-parameters) for more information.
+
+See **[below](#migrating-to-native-parameters)** for details about updating your client code to use native parameters.
+
+See `examples/parameters.py` in this repository for a runnable demo.
+
+## Requirements
+
+- `databricks-sql-connector>=3.0.0`
+- A SQL warehouse or all-purpose cluster running Databricks Runtime >=14.2
+
+## Limitations
+
+- A query executed with native parameters can contain at most 255 parameter markers
+- The maximum size of all parameterized values cannot exceed 1MB
+
+## SQL Syntax
+
+Variables in your SQL query can use one of three PEP-249 [paramstyles](https://peps.python.org/pep-0249/#paramstyle). A parameterized query can use exactly one paramstyle.
+
+|paramstyle|example|comment|
+|-|-|-|
+|`named`|`:param`|Parameters must be named|
+|`qmark`|`?`|Parameter names are ignored|
+|`pyformat`|`%(param)s`|Legacy syntax. Will be deprecated. Parameters must be named.|
+
+#### Example
+
+```sql
+-- named paramstyle
+SELECT * FROM table WHERE field = :value
+
+-- qmark paramstyle
+SELECT * FROM table WHERE field = ?
+
+-- pyformat paramstyle (legacy)
+SELECT * FROM table WHERE field = %(value)s
+```
+
+## Python Syntax
+
+This connector follows the [PEP-249 interface](https://peps.python.org/pep-0249/#id20). The expected structure of the parameter collection follows the paramstyle of the variables in your query. 
+
+### `named` paramstyle Usage Example
+
+When your SQL query uses `named` paramstyle variable markers, you need specify a name for each value that corresponds to a variable marker in your query.
+
+Generally, you do this by passing `parameters` as a dictionary whose keys match the variables in your query. The length of the dictionary must exactly match the count of variable markers or an exception will be raised.
+
+```python
+from databricks import sql
+
+with sql.connect(...) as conn:
+    with conn.cursor() as cursor():
+        query = "SELECT field FROM table WHERE field = :value1 AND another_field = :value2"
+        parameters = {"value1": "foo", "value2": 20}
+        result = cursor.execute(query, parameters=parameters).fetchone()
+```
+
+This paramstyle is a drop-in replacement for the `pyformat` paramstyle which was used in connector versions below 3.0.0. It should be used going forward.
+
+### `qmark` paramstyle Usage Example
+
+When your SQL query uses `qmark` paramstyle variable markers, you only need to specify a value for each variable marker in your query.
+
+You do this by passing `parameters` as a list. The order of values in the list corresponds to the order of `qmark` variables in your query. The length of the list must exactly match the count of variable markers in your query or an exception will be raised.
+
+```python
+from databricks import sql
+
+with sql.connect(...) as conn:
+    with conn.cursor() as cursor():
+        query = "SELECT field FROM table WHERE field = ? AND another_field = ?"
+        parameters = ["foo", 20]
+        result = cursor.execute(query, parameters=parameters).fetchone()
+```
+
+The result of the above two examples is identical.
+
+### Legacy `pyformat` paramstyle Usage Example
+
+Databricks Runtime expects variable markers to use either `named` or `qmark` paramstyles. Historically, this connector used `pyformat` which Databricks Runtime does not support. So to assist assist customers transitioning their codebases from `pyformat` → `named`, we can dynamically rewrite the variable markers before sending the query to Databricks. This happens only when `use_inline_params=False`.
+
+ This dynamic rewrite will be deprecated in a future release. New queries should be written using the `named` paramstyle instead. And users should update their client code to replace `pyformat` markers with `named` markers. 
+
+For example:
+
+```sql
+-- a query written for databricks-sql-connector==2.9.3 and below
+
+SELECT field1, field2, %(param1)s FROM table WHERE field4 = %(param2)s
+
+-- rewritten for databricks-sql-connector==3.0.0 and above
+
+SELECT field1, field2, :param1 FROM table WHERE field4 = :param2
+```
+
+
+**Note:** While named `pyformat` markers are transparently replaced when `use_inline_params=False`, un-named inline `%s`-style markers are ignored. If your client code makes extensive use of `%s` markers, these queries will need to be updated to use `?` markers before you can execute them when `use_inline_params=False`. See [When to use inline parameters](#when-to-use-inline-parameters) for more information.
+
+### Type inference
+
+Under the covers, parameter values are annotated with a valid Databricks SQL type. As shown in the examples above, this connector accepts primitive Python types like `int`, `str`, and `Decimal`. When this happens, the connector infers the corresponding Databricks SQL type (e.g. `INT`, `STRING`, `DECIMAL`) automatically. This means that the parameters passed to `cursor.execute()` are always wrapped in a `TDbsqlParameter` subtype prior to execution.
+
+Automatic inferrence is sufficient for most usages. But you can bypass the inference by explicitly setting the Databricks SQL type in your client code. All supported Databricks SQL types have `TDbsqlParameter` implementations which you can import from `databricks.sql.parameters`. 
+
+`TDbsqlParameter` objects must always be passed within a list. Either paramstyle (`:named` or `?`) may be used. However, if your query uses the `named` paramstyle, all `TDbsqlParameter` objects must be provided a `name` when they are constructed.
+
+```python
+from databricks import sql
+from databricks.sql.parameters import StringParameter, IntegerParameter
+
+# with `named` markers
+with sql.connect(...) as conn:
+    with conn.cursor() as cursor():
+        query = "SELECT field FROM table WHERE field = :value1 AND another_field = :value2"
+        parameters = [
+            StringParameter(name="value1", value="foo"),
+            IntegerParameter(name="value2", value=20)
+        ]
+        result = cursor.execute(query, parameters=parameters).fetchone()
+
+# with `?` markers
+with sql.connect(...) as conn:
+    with conn.cursor() as cursor():
+        query = "SELECT field FROM table WHERE field = ? AND another_field = ?"
+        parameters = [
+            StringParameter(value="foo"),
+            IntegerParameter(value=20)
+        ]
+        result = cursor.execute(query, parameters=parameters).fetchone()
+```
+
+In general, we recommend using `?` markers when passing `TDbsqlParameter`'s directly.
+
+**Note**: When using `?` markers, you can bypass inference for _some_ parameters by passing a list containing both primitive Python types and `TDbsqlParameter` objects. `TDbsqlParameter` objects can never be passed in a dictionary.
+
+# Using Inline Parameters
+
+Since it's initial release, this connector's `cursor.execute()` method has supported passing a sequence or mapping of parameter values. Prior to Databricks Runtime introducing native parameter support, however, "parameterized" queries could not be executed in a guaranteed safe manner. Instead, the connector made a best effort to escape parameter values and and render those strings inline with the query.
+
+This approach has several drawbacks:
+
+- It's not guaranteed to be safe from SQL injection
+- The server could not boost performance by caching prepared statements
+- The parameter marker syntax conflicted with SQL syntax in some cases
+
+Nevertheless, this behaviour is preserved in version 3.0.0 and above for legacy purposes. It will be removed in a subsequent major release. To enable this legacy code path, you must now construct your connection with `use_inline_params=True`.
+
+## Requirements
+
+Rendering parameters inline is supported on all versions of DBR since these queries are indistinguishable from ad-hoc query text.
+
+
+## SQL Syntax
+
+Variables in your SQL query can look like `%(param)s` or like `%s`. 
+
+#### Example
+
+```sql
+-- pyformat paramstyle is used for named parameters
+SELECT * FROM table WHERE field = %(value)s
+
+-- %s is used for positional parameters
+SELECT * FROM table WHERE field = %s
+```
+
+## Python Syntax
+
+This connector follows the [PEP-249 interface](https://peps.python.org/pep-0249/#id20). The expected structure of the parameter collection follows the paramstyle of the variables in your query. 
+
+### `pyformat` paramstyle Usage Example
+
+Parameters must be passed as a dictionary.
+
+```python
+from databricks import sql
+
+with sql.connect(..., use_inline_params=True) as conn:
+    with conn.cursor() as cursor():
+        query = "SELECT field FROM table WHERE field = %(value1)s AND another_field = %(value2)s"
+        parameters = {"value1": "foo", "value2": 20}
+        result = cursor.execute(query, parameters=parameters).fetchone()
+```
+
+The above query would be rendered into the following SQL:
+
+```sql
+SELECT field FROM table WHERE field = 'foo' AND another_field = 20
+```
+
+### `%s` paramstyle Usage Example
+
+Parameters must be passed as a list.
+
+```python
+from databricks import sql
+
+with sql.connect(..., use_inline_params=True) as conn:
+    with conn.cursor() as cursor():
+        query = "SELECT field FROM table WHERE field = %s AND another_field = %s"
+        parameters = ["foo", 20]
+        result = cursor.execute(query, parameters=parameters).fetchone()
+```
+
+The result of the above two examples is identical.
+
+**Note**: `%s` is not compliant with PEP-249 and only works due to the specific implementation of our inline renderer. 
+
+**Note:** This `%s` syntax overlaps with valid SQL syntax around the usage of `LIKE` DML. For example if your query includes a clause like `WHERE field LIKE '%sequence'`, the parameter inlining function will raise an exception because this string appears to include an inline marker but none is provided. When `use_inline_params=False`, we will pass `%s` occurrences along to the database, allowing it to be used as expected in `LIKE` statements.
+
+### Passing sequences as parameter values
+
+Parameter values can also be passed as a sequence. This is typically used when writing `WHERE ... IN` clauses:
+
+```python
+from databricks import sql
+
+with sql.connect(..., use_inline_params=True) as conn:
+    with conn.cursor() as cursor():
+        query = "SELECT field FROM table WHERE field IN %(value_list)s"
+        parameters = {"value_list": [1,2,3,4,5]}
+        result = cursor.execute(query, parameters=parameters).fetchone()
+```
+
+Output:
+
+```sql
+SELECT field FROM table WHERE field IN (1,2,3,4,5)
+```
+
+**Note**: this behavior is not specified by PEP-249 and only works due to the specific implementation of our inline renderer.
+
+### Migrating to native parameters
+
+Native parameters are meant to be a drop-in replacement for inline parameters. In most use-cases, upgrading to `databricks-sql-connector>=3.0.0` will grant an immediate improvement to safety. And future improvements to parameterization (such as support for binding complex types like `STRUCT`, `MAP`, and `ARRAY`) will only be available when `use_inline_params=False`.
+
+To completely migrate, you need to [revise your SQL queries](#legacy-pyformat-paramstyle-usage-example) to use the new paramstyles.
+
+
+### When to use inline parameters
+
+You should only set `use_inline_params=True` in the following cases:
+
+1. Your client code passes more than 255 parameters in a single query execution
+2. Your client code passes parameter values greater than 1MB in a single query execution
+3. Your client code makes extensive use of [`%s` positional parameter markers](#s-paramstyle-usage-example)
+4. Your client code uses [passes sequences as parameter values](#passing-sequences-as-parameter-values)
+
+We expect limitations (1) and (2) to be addressed in a future Databricks Runtime release.

--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -212,7 +212,7 @@ The result of the above two examples is identical.
 
 **Note**: `%s` is not compliant with PEP-249 and only works due to the specific implementation of our inline renderer. 
 
-**Note:** This `%s` syntax overlaps with valid SQL syntax around the usage of `LIKE` DML. For example if your query includes a clause like `WHERE field LIKE '%sequence'`, the parameter inlining function will raise an exception because this string appears to include an inline marker but none is provided. When `use_inline_params=False`, we will pass `%s` occurrences along to the database, allowing it to be used as expected in `LIKE` statements.
+**Note:** This `%s` syntax overlaps with valid SQL syntax around the usage of `LIKE` DML. For example if your query includes a clause like `WHERE field LIKE '%sequence'`, the parameter inlining function will raise an exception because this string appears to include an inline marker but none is provided. This means that connector versions below 3.0.0 it has been impossible to execute a query that included both parameters and LIKE wildcards. When `use_inline_params=False`, we will pass `%s` occurrences along to the database, allowing it to be used as expected in `LIKE` statements.
 
 ### Passing sequences as parameter values
 
@@ -238,7 +238,7 @@ SELECT field FROM table WHERE field IN (1,2,3,4,5)
 
 ### Migrating to native parameters
 
-Native parameters are meant to be a drop-in replacement for inline parameters. In most use-cases, upgrading to `databricks-sql-connector>=3.0.0` will grant an immediate improvement to safety. And future improvements to parameterization (such as support for binding complex types like `STRUCT`, `MAP`, and `ARRAY`) will only be available when `use_inline_params=False`.
+Native parameters are meant to be a drop-in replacement for inline parameters. In most use-cases, upgrading to `databricks-sql-connector>=3.0.0` will grant an immediate improvement to safety. Plus, native parameters allow you to use SQL LIKE wildcards (`%`) in your queries which is impossible with inline parameters. Future improvements to parameterization (such as support for binding complex types like `STRUCT`, `MAP`, and `ARRAY`) will only be available when `use_inline_params=False`.
 
 To completely migrate, you need to [revise your SQL queries](#legacy-pyformat-paramstyle-usage-example) to use the new paramstyles.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -41,3 +41,4 @@ this example the string `ExamplePartnerTag` will be added to the the user agent 
 - **`sqlalchemy.py`** shows a basic example of connecting to Databricks with [SQLAlchemy](https://www.sqlalchemy.org/). 
 - **`custom_cred_provider.py`** shows how to pass a custom credential provider to bypass connector authentication. Please install databricks-sdk prior to running this example.
 - **`v3_retries_query_execute.py`** shows how to enable v3 retries in connector version 2.9.x including how to enable retries for non-default retry cases.
+- **`parameters.py`** shows how to use parameters in native and inline modes.

--- a/examples/parameters.py
+++ b/examples/parameters.py
@@ -1,0 +1,121 @@
+"""
+This example demonstrates how to use parameters in both native (default) and inline (legacy) mode.
+"""
+
+from decimal import Decimal
+from databricks import sql
+from databricks.sql.parameters import *
+
+import os
+from databricks import sql
+from datetime import datetime
+import pytz
+
+host = os.getenv("DATABRICKS_SERVER_HOSTNAME")
+http_path = os.getenv("DATABRICKS_HTTP_PATH")
+access_token = os.getenv("DATABRICKS_TOKEN")
+
+
+native_connection = sql.connect(
+    server_hostname=host, http_path=http_path, access_token=access_token
+)
+
+inline_connection = sql.connect(
+    server_hostname=host,
+    http_path=http_path,
+    access_token=access_token,
+    use_inline_params="silent",
+)
+
+# Example 1 demonstrates how in most cases, queries written for databricks-sql-connector<3.0.0 will work
+# with databricks-sql-connector>=3.0.0. This is because the default mode is native mode, which is backwards
+# compatible with the legacy inline mode.
+
+LEGACY_NAMED_QUERY = "SELECT %(name)s `name`, %(age)s `age`, %(active)s `active`"
+EX1_PARAMS = {"name": "Jane", "age": 30, "active": True}
+
+with native_connection.cursor() as cursor:
+    ex1_native_result = cursor.execute(LEGACY_NAMED_QUERY, EX1_PARAMS).fetchone()
+
+with inline_connection.cursor() as cursor:
+    ex1_inline_result = cursor.execute(LEGACY_NAMED_QUERY, EX1_PARAMS).fetchone()
+
+print("\nEXAMPLE 1")
+print("Example 1 result in native mode\t→\t", ex1_native_result)
+print("Example 1 result in inline mode\t→\t", ex1_inline_result)
+
+
+# Example 2 shows how to update example 1 to use the new `named` parameter markers.
+# This query would fail in inline mode.
+
+# This is an example of the automatic transformation from pyformat → named.
+# The output looks like this:
+# SELECT :name `name`, :age `age`, :active `active`
+NATIVE_NAMED_QUERY = LEGACY_NAMED_QUERY % {
+    "name": ":name",
+    "age": ":age",
+    "active": ":active",
+}
+EX2_PARAMS = EX1_PARAMS
+
+with native_connection.cursor() as cursor:
+    ex2_named_result = cursor.execute(NATIVE_NAMED_QUERY, EX1_PARAMS).fetchone()
+
+with native_connection.cursor() as cursor:
+    ex2_pyformat_result = cursor.execute(LEGACY_NAMED_QUERY, EX1_PARAMS).fetchone()
+
+print("\nEXAMPLE 2")
+print("Example 2 result with pyformat \t→\t", ex2_named_result)
+print("Example 2 result with named \t→\t", ex2_pyformat_result)
+
+
+# Example 3 shows how to use positional parameters. Notice the syntax is different between native and inline modes.
+# No automatic transformation is done here. So the LEGACY_POSITIONAL_QUERY will not work in native mode.
+
+NATIVE_POSITIONAL_QUERY = "SELECT ? `name`, ? `age`, ? `active`"
+LEGACY_POSITIONAL_QUERY = "SELECT %s `name`, %s `age`, %s `active`"
+
+EX3_PARAMS = ["Jane", 30, True]
+
+with native_connection.cursor() as cursor:
+    ex3_native_result = cursor.execute(NATIVE_POSITIONAL_QUERY, EX3_PARAMS).fetchone()
+
+with inline_connection.cursor() as cursor:
+    ex3_inline_result = cursor.execute(LEGACY_POSITIONAL_QUERY, EX3_PARAMS).fetchone()
+
+print("\nEXAMPLE 3")
+print("Example 3 result in native mode\t→\t", ex3_native_result)
+print("Example 3 result in inline mode\t→\t", ex3_inline_result)
+
+# Example 4 shows how to bypass type inference and set an exact Databricks SQL type for a parameter.
+# This is only possible when use_inline_params=False
+
+
+moment = datetime(2012, 10, 15, 12, 57, 18)
+chicago_timezone = pytz.timezone("America/Chicago")
+
+# For this parameter value, we don't bypass inference. So we know that the connector
+# will infer the datetime object to be a TIMESTAMP, which preserves the timezone info.
+ex4_p1 = chicago_timezone.localize(moment)
+
+# For this parameter value, we bypass inference and set the type to TIMESTAMP_NTZ,
+# which does not preserve the timezone info. Therefore we expect the timezone
+# will be dropped in the roundtrip.
+ex4_p2 = TimestampNTZParameter(value=ex4_p1)
+
+# For this parameter, we don't bypass inference. So we know that the connector
+# will infer the Decimal to be a DECIMAL and will preserve its current precision and scale.
+ex4_p3 = Decimal("12.3456")
+
+# For this parameter value, we bind a decimal with custom scale and precision
+# that will result in the decimal being truncated.
+ex4_p4 = DecimalParameter(value=ex4_p3, scale=4, precision=2)
+
+EX4_QUERY = "SELECT ? `p1`, ? `p2`, ? `p3`, ? `p4`"
+EX4_PARAMS = [ex4_p1, ex4_p2, ex4_p3, ex4_p4]
+with native_connection.cursor() as cursor:
+    result = cursor.execute(EX4_QUERY, EX4_PARAMS).fetchone()
+
+print("\nEXAMPLE 4")
+print("Example 4 inferred result\t→\t {}\t{}".format(result.p1, result.p3))
+print("Example 4 explicit result\t→\t {}\t\t{}".format(result.p2, result.p4))

--- a/poetry.lock
+++ b/poetry.lock
@@ -23,21 +23,17 @@ tz = ["python-dateutil"]
 
 [[package]]
 name = "astroid"
-version = "2.11.7"
+version = "3.0.1"
 description = "An abstract syntax tree for Python with inference support."
 optional = false
-python-versions = ">=3.6.2"
+python-versions = ">=3.8.0"
 files = [
-    {file = "astroid-2.11.7-py3-none-any.whl", hash = "sha256:86b0a340a512c65abf4368b80252754cda17c02cdbbd3f587dddf98112233e7b"},
-    {file = "astroid-2.11.7.tar.gz", hash = "sha256:bb24615c77f4837c707669d16907331374ae8a964650a66999da3f5ca68dc946"},
+    {file = "astroid-3.0.1-py3-none-any.whl", hash = "sha256:7d5895c9825e18079c5aeac0572bc2e4c83205c95d416e0b4fee8bc361d2d9ca"},
+    {file = "astroid-3.0.1.tar.gz", hash = "sha256:86b0bb7d7da0be1a7c4aedb7974e391b32d4ed89e33de6ed6902b4b15c97577e"},
 ]
 
 [package.dependencies]
-lazy-object-proxy = ">=1.4.0"
-setuptools = ">=20.0"
-typed-ast = {version = ">=1.4.0,<2.0", markers = "implementation_name == \"cpython\" and python_version < \"3.8\""}
-typing-extensions = {version = ">=3.10", markers = "python_version < \"3.10\""}
-wrapt = ">=1.11,<2"
+typing-extensions = {version = ">=4.0.0", markers = "python_version < \"3.11\""}
 
 [[package]]
 name = "black"
@@ -66,7 +62,6 @@ mypy-extensions = ">=0.4.3"
 pathspec = ">=0.9.0"
 platformdirs = ">=2"
 tomli = {version = ">=1.1.0", markers = "python_full_version < \"3.11.0a7\""}
-typed-ast = {version = ">=1.4.2", markers = "python_version < \"3.8\" and implementation_name == \"cpython\""}
 typing-extensions = {version = ">=3.10.0.0", markers = "python_version < \"3.10\""}
 
 [package.extras]
@@ -88,101 +83,101 @@ files = [
 
 [[package]]
 name = "charset-normalizer"
-version = "3.3.1"
+version = "3.3.2"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
 optional = false
 python-versions = ">=3.7.0"
 files = [
-    {file = "charset-normalizer-3.3.1.tar.gz", hash = "sha256:d9137a876020661972ca6eec0766d81aef8a5627df628b664b234b73396e727e"},
-    {file = "charset_normalizer-3.3.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:8aee051c89e13565c6bd366813c386939f8e928af93c29fda4af86d25b73d8f8"},
-    {file = "charset_normalizer-3.3.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:352a88c3df0d1fa886562384b86f9a9e27563d4704ee0e9d56ec6fcd270ea690"},
-    {file = "charset_normalizer-3.3.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:223b4d54561c01048f657fa6ce41461d5ad8ff128b9678cfe8b2ecd951e3f8a2"},
-    {file = "charset_normalizer-3.3.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4f861d94c2a450b974b86093c6c027888627b8082f1299dfd5a4bae8e2292821"},
-    {file = "charset_normalizer-3.3.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1171ef1fc5ab4693c5d151ae0fdad7f7349920eabbaca6271f95969fa0756c2d"},
-    {file = "charset_normalizer-3.3.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:28f512b9a33235545fbbdac6a330a510b63be278a50071a336afc1b78781b147"},
-    {file = "charset_normalizer-3.3.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c0e842112fe3f1a4ffcf64b06dc4c61a88441c2f02f373367f7b4c1aa9be2ad5"},
-    {file = "charset_normalizer-3.3.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3f9bc2ce123637a60ebe819f9fccc614da1bcc05798bbbaf2dd4ec91f3e08846"},
-    {file = "charset_normalizer-3.3.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:f194cce575e59ffe442c10a360182a986535fd90b57f7debfaa5c845c409ecc3"},
-    {file = "charset_normalizer-3.3.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:9a74041ba0bfa9bc9b9bb2cd3238a6ab3b7618e759b41bd15b5f6ad958d17605"},
-    {file = "charset_normalizer-3.3.1-cp310-cp310-musllinux_1_1_ppc64le.whl", hash = "sha256:b578cbe580e3b41ad17b1c428f382c814b32a6ce90f2d8e39e2e635d49e498d1"},
-    {file = "charset_normalizer-3.3.1-cp310-cp310-musllinux_1_1_s390x.whl", hash = "sha256:6db3cfb9b4fcecb4390db154e75b49578c87a3b9979b40cdf90d7e4b945656e1"},
-    {file = "charset_normalizer-3.3.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:debb633f3f7856f95ad957d9b9c781f8e2c6303ef21724ec94bea2ce2fcbd056"},
-    {file = "charset_normalizer-3.3.1-cp310-cp310-win32.whl", hash = "sha256:87071618d3d8ec8b186d53cb6e66955ef2a0e4fa63ccd3709c0c90ac5a43520f"},
-    {file = "charset_normalizer-3.3.1-cp310-cp310-win_amd64.whl", hash = "sha256:e372d7dfd154009142631de2d316adad3cc1c36c32a38b16a4751ba78da2a397"},
-    {file = "charset_normalizer-3.3.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:ae4070f741f8d809075ef697877fd350ecf0b7c5837ed68738607ee0a2c572cf"},
-    {file = "charset_normalizer-3.3.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:58e875eb7016fd014c0eea46c6fa92b87b62c0cb31b9feae25cbbe62c919f54d"},
-    {file = "charset_normalizer-3.3.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:dbd95e300367aa0827496fe75a1766d198d34385a58f97683fe6e07f89ca3e3c"},
-    {file = "charset_normalizer-3.3.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:de0b4caa1c8a21394e8ce971997614a17648f94e1cd0640fbd6b4d14cab13a72"},
-    {file = "charset_normalizer-3.3.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:985c7965f62f6f32bf432e2681173db41336a9c2611693247069288bcb0c7f8b"},
-    {file = "charset_normalizer-3.3.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a15c1fe6d26e83fd2e5972425a772cca158eae58b05d4a25a4e474c221053e2d"},
-    {file = "charset_normalizer-3.3.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ae55d592b02c4349525b6ed8f74c692509e5adffa842e582c0f861751701a673"},
-    {file = "charset_normalizer-3.3.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:be4d9c2770044a59715eb57c1144dedea7c5d5ae80c68fb9959515037cde2008"},
-    {file = "charset_normalizer-3.3.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:851cf693fb3aaef71031237cd68699dded198657ec1e76a76eb8be58c03a5d1f"},
-    {file = "charset_normalizer-3.3.1-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:31bbaba7218904d2eabecf4feec0d07469284e952a27400f23b6628439439fa7"},
-    {file = "charset_normalizer-3.3.1-cp311-cp311-musllinux_1_1_ppc64le.whl", hash = "sha256:871d045d6ccc181fd863a3cd66ee8e395523ebfbc57f85f91f035f50cee8e3d4"},
-    {file = "charset_normalizer-3.3.1-cp311-cp311-musllinux_1_1_s390x.whl", hash = "sha256:501adc5eb6cd5f40a6f77fbd90e5ab915c8fd6e8c614af2db5561e16c600d6f3"},
-    {file = "charset_normalizer-3.3.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:f5fb672c396d826ca16a022ac04c9dce74e00a1c344f6ad1a0fdc1ba1f332213"},
-    {file = "charset_normalizer-3.3.1-cp311-cp311-win32.whl", hash = "sha256:bb06098d019766ca16fc915ecaa455c1f1cd594204e7f840cd6258237b5079a8"},
-    {file = "charset_normalizer-3.3.1-cp311-cp311-win_amd64.whl", hash = "sha256:8af5a8917b8af42295e86b64903156b4f110a30dca5f3b5aedea123fbd638bff"},
-    {file = "charset_normalizer-3.3.1-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:7ae8e5142dcc7a49168f4055255dbcced01dc1714a90a21f87448dc8d90617d1"},
-    {file = "charset_normalizer-3.3.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:5b70bab78accbc672f50e878a5b73ca692f45f5b5e25c8066d748c09405e6a55"},
-    {file = "charset_normalizer-3.3.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5ceca5876032362ae73b83347be8b5dbd2d1faf3358deb38c9c88776779b2e2f"},
-    {file = "charset_normalizer-3.3.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:34d95638ff3613849f473afc33f65c401a89f3b9528d0d213c7037c398a51296"},
-    {file = "charset_normalizer-3.3.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9edbe6a5bf8b56a4a84533ba2b2f489d0046e755c29616ef8830f9e7d9cf5728"},
-    {file = "charset_normalizer-3.3.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f6a02a3c7950cafaadcd46a226ad9e12fc9744652cc69f9e5534f98b47f3bbcf"},
-    {file = "charset_normalizer-3.3.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:10b8dd31e10f32410751b3430996f9807fc4d1587ca69772e2aa940a82ab571a"},
-    {file = "charset_normalizer-3.3.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:edc0202099ea1d82844316604e17d2b175044f9bcb6b398aab781eba957224bd"},
-    {file = "charset_normalizer-3.3.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:b891a2f68e09c5ef989007fac11476ed33c5c9994449a4e2c3386529d703dc8b"},
-    {file = "charset_normalizer-3.3.1-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:71ef3b9be10070360f289aea4838c784f8b851be3ba58cf796262b57775c2f14"},
-    {file = "charset_normalizer-3.3.1-cp312-cp312-musllinux_1_1_ppc64le.whl", hash = "sha256:55602981b2dbf8184c098bc10287e8c245e351cd4fdcad050bd7199d5a8bf514"},
-    {file = "charset_normalizer-3.3.1-cp312-cp312-musllinux_1_1_s390x.whl", hash = "sha256:46fb9970aa5eeca547d7aa0de5d4b124a288b42eaefac677bde805013c95725c"},
-    {file = "charset_normalizer-3.3.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:520b7a142d2524f999447b3a0cf95115df81c4f33003c51a6ab637cbda9d0bf4"},
-    {file = "charset_normalizer-3.3.1-cp312-cp312-win32.whl", hash = "sha256:8ec8ef42c6cd5856a7613dcd1eaf21e5573b2185263d87d27c8edcae33b62a61"},
-    {file = "charset_normalizer-3.3.1-cp312-cp312-win_amd64.whl", hash = "sha256:baec8148d6b8bd5cee1ae138ba658c71f5b03e0d69d5907703e3e1df96db5e41"},
-    {file = "charset_normalizer-3.3.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:63a6f59e2d01310f754c270e4a257426fe5a591dc487f1983b3bbe793cf6bac6"},
-    {file = "charset_normalizer-3.3.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1d6bfc32a68bc0933819cfdfe45f9abc3cae3877e1d90aac7259d57e6e0f85b1"},
-    {file = "charset_normalizer-3.3.1-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4f3100d86dcd03c03f7e9c3fdb23d92e32abbca07e7c13ebd7ddfbcb06f5991f"},
-    {file = "charset_normalizer-3.3.1-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:39b70a6f88eebe239fa775190796d55a33cfb6d36b9ffdd37843f7c4c1b5dc67"},
-    {file = "charset_normalizer-3.3.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4e12f8ee80aa35e746230a2af83e81bd6b52daa92a8afaef4fea4a2ce9b9f4fa"},
-    {file = "charset_normalizer-3.3.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7b6cefa579e1237ce198619b76eaa148b71894fb0d6bcf9024460f9bf30fd228"},
-    {file = "charset_normalizer-3.3.1-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:61f1e3fb621f5420523abb71f5771a204b33c21d31e7d9d86881b2cffe92c47c"},
-    {file = "charset_normalizer-3.3.1-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:4f6e2a839f83a6a76854d12dbebde50e4b1afa63e27761549d006fa53e9aa80e"},
-    {file = "charset_normalizer-3.3.1-cp37-cp37m-musllinux_1_1_ppc64le.whl", hash = "sha256:1ec937546cad86d0dce5396748bf392bb7b62a9eeb8c66efac60e947697f0e58"},
-    {file = "charset_normalizer-3.3.1-cp37-cp37m-musllinux_1_1_s390x.whl", hash = "sha256:82ca51ff0fc5b641a2d4e1cc8c5ff108699b7a56d7f3ad6f6da9dbb6f0145b48"},
-    {file = "charset_normalizer-3.3.1-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:633968254f8d421e70f91c6ebe71ed0ab140220469cf87a9857e21c16687c034"},
-    {file = "charset_normalizer-3.3.1-cp37-cp37m-win32.whl", hash = "sha256:c0c72d34e7de5604df0fde3644cc079feee5e55464967d10b24b1de268deceb9"},
-    {file = "charset_normalizer-3.3.1-cp37-cp37m-win_amd64.whl", hash = "sha256:63accd11149c0f9a99e3bc095bbdb5a464862d77a7e309ad5938fbc8721235ae"},
-    {file = "charset_normalizer-3.3.1-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:5a3580a4fdc4ac05f9e53c57f965e3594b2f99796231380adb2baaab96e22761"},
-    {file = "charset_normalizer-3.3.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:2465aa50c9299d615d757c1c888bc6fef384b7c4aec81c05a0172b4400f98557"},
-    {file = "charset_normalizer-3.3.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:cb7cd68814308aade9d0c93c5bd2ade9f9441666f8ba5aa9c2d4b389cb5e2a45"},
-    {file = "charset_normalizer-3.3.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:91e43805ccafa0a91831f9cd5443aa34528c0c3f2cc48c4cb3d9a7721053874b"},
-    {file = "charset_normalizer-3.3.1-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:854cc74367180beb327ab9d00f964f6d91da06450b0855cbbb09187bcdb02de5"},
-    {file = "charset_normalizer-3.3.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c15070ebf11b8b7fd1bfff7217e9324963c82dbdf6182ff7050519e350e7ad9f"},
-    {file = "charset_normalizer-3.3.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2c4c99f98fc3a1835af8179dcc9013f93594d0670e2fa80c83aa36346ee763d2"},
-    {file = "charset_normalizer-3.3.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3fb765362688821404ad6cf86772fc54993ec11577cd5a92ac44b4c2ba52155b"},
-    {file = "charset_normalizer-3.3.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:dced27917823df984fe0c80a5c4ad75cf58df0fbfae890bc08004cd3888922a2"},
-    {file = "charset_normalizer-3.3.1-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:a66bcdf19c1a523e41b8e9d53d0cedbfbac2e93c649a2e9502cb26c014d0980c"},
-    {file = "charset_normalizer-3.3.1-cp38-cp38-musllinux_1_1_ppc64le.whl", hash = "sha256:ecd26be9f112c4f96718290c10f4caea6cc798459a3a76636b817a0ed7874e42"},
-    {file = "charset_normalizer-3.3.1-cp38-cp38-musllinux_1_1_s390x.whl", hash = "sha256:3f70fd716855cd3b855316b226a1ac8bdb3caf4f7ea96edcccc6f484217c9597"},
-    {file = "charset_normalizer-3.3.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:17a866d61259c7de1bdadef418a37755050ddb4b922df8b356503234fff7932c"},
-    {file = "charset_normalizer-3.3.1-cp38-cp38-win32.whl", hash = "sha256:548eefad783ed787b38cb6f9a574bd8664468cc76d1538215d510a3cd41406cb"},
-    {file = "charset_normalizer-3.3.1-cp38-cp38-win_amd64.whl", hash = "sha256:45f053a0ece92c734d874861ffe6e3cc92150e32136dd59ab1fb070575189c97"},
-    {file = "charset_normalizer-3.3.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:bc791ec3fd0c4309a753f95bb6c749ef0d8ea3aea91f07ee1cf06b7b02118f2f"},
-    {file = "charset_normalizer-3.3.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:0c8c61fb505c7dad1d251c284e712d4e0372cef3b067f7ddf82a7fa82e1e9a93"},
-    {file = "charset_normalizer-3.3.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:2c092be3885a1b7899cd85ce24acedc1034199d6fca1483fa2c3a35c86e43041"},
-    {file = "charset_normalizer-3.3.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c2000c54c395d9e5e44c99dc7c20a64dc371f777faf8bae4919ad3e99ce5253e"},
-    {file = "charset_normalizer-3.3.1-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4cb50a0335382aac15c31b61d8531bc9bb657cfd848b1d7158009472189f3d62"},
-    {file = "charset_normalizer-3.3.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c30187840d36d0ba2893bc3271a36a517a717f9fd383a98e2697ee890a37c273"},
-    {file = "charset_normalizer-3.3.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fe81b35c33772e56f4b6cf62cf4aedc1762ef7162a31e6ac7fe5e40d0149eb67"},
-    {file = "charset_normalizer-3.3.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d0bf89afcbcf4d1bb2652f6580e5e55a840fdf87384f6063c4a4f0c95e378656"},
-    {file = "charset_normalizer-3.3.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:06cf46bdff72f58645434d467bf5228080801298fbba19fe268a01b4534467f5"},
-    {file = "charset_normalizer-3.3.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:3c66df3f41abee950d6638adc7eac4730a306b022570f71dd0bd6ba53503ab57"},
-    {file = "charset_normalizer-3.3.1-cp39-cp39-musllinux_1_1_ppc64le.whl", hash = "sha256:cd805513198304026bd379d1d516afbf6c3c13f4382134a2c526b8b854da1c2e"},
-    {file = "charset_normalizer-3.3.1-cp39-cp39-musllinux_1_1_s390x.whl", hash = "sha256:9505dc359edb6a330efcd2be825fdb73ee3e628d9010597aa1aee5aa63442e97"},
-    {file = "charset_normalizer-3.3.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:31445f38053476a0c4e6d12b047b08ced81e2c7c712e5a1ad97bc913256f91b2"},
-    {file = "charset_normalizer-3.3.1-cp39-cp39-win32.whl", hash = "sha256:bd28b31730f0e982ace8663d108e01199098432a30a4c410d06fe08fdb9e93f4"},
-    {file = "charset_normalizer-3.3.1-cp39-cp39-win_amd64.whl", hash = "sha256:555fe186da0068d3354cdf4bbcbc609b0ecae4d04c921cc13e209eece7720727"},
-    {file = "charset_normalizer-3.3.1-py3-none-any.whl", hash = "sha256:800561453acdecedaac137bf09cd719c7a440b6800ec182f077bb8e7025fb708"},
+    {file = "charset-normalizer-3.3.2.tar.gz", hash = "sha256:f30c3cb33b24454a82faecaf01b19c18562b1e89558fb6c56de4d9118a032fd5"},
+    {file = "charset_normalizer-3.3.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:25baf083bf6f6b341f4121c2f3c548875ee6f5339300e08be3f2b2ba1721cdd3"},
+    {file = "charset_normalizer-3.3.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:06435b539f889b1f6f4ac1758871aae42dc3a8c0e24ac9e60c2384973ad73027"},
+    {file = "charset_normalizer-3.3.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9063e24fdb1e498ab71cb7419e24622516c4a04476b17a2dab57e8baa30d6e03"},
+    {file = "charset_normalizer-3.3.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6897af51655e3691ff853668779c7bad41579facacf5fd7253b0133308cf000d"},
+    {file = "charset_normalizer-3.3.2-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1d3193f4a680c64b4b6a9115943538edb896edc190f0b222e73761716519268e"},
+    {file = "charset_normalizer-3.3.2-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cd70574b12bb8a4d2aaa0094515df2463cb429d8536cfb6c7ce983246983e5a6"},
+    {file = "charset_normalizer-3.3.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8465322196c8b4d7ab6d1e049e4c5cb460d0394da4a27d23cc242fbf0034b6b5"},
+    {file = "charset_normalizer-3.3.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a9a8e9031d613fd2009c182b69c7b2c1ef8239a0efb1df3f7c8da66d5dd3d537"},
+    {file = "charset_normalizer-3.3.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:beb58fe5cdb101e3a055192ac291b7a21e3b7ef4f67fa1d74e331a7f2124341c"},
+    {file = "charset_normalizer-3.3.2-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:e06ed3eb3218bc64786f7db41917d4e686cc4856944f53d5bdf83a6884432e12"},
+    {file = "charset_normalizer-3.3.2-cp310-cp310-musllinux_1_1_ppc64le.whl", hash = "sha256:2e81c7b9c8979ce92ed306c249d46894776a909505d8f5a4ba55b14206e3222f"},
+    {file = "charset_normalizer-3.3.2-cp310-cp310-musllinux_1_1_s390x.whl", hash = "sha256:572c3763a264ba47b3cf708a44ce965d98555f618ca42c926a9c1616d8f34269"},
+    {file = "charset_normalizer-3.3.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:fd1abc0d89e30cc4e02e4064dc67fcc51bd941eb395c502aac3ec19fab46b519"},
+    {file = "charset_normalizer-3.3.2-cp310-cp310-win32.whl", hash = "sha256:3d47fa203a7bd9c5b6cee4736ee84ca03b8ef23193c0d1ca99b5089f72645c73"},
+    {file = "charset_normalizer-3.3.2-cp310-cp310-win_amd64.whl", hash = "sha256:10955842570876604d404661fbccbc9c7e684caf432c09c715ec38fbae45ae09"},
+    {file = "charset_normalizer-3.3.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:802fe99cca7457642125a8a88a084cef28ff0cf9407060f7b93dca5aa25480db"},
+    {file = "charset_normalizer-3.3.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:573f6eac48f4769d667c4442081b1794f52919e7edada77495aaed9236d13a96"},
+    {file = "charset_normalizer-3.3.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:549a3a73da901d5bc3ce8d24e0600d1fa85524c10287f6004fbab87672bf3e1e"},
+    {file = "charset_normalizer-3.3.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f27273b60488abe721a075bcca6d7f3964f9f6f067c8c4c605743023d7d3944f"},
+    {file = "charset_normalizer-3.3.2-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1ceae2f17a9c33cb48e3263960dc5fc8005351ee19db217e9b1bb15d28c02574"},
+    {file = "charset_normalizer-3.3.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:65f6f63034100ead094b8744b3b97965785388f308a64cf8d7c34f2f2e5be0c4"},
+    {file = "charset_normalizer-3.3.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:753f10e867343b4511128c6ed8c82f7bec3bd026875576dfd88483c5c73b2fd8"},
+    {file = "charset_normalizer-3.3.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4a78b2b446bd7c934f5dcedc588903fb2f5eec172f3d29e52a9096a43722adfc"},
+    {file = "charset_normalizer-3.3.2-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:e537484df0d8f426ce2afb2d0f8e1c3d0b114b83f8850e5f2fbea0e797bd82ae"},
+    {file = "charset_normalizer-3.3.2-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:eb6904c354526e758fda7167b33005998fb68c46fbc10e013ca97f21ca5c8887"},
+    {file = "charset_normalizer-3.3.2-cp311-cp311-musllinux_1_1_ppc64le.whl", hash = "sha256:deb6be0ac38ece9ba87dea880e438f25ca3eddfac8b002a2ec3d9183a454e8ae"},
+    {file = "charset_normalizer-3.3.2-cp311-cp311-musllinux_1_1_s390x.whl", hash = "sha256:4ab2fe47fae9e0f9dee8c04187ce5d09f48eabe611be8259444906793ab7cbce"},
+    {file = "charset_normalizer-3.3.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:80402cd6ee291dcb72644d6eac93785fe2c8b9cb30893c1af5b8fdd753b9d40f"},
+    {file = "charset_normalizer-3.3.2-cp311-cp311-win32.whl", hash = "sha256:7cd13a2e3ddeed6913a65e66e94b51d80a041145a026c27e6bb76c31a853c6ab"},
+    {file = "charset_normalizer-3.3.2-cp311-cp311-win_amd64.whl", hash = "sha256:663946639d296df6a2bb2aa51b60a2454ca1cb29835324c640dafb5ff2131a77"},
+    {file = "charset_normalizer-3.3.2-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:0b2b64d2bb6d3fb9112bafa732def486049e63de9618b5843bcdd081d8144cd8"},
+    {file = "charset_normalizer-3.3.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:ddbb2551d7e0102e7252db79ba445cdab71b26640817ab1e3e3648dad515003b"},
+    {file = "charset_normalizer-3.3.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:55086ee1064215781fff39a1af09518bc9255b50d6333f2e4c74ca09fac6a8f6"},
+    {file = "charset_normalizer-3.3.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8f4a014bc36d3c57402e2977dada34f9c12300af536839dc38c0beab8878f38a"},
+    {file = "charset_normalizer-3.3.2-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a10af20b82360ab00827f916a6058451b723b4e65030c5a18577c8b2de5b3389"},
+    {file = "charset_normalizer-3.3.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8d756e44e94489e49571086ef83b2bb8ce311e730092d2c34ca8f7d925cb20aa"},
+    {file = "charset_normalizer-3.3.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:90d558489962fd4918143277a773316e56c72da56ec7aa3dc3dbbe20fdfed15b"},
+    {file = "charset_normalizer-3.3.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6ac7ffc7ad6d040517be39eb591cac5ff87416c2537df6ba3cba3bae290c0fed"},
+    {file = "charset_normalizer-3.3.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:7ed9e526742851e8d5cc9e6cf41427dfc6068d4f5a3bb03659444b4cabf6bc26"},
+    {file = "charset_normalizer-3.3.2-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:8bdb58ff7ba23002a4c5808d608e4e6c687175724f54a5dade5fa8c67b604e4d"},
+    {file = "charset_normalizer-3.3.2-cp312-cp312-musllinux_1_1_ppc64le.whl", hash = "sha256:6b3251890fff30ee142c44144871185dbe13b11bab478a88887a639655be1068"},
+    {file = "charset_normalizer-3.3.2-cp312-cp312-musllinux_1_1_s390x.whl", hash = "sha256:b4a23f61ce87adf89be746c8a8974fe1c823c891d8f86eb218bb957c924bb143"},
+    {file = "charset_normalizer-3.3.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:efcb3f6676480691518c177e3b465bcddf57cea040302f9f4e6e191af91174d4"},
+    {file = "charset_normalizer-3.3.2-cp312-cp312-win32.whl", hash = "sha256:d965bba47ddeec8cd560687584e88cf699fd28f192ceb452d1d7ee807c5597b7"},
+    {file = "charset_normalizer-3.3.2-cp312-cp312-win_amd64.whl", hash = "sha256:96b02a3dc4381e5494fad39be677abcb5e6634bf7b4fa83a6dd3112607547001"},
+    {file = "charset_normalizer-3.3.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:95f2a5796329323b8f0512e09dbb7a1860c46a39da62ecb2324f116fa8fdc85c"},
+    {file = "charset_normalizer-3.3.2-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c002b4ffc0be611f0d9da932eb0f704fe2602a9a949d1f738e4c34c75b0863d5"},
+    {file = "charset_normalizer-3.3.2-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a981a536974bbc7a512cf44ed14938cf01030a99e9b3a06dd59578882f06f985"},
+    {file = "charset_normalizer-3.3.2-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3287761bc4ee9e33561a7e058c72ac0938c4f57fe49a09eae428fd88aafe7bb6"},
+    {file = "charset_normalizer-3.3.2-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:42cb296636fcc8b0644486d15c12376cb9fa75443e00fb25de0b8602e64c1714"},
+    {file = "charset_normalizer-3.3.2-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0a55554a2fa0d408816b3b5cedf0045f4b8e1a6065aec45849de2d6f3f8e9786"},
+    {file = "charset_normalizer-3.3.2-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:c083af607d2515612056a31f0a8d9e0fcb5876b7bfc0abad3ecd275bc4ebc2d5"},
+    {file = "charset_normalizer-3.3.2-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:87d1351268731db79e0f8e745d92493ee2841c974128ef629dc518b937d9194c"},
+    {file = "charset_normalizer-3.3.2-cp37-cp37m-musllinux_1_1_ppc64le.whl", hash = "sha256:bd8f7df7d12c2db9fab40bdd87a7c09b1530128315d047a086fa3ae3435cb3a8"},
+    {file = "charset_normalizer-3.3.2-cp37-cp37m-musllinux_1_1_s390x.whl", hash = "sha256:c180f51afb394e165eafe4ac2936a14bee3eb10debc9d9e4db8958fe36afe711"},
+    {file = "charset_normalizer-3.3.2-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:8c622a5fe39a48f78944a87d4fb8a53ee07344641b0562c540d840748571b811"},
+    {file = "charset_normalizer-3.3.2-cp37-cp37m-win32.whl", hash = "sha256:db364eca23f876da6f9e16c9da0df51aa4f104a972735574842618b8c6d999d4"},
+    {file = "charset_normalizer-3.3.2-cp37-cp37m-win_amd64.whl", hash = "sha256:86216b5cee4b06df986d214f664305142d9c76df9b6512be2738aa72a2048f99"},
+    {file = "charset_normalizer-3.3.2-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:6463effa3186ea09411d50efc7d85360b38d5f09b870c48e4600f63af490e56a"},
+    {file = "charset_normalizer-3.3.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:6c4caeef8fa63d06bd437cd4bdcf3ffefe6738fb1b25951440d80dc7df8c03ac"},
+    {file = "charset_normalizer-3.3.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:37e55c8e51c236f95b033f6fb391d7d7970ba5fe7ff453dad675e88cf303377a"},
+    {file = "charset_normalizer-3.3.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fb69256e180cb6c8a894fee62b3afebae785babc1ee98b81cdf68bbca1987f33"},
+    {file = "charset_normalizer-3.3.2-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ae5f4161f18c61806f411a13b0310bea87f987c7d2ecdbdaad0e94eb2e404238"},
+    {file = "charset_normalizer-3.3.2-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b2b0a0c0517616b6869869f8c581d4eb2dd83a4d79e0ebcb7d373ef9956aeb0a"},
+    {file = "charset_normalizer-3.3.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:45485e01ff4d3630ec0d9617310448a8702f70e9c01906b0d0118bdf9d124cf2"},
+    {file = "charset_normalizer-3.3.2-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:eb00ed941194665c332bf8e078baf037d6c35d7c4f3102ea2d4f16ca94a26dc8"},
+    {file = "charset_normalizer-3.3.2-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:2127566c664442652f024c837091890cb1942c30937add288223dc895793f898"},
+    {file = "charset_normalizer-3.3.2-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:a50aebfa173e157099939b17f18600f72f84eed3049e743b68ad15bd69b6bf99"},
+    {file = "charset_normalizer-3.3.2-cp38-cp38-musllinux_1_1_ppc64le.whl", hash = "sha256:4d0d1650369165a14e14e1e47b372cfcb31d6ab44e6e33cb2d4e57265290044d"},
+    {file = "charset_normalizer-3.3.2-cp38-cp38-musllinux_1_1_s390x.whl", hash = "sha256:923c0c831b7cfcb071580d3f46c4baf50f174be571576556269530f4bbd79d04"},
+    {file = "charset_normalizer-3.3.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:06a81e93cd441c56a9b65d8e1d043daeb97a3d0856d177d5c90ba85acb3db087"},
+    {file = "charset_normalizer-3.3.2-cp38-cp38-win32.whl", hash = "sha256:6ef1d82a3af9d3eecdba2321dc1b3c238245d890843e040e41e470ffa64c3e25"},
+    {file = "charset_normalizer-3.3.2-cp38-cp38-win_amd64.whl", hash = "sha256:eb8821e09e916165e160797a6c17edda0679379a4be5c716c260e836e122f54b"},
+    {file = "charset_normalizer-3.3.2-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:c235ebd9baae02f1b77bcea61bce332cb4331dc3617d254df3323aa01ab47bd4"},
+    {file = "charset_normalizer-3.3.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:5b4c145409bef602a690e7cfad0a15a55c13320ff7a3ad7ca59c13bb8ba4d45d"},
+    {file = "charset_normalizer-3.3.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:68d1f8a9e9e37c1223b656399be5d6b448dea850bed7d0f87a8311f1ff3dabb0"},
+    {file = "charset_normalizer-3.3.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:22afcb9f253dac0696b5a4be4a1c0f8762f8239e21b99680099abd9b2b1b2269"},
+    {file = "charset_normalizer-3.3.2-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e27ad930a842b4c5eb8ac0016b0a54f5aebbe679340c26101df33424142c143c"},
+    {file = "charset_normalizer-3.3.2-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1f79682fbe303db92bc2b1136016a38a42e835d932bab5b3b1bfcfbf0640e519"},
+    {file = "charset_normalizer-3.3.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b261ccdec7821281dade748d088bb6e9b69e6d15b30652b74cbbac25e280b796"},
+    {file = "charset_normalizer-3.3.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:122c7fa62b130ed55f8f285bfd56d5f4b4a5b503609d181f9ad85e55c89f4185"},
+    {file = "charset_normalizer-3.3.2-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:d0eccceffcb53201b5bfebb52600a5fb483a20b61da9dbc885f8b103cbe7598c"},
+    {file = "charset_normalizer-3.3.2-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:9f96df6923e21816da7e0ad3fd47dd8f94b2a5ce594e00677c0013018b813458"},
+    {file = "charset_normalizer-3.3.2-cp39-cp39-musllinux_1_1_ppc64le.whl", hash = "sha256:7f04c839ed0b6b98b1a7501a002144b76c18fb1c1850c8b98d458ac269e26ed2"},
+    {file = "charset_normalizer-3.3.2-cp39-cp39-musllinux_1_1_s390x.whl", hash = "sha256:34d1c8da1e78d2e001f363791c98a272bb734000fcef47a491c1e3b0505657a8"},
+    {file = "charset_normalizer-3.3.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:ff8fa367d09b717b2a17a052544193ad76cd49979c805768879cb63d9ca50561"},
+    {file = "charset_normalizer-3.3.2-cp39-cp39-win32.whl", hash = "sha256:aed38f6e4fb3f5d6bf81bfa990a07806be9d83cf7bacef998ab1a9bd660a581f"},
+    {file = "charset_normalizer-3.3.2-cp39-cp39-win_amd64.whl", hash = "sha256:b01b88d45a6fcb69667cd6d2f7a9aeb4bf53760d7fc536bf679ec94fe9f3ff3d"},
+    {file = "charset_normalizer-3.3.2-py3-none-any.whl", hash = "sha256:3e4d1f6587322d2788836a99c69062fbb091331ec940e02d12d179c1d53e25fc"},
 ]
 
 [[package]]
@@ -198,7 +193,6 @@ files = [
 
 [package.dependencies]
 colorama = {version = "*", markers = "platform_system == \"Windows\""}
-importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 
 [[package]]
 name = "colorama"
@@ -333,41 +327,40 @@ files = [
 
 [[package]]
 name = "importlib-metadata"
-version = "6.7.0"
+version = "6.8.0"
 description = "Read metadata from Python packages"
-optional = false
-python-versions = ">=3.7"
+optional = true
+python-versions = ">=3.8"
 files = [
-    {file = "importlib_metadata-6.7.0-py3-none-any.whl", hash = "sha256:cb52082e659e97afc5dac71e79de97d8681de3aa07ff18578330904a9d18e5b5"},
-    {file = "importlib_metadata-6.7.0.tar.gz", hash = "sha256:1aaf550d4f73e5d6783e7acb77aec43d49da8017410afae93822cc9cca98c4d4"},
+    {file = "importlib_metadata-6.8.0-py3-none-any.whl", hash = "sha256:3ebb78df84a805d7698245025b975d9d67053cd94c79245ba4b3eb694abe68bb"},
+    {file = "importlib_metadata-6.8.0.tar.gz", hash = "sha256:dbace7892d8c0c4ac1ad096662232f831d4e64f4c4545bd53016a3e9d4654743"},
 ]
 
 [package.dependencies]
-typing-extensions = {version = ">=3.6.4", markers = "python_version < \"3.8\""}
 zipp = ">=0.5"
 
 [package.extras]
 docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
 perf = ["ipython"]
-testing = ["flufl.flake8", "importlib-resources (>=1.3)", "packaging", "pyfakefs", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-mypy (>=0.9.1)", "pytest-perf (>=0.9.2)", "pytest-ruff"]
+testing = ["flufl.flake8", "importlib-resources (>=1.3)", "packaging", "pyfakefs", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy (>=0.9.1)", "pytest-perf (>=0.9.2)", "pytest-ruff"]
 
 [[package]]
 name = "importlib-resources"
-version = "5.12.0"
+version = "6.1.0"
 description = "Read resources from Python packages"
 optional = true
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "importlib_resources-5.12.0-py3-none-any.whl", hash = "sha256:7b1deeebbf351c7578e09bf2f63fa2ce8b5ffec296e0d349139d43cca061a81a"},
-    {file = "importlib_resources-5.12.0.tar.gz", hash = "sha256:4be82589bf5c1d7999aedf2a45159d10cb3ca4f19b2271f8792bc8e6da7b22f6"},
+    {file = "importlib_resources-6.1.0-py3-none-any.whl", hash = "sha256:aa50258bbfa56d4e33fbd8aa3ef48ded10d1735f11532b8df95388cc6bdb7e83"},
+    {file = "importlib_resources-6.1.0.tar.gz", hash = "sha256:9d48dcccc213325e810fd723e7fbb45ccb39f6cf5c31f00cf2b965f5f10f3cb9"},
 ]
 
 [package.dependencies]
 zipp = {version = ">=3.1.0", markers = "python_version < \"3.10\""}
 
 [package.extras]
-docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
-testing = ["flake8 (<5)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)"]
+docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (<7.2.5)", "sphinx (>=3.5)", "sphinx-lint"]
+testing = ["pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy (>=0.9.1)", "pytest-ruff", "zipp (>=3.17)"]
 
 [[package]]
 name = "iniconfig"
@@ -382,65 +375,20 @@ files = [
 
 [[package]]
 name = "isort"
-version = "5.11.5"
+version = "5.12.0"
 description = "A Python utility / library to sort Python imports."
 optional = false
-python-versions = ">=3.7.0"
+python-versions = ">=3.8.0"
 files = [
-    {file = "isort-5.11.5-py3-none-any.whl", hash = "sha256:ba1d72fb2595a01c7895a5128f9585a5cc4b6d395f1c8d514989b9a7eb2a8746"},
-    {file = "isort-5.11.5.tar.gz", hash = "sha256:6be1f76a507cb2ecf16c7cf14a37e41609ca082330be4e3436a18ef74add55db"},
+    {file = "isort-5.12.0-py3-none-any.whl", hash = "sha256:f84c2818376e66cf843d497486ea8fed8700b340f308f076c6fb1229dff318b6"},
+    {file = "isort-5.12.0.tar.gz", hash = "sha256:8bef7dde241278824a6d83f44a544709b065191b95b6e50894bdc722fcba0504"},
 ]
 
 [package.extras]
-colors = ["colorama (>=0.4.3,<0.5.0)"]
+colors = ["colorama (>=0.4.3)"]
 pipfile-deprecated-finder = ["pip-shims (>=0.5.2)", "pipreqs", "requirementslib"]
 plugins = ["setuptools"]
 requirements-deprecated-finder = ["pip-api", "pipreqs"]
-
-[[package]]
-name = "lazy-object-proxy"
-version = "1.9.0"
-description = "A fast and thorough lazy object proxy."
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "lazy-object-proxy-1.9.0.tar.gz", hash = "sha256:659fb5809fa4629b8a1ac5106f669cfc7bef26fbb389dda53b3e010d1ac4ebae"},
-    {file = "lazy_object_proxy-1.9.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:b40387277b0ed2d0602b8293b94d7257e17d1479e257b4de114ea11a8cb7f2d7"},
-    {file = "lazy_object_proxy-1.9.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e8c6cfb338b133fbdbc5cfaa10fe3c6aeea827db80c978dbd13bc9dd8526b7d4"},
-    {file = "lazy_object_proxy-1.9.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:721532711daa7db0d8b779b0bb0318fa87af1c10d7fe5e52ef30f8eff254d0cd"},
-    {file = "lazy_object_proxy-1.9.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:66a3de4a3ec06cd8af3f61b8e1ec67614fbb7c995d02fa224813cb7afefee701"},
-    {file = "lazy_object_proxy-1.9.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:1aa3de4088c89a1b69f8ec0dcc169aa725b0ff017899ac568fe44ddc1396df46"},
-    {file = "lazy_object_proxy-1.9.0-cp310-cp310-win32.whl", hash = "sha256:f0705c376533ed2a9e5e97aacdbfe04cecd71e0aa84c7c0595d02ef93b6e4455"},
-    {file = "lazy_object_proxy-1.9.0-cp310-cp310-win_amd64.whl", hash = "sha256:ea806fd4c37bf7e7ad82537b0757999264d5f70c45468447bb2b91afdbe73a6e"},
-    {file = "lazy_object_proxy-1.9.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:946d27deaff6cf8452ed0dba83ba38839a87f4f7a9732e8f9fd4107b21e6ff07"},
-    {file = "lazy_object_proxy-1.9.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:79a31b086e7e68b24b99b23d57723ef7e2c6d81ed21007b6281ebcd1688acb0a"},
-    {file = "lazy_object_proxy-1.9.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f699ac1c768270c9e384e4cbd268d6e67aebcfae6cd623b4d7c3bfde5a35db59"},
-    {file = "lazy_object_proxy-1.9.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:bfb38f9ffb53b942f2b5954e0f610f1e721ccebe9cce9025a38c8ccf4a5183a4"},
-    {file = "lazy_object_proxy-1.9.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:189bbd5d41ae7a498397287c408617fe5c48633e7755287b21d741f7db2706a9"},
-    {file = "lazy_object_proxy-1.9.0-cp311-cp311-win32.whl", hash = "sha256:81fc4d08b062b535d95c9ea70dbe8a335c45c04029878e62d744bdced5141586"},
-    {file = "lazy_object_proxy-1.9.0-cp311-cp311-win_amd64.whl", hash = "sha256:f2457189d8257dd41ae9b434ba33298aec198e30adf2dcdaaa3a28b9994f6adb"},
-    {file = "lazy_object_proxy-1.9.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:d9e25ef10a39e8afe59a5c348a4dbf29b4868ab76269f81ce1674494e2565a6e"},
-    {file = "lazy_object_proxy-1.9.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cbf9b082426036e19c6924a9ce90c740a9861e2bdc27a4834fd0a910742ac1e8"},
-    {file = "lazy_object_proxy-1.9.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9f5fa4a61ce2438267163891961cfd5e32ec97a2c444e5b842d574251ade27d2"},
-    {file = "lazy_object_proxy-1.9.0-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:8fa02eaab317b1e9e03f69aab1f91e120e7899b392c4fc19807a8278a07a97e8"},
-    {file = "lazy_object_proxy-1.9.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:e7c21c95cae3c05c14aafffe2865bbd5e377cfc1348c4f7751d9dc9a48ca4bda"},
-    {file = "lazy_object_proxy-1.9.0-cp37-cp37m-win32.whl", hash = "sha256:f12ad7126ae0c98d601a7ee504c1122bcef553d1d5e0c3bfa77b16b3968d2734"},
-    {file = "lazy_object_proxy-1.9.0-cp37-cp37m-win_amd64.whl", hash = "sha256:edd20c5a55acb67c7ed471fa2b5fb66cb17f61430b7a6b9c3b4a1e40293b1671"},
-    {file = "lazy_object_proxy-1.9.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:2d0daa332786cf3bb49e10dc6a17a52f6a8f9601b4cf5c295a4f85854d61de63"},
-    {file = "lazy_object_proxy-1.9.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9cd077f3d04a58e83d04b20e334f678c2b0ff9879b9375ed107d5d07ff160171"},
-    {file = "lazy_object_proxy-1.9.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:660c94ea760b3ce47d1855a30984c78327500493d396eac4dfd8bd82041b22be"},
-    {file = "lazy_object_proxy-1.9.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:212774e4dfa851e74d393a2370871e174d7ff0ebc980907723bb67d25c8a7c30"},
-    {file = "lazy_object_proxy-1.9.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:f0117049dd1d5635bbff65444496c90e0baa48ea405125c088e93d9cf4525b11"},
-    {file = "lazy_object_proxy-1.9.0-cp38-cp38-win32.whl", hash = "sha256:0a891e4e41b54fd5b8313b96399f8b0e173bbbfc03c7631f01efbe29bb0bcf82"},
-    {file = "lazy_object_proxy-1.9.0-cp38-cp38-win_amd64.whl", hash = "sha256:9990d8e71b9f6488e91ad25f322898c136b008d87bf852ff65391b004da5e17b"},
-    {file = "lazy_object_proxy-1.9.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:9e7551208b2aded9c1447453ee366f1c4070602b3d932ace044715d89666899b"},
-    {file = "lazy_object_proxy-1.9.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5f83ac4d83ef0ab017683d715ed356e30dd48a93746309c8f3517e1287523ef4"},
-    {file = "lazy_object_proxy-1.9.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7322c3d6f1766d4ef1e51a465f47955f1e8123caee67dd641e67d539a534d006"},
-    {file = "lazy_object_proxy-1.9.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:18b78ec83edbbeb69efdc0e9c1cb41a3b1b1ed11ddd8ded602464c3fc6020494"},
-    {file = "lazy_object_proxy-1.9.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:09763491ce220c0299688940f8dc2c5d05fd1f45af1e42e636b2e8b2303e4382"},
-    {file = "lazy_object_proxy-1.9.0-cp39-cp39-win32.whl", hash = "sha256:9090d8e53235aa280fc9239a86ae3ea8ac58eff66a705fa6aa2ec4968b95c821"},
-    {file = "lazy_object_proxy-1.9.0-cp39-cp39-win_amd64.whl", hash = "sha256:db1c1722726f47e10e0b5fdbf15ac3b8adb58c091d12b3ab713965795036985f"},
-]
 
 [[package]]
 name = "lz4"
@@ -503,7 +451,6 @@ files = [
 ]
 
 [package.dependencies]
-importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 MarkupSafe = ">=0.9.2"
 
 [package.extras]
@@ -617,7 +564,6 @@ files = [
 [package.dependencies]
 mypy-extensions = ">=0.4.3"
 tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
-typed-ast = {version = ">=1.4.0,<2", markers = "python_version < \"3.8\""}
 typing-extensions = ">=3.10"
 
 [package.extras]
@@ -638,42 +584,39 @@ files = [
 
 [[package]]
 name = "numpy"
-version = "1.21.6"
-description = "NumPy is the fundamental package for array computing with Python."
+version = "1.24.4"
+description = "Fundamental package for array computing in Python"
 optional = false
-python-versions = ">=3.7,<3.11"
+python-versions = ">=3.8"
 files = [
-    {file = "numpy-1.21.6-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:8737609c3bbdd48e380d463134a35ffad3b22dc56295eff6f79fd85bd0eeeb25"},
-    {file = "numpy-1.21.6-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:fdffbfb6832cd0b300995a2b08b8f6fa9f6e856d562800fea9182316d99c4e8e"},
-    {file = "numpy-1.21.6-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:3820724272f9913b597ccd13a467cc492a0da6b05df26ea09e78b171a0bb9da6"},
-    {file = "numpy-1.21.6-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f17e562de9edf691a42ddb1eb4a5541c20dd3f9e65b09ded2beb0799c0cf29bb"},
-    {file = "numpy-1.21.6-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5f30427731561ce75d7048ac254dbe47a2ba576229250fb60f0fb74db96501a1"},
-    {file = "numpy-1.21.6-cp310-cp310-win32.whl", hash = "sha256:d4bf4d43077db55589ffc9009c0ba0a94fa4908b9586d6ccce2e0b164c86303c"},
-    {file = "numpy-1.21.6-cp310-cp310-win_amd64.whl", hash = "sha256:d136337ae3cc69aa5e447e78d8e1514be8c3ec9b54264e680cf0b4bd9011574f"},
-    {file = "numpy-1.21.6-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:6aaf96c7f8cebc220cdfc03f1d5a31952f027dda050e5a703a0d1c396075e3e7"},
-    {file = "numpy-1.21.6-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:67c261d6c0a9981820c3a149d255a76918278a6b03b6a036800359aba1256d46"},
-    {file = "numpy-1.21.6-cp37-cp37m-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:a6be4cb0ef3b8c9250c19cc122267263093eee7edd4e3fa75395dfda8c17a8e2"},
-    {file = "numpy-1.21.6-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7c4068a8c44014b2d55f3c3f574c376b2494ca9cc73d2f1bd692382b6dffe3db"},
-    {file = "numpy-1.21.6-cp37-cp37m-win32.whl", hash = "sha256:7c7e5fa88d9ff656e067876e4736379cc962d185d5cd808014a8a928d529ef4e"},
-    {file = "numpy-1.21.6-cp37-cp37m-win_amd64.whl", hash = "sha256:bcb238c9c96c00d3085b264e5c1a1207672577b93fa666c3b14a45240b14123a"},
-    {file = "numpy-1.21.6-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:82691fda7c3f77c90e62da69ae60b5ac08e87e775b09813559f8901a88266552"},
-    {file = "numpy-1.21.6-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:643843bcc1c50526b3a71cd2ee561cf0d8773f062c8cbaf9ffac9fdf573f83ab"},
-    {file = "numpy-1.21.6-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:357768c2e4451ac241465157a3e929b265dfac85d9214074985b1786244f2ef3"},
-    {file = "numpy-1.21.6-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:9f411b2c3f3d76bba0865b35a425157c5dcf54937f82bbeb3d3c180789dd66a6"},
-    {file = "numpy-1.21.6-cp38-cp38-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:4aa48afdce4660b0076a00d80afa54e8a97cd49f457d68a4342d188a09451c1a"},
-    {file = "numpy-1.21.6-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d6a96eef20f639e6a97d23e57dd0c1b1069a7b4fd7027482a4c5c451cd7732f4"},
-    {file = "numpy-1.21.6-cp38-cp38-win32.whl", hash = "sha256:5c3c8def4230e1b959671eb959083661b4a0d2e9af93ee339c7dada6759a9470"},
-    {file = "numpy-1.21.6-cp38-cp38-win_amd64.whl", hash = "sha256:bf2ec4b75d0e9356edea834d1de42b31fe11f726a81dfb2c2112bc1eaa508fcf"},
-    {file = "numpy-1.21.6-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:4391bd07606be175aafd267ef9bea87cf1b8210c787666ce82073b05f202add1"},
-    {file = "numpy-1.21.6-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:67f21981ba2f9d7ba9ade60c9e8cbaa8cf8e9ae51673934480e45cf55e953673"},
-    {file = "numpy-1.21.6-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:ee5ec40fdd06d62fe5d4084bef4fd50fd4bb6bfd2bf519365f569dc470163ab0"},
-    {file = "numpy-1.21.6-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:1dbe1c91269f880e364526649a52eff93ac30035507ae980d2fed33aaee633ac"},
-    {file = "numpy-1.21.6-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:d9caa9d5e682102453d96a0ee10c7241b72859b01a941a397fd965f23b3e016b"},
-    {file = "numpy-1.21.6-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:58459d3bad03343ac4b1b42ed14d571b8743dc80ccbf27444f266729df1d6f5b"},
-    {file = "numpy-1.21.6-cp39-cp39-win32.whl", hash = "sha256:7f5ae4f304257569ef3b948810816bc87c9146e8c446053539947eedeaa32786"},
-    {file = "numpy-1.21.6-cp39-cp39-win_amd64.whl", hash = "sha256:e31f0bb5928b793169b87e3d1e070f2342b22d5245c755e2b81caa29756246c3"},
-    {file = "numpy-1.21.6-pp37-pypy37_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:dd1c8f6bd65d07d3810b90d02eba7997e32abbdf1277a481d698969e921a3be0"},
-    {file = "numpy-1.21.6.zip", hash = "sha256:ecb55251139706669fdec2ff073c98ef8e9a84473e51e716211b41aa0f18e656"},
+    {file = "numpy-1.24.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:c0bfb52d2169d58c1cdb8cc1f16989101639b34c7d3ce60ed70b19c63eba0b64"},
+    {file = "numpy-1.24.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ed094d4f0c177b1b8e7aa9cba7d6ceed51c0e569a5318ac0ca9a090680a6a1b1"},
+    {file = "numpy-1.24.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:79fc682a374c4a8ed08b331bef9c5f582585d1048fa6d80bc6c35bc384eee9b4"},
+    {file = "numpy-1.24.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7ffe43c74893dbf38c2b0a1f5428760a1a9c98285553c89e12d70a96a7f3a4d6"},
+    {file = "numpy-1.24.4-cp310-cp310-win32.whl", hash = "sha256:4c21decb6ea94057331e111a5bed9a79d335658c27ce2adb580fb4d54f2ad9bc"},
+    {file = "numpy-1.24.4-cp310-cp310-win_amd64.whl", hash = "sha256:b4bea75e47d9586d31e892a7401f76e909712a0fd510f58f5337bea9572c571e"},
+    {file = "numpy-1.24.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f136bab9c2cfd8da131132c2cf6cc27331dd6fae65f95f69dcd4ae3c3639c810"},
+    {file = "numpy-1.24.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e2926dac25b313635e4d6cf4dc4e51c8c0ebfed60b801c799ffc4c32bf3d1254"},
+    {file = "numpy-1.24.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:222e40d0e2548690405b0b3c7b21d1169117391c2e82c378467ef9ab4c8f0da7"},
+    {file = "numpy-1.24.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7215847ce88a85ce39baf9e89070cb860c98fdddacbaa6c0da3ffb31b3350bd5"},
+    {file = "numpy-1.24.4-cp311-cp311-win32.whl", hash = "sha256:4979217d7de511a8d57f4b4b5b2b965f707768440c17cb70fbf254c4b225238d"},
+    {file = "numpy-1.24.4-cp311-cp311-win_amd64.whl", hash = "sha256:b7b1fc9864d7d39e28f41d089bfd6353cb5f27ecd9905348c24187a768c79694"},
+    {file = "numpy-1.24.4-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:1452241c290f3e2a312c137a9999cdbf63f78864d63c79039bda65ee86943f61"},
+    {file = "numpy-1.24.4-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:04640dab83f7c6c85abf9cd729c5b65f1ebd0ccf9de90b270cd61935eef0197f"},
+    {file = "numpy-1.24.4-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a5425b114831d1e77e4b5d812b69d11d962e104095a5b9c3b641a218abcc050e"},
+    {file = "numpy-1.24.4-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dd80e219fd4c71fc3699fc1dadac5dcf4fd882bfc6f7ec53d30fa197b8ee22dc"},
+    {file = "numpy-1.24.4-cp38-cp38-win32.whl", hash = "sha256:4602244f345453db537be5314d3983dbf5834a9701b7723ec28923e2889e0bb2"},
+    {file = "numpy-1.24.4-cp38-cp38-win_amd64.whl", hash = "sha256:692f2e0f55794943c5bfff12b3f56f99af76f902fc47487bdfe97856de51a706"},
+    {file = "numpy-1.24.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:2541312fbf09977f3b3ad449c4e5f4bb55d0dbf79226d7724211acc905049400"},
+    {file = "numpy-1.24.4-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:9667575fb6d13c95f1b36aca12c5ee3356bf001b714fc354eb5465ce1609e62f"},
+    {file = "numpy-1.24.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f3a86ed21e4f87050382c7bc96571755193c4c1392490744ac73d660e8f564a9"},
+    {file = "numpy-1.24.4-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d11efb4dbecbdf22508d55e48d9c8384db795e1b7b51ea735289ff96613ff74d"},
+    {file = "numpy-1.24.4-cp39-cp39-win32.whl", hash = "sha256:6620c0acd41dbcb368610bb2f4d83145674040025e5536954782467100aa8835"},
+    {file = "numpy-1.24.4-cp39-cp39-win_amd64.whl", hash = "sha256:befe2bf740fd8373cf56149a5c23a0f601e82869598d41f8e188a0e9869926f8"},
+    {file = "numpy-1.24.4-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:31f13e25b4e304632a4619d0e0777662c2ffea99fcae2029556b17d8ff958aef"},
+    {file = "numpy-1.24.4-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:95f7ac6540e95bc440ad77f56e520da5bf877f87dca58bd095288dce8940532a"},
+    {file = "numpy-1.24.4-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:e98f220aa76ca2a977fe435f5b04d7b3470c0a2e6312907b37ba6068f26787f2"},
+    {file = "numpy-1.24.4.tar.gz", hash = "sha256:80f5e3a4e498641401868df4208b74581206afbee7cf7b8329daae82676d9463"},
 ]
 
 [[package]]
@@ -750,52 +693,6 @@ files = [
     {file = "packaging-23.2-py3-none-any.whl", hash = "sha256:8c491190033a9af7e1d931d0b5dacc2ef47509b34dd0de67ed209b5203fc88c7"},
     {file = "packaging-23.2.tar.gz", hash = "sha256:048fb0e9405036518eaaf48a55953c750c11e1a1b68e0dd1a9d62ed0c092cfc5"},
 ]
-
-[[package]]
-name = "pandas"
-version = "1.3.5"
-description = "Powerful data structures for data analysis, time series, and statistics"
-optional = false
-python-versions = ">=3.7.1"
-files = [
-    {file = "pandas-1.3.5-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:62d5b5ce965bae78f12c1c0df0d387899dd4211ec0bdc52822373f13a3a022b9"},
-    {file = "pandas-1.3.5-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:adfeb11be2d54f275142c8ba9bf67acee771b7186a5745249c7d5a06c670136b"},
-    {file = "pandas-1.3.5-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:60a8c055d58873ad81cae290d974d13dd479b82cbb975c3e1fa2cf1920715296"},
-    {file = "pandas-1.3.5-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fd541ab09e1f80a2a1760032d665f6e032d8e44055d602d65eeea6e6e85498cb"},
-    {file = "pandas-1.3.5-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2651d75b9a167cc8cc572cf787ab512d16e316ae00ba81874b560586fa1325e0"},
-    {file = "pandas-1.3.5-cp310-cp310-win_amd64.whl", hash = "sha256:aaf183a615ad790801fa3cf2fa450e5b6d23a54684fe386f7e3208f8b9bfbef6"},
-    {file = "pandas-1.3.5-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:344295811e67f8200de2390093aeb3c8309f5648951b684d8db7eee7d1c81fb7"},
-    {file = "pandas-1.3.5-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:552020bf83b7f9033b57cbae65589c01e7ef1544416122da0c79140c93288f56"},
-    {file = "pandas-1.3.5-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5cce0c6bbeb266b0e39e35176ee615ce3585233092f685b6a82362523e59e5b4"},
-    {file = "pandas-1.3.5-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7d28a3c65463fd0d0ba8bbb7696b23073efee0510783340a44b08f5e96ffce0c"},
-    {file = "pandas-1.3.5-cp37-cp37m-win32.whl", hash = "sha256:a62949c626dd0ef7de11de34b44c6475db76995c2064e2d99c6498c3dba7fe58"},
-    {file = "pandas-1.3.5-cp37-cp37m-win_amd64.whl", hash = "sha256:8025750767e138320b15ca16d70d5cdc1886e8f9cc56652d89735c016cd8aea6"},
-    {file = "pandas-1.3.5-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:fe95bae4e2d579812865db2212bb733144e34d0c6785c0685329e5b60fcb85dd"},
-    {file = "pandas-1.3.5-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5f261553a1e9c65b7a310302b9dbac31cf0049a51695c14ebe04e4bfd4a96f02"},
-    {file = "pandas-1.3.5-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8b6dbec5f3e6d5dc80dcfee250e0a2a652b3f28663492f7dab9a24416a48ac39"},
-    {file = "pandas-1.3.5-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d3bc49af96cd6285030a64779de5b3688633a07eb75c124b0747134a63f4c05f"},
-    {file = "pandas-1.3.5-cp38-cp38-win32.whl", hash = "sha256:b6b87b2fb39e6383ca28e2829cddef1d9fc9e27e55ad91ca9c435572cdba51bf"},
-    {file = "pandas-1.3.5-cp38-cp38-win_amd64.whl", hash = "sha256:a395692046fd8ce1edb4c6295c35184ae0c2bbe787ecbe384251da609e27edcb"},
-    {file = "pandas-1.3.5-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:bd971a3f08b745a75a86c00b97f3007c2ea175951286cdda6abe543e687e5f2f"},
-    {file = "pandas-1.3.5-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:37f06b59e5bc05711a518aa10beaec10942188dccb48918bb5ae602ccbc9f1a0"},
-    {file = "pandas-1.3.5-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2c21778a688d3712d35710501f8001cdbf96eb70a7c587a3d5613573299fdca6"},
-    {file = "pandas-1.3.5-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3345343206546545bc26a05b4602b6a24385b5ec7c75cb6059599e3d56831da2"},
-    {file = "pandas-1.3.5-cp39-cp39-win32.whl", hash = "sha256:c69406a2808ba6cf580c2255bcf260b3f214d2664a3a4197d0e640f573b46fd3"},
-    {file = "pandas-1.3.5-cp39-cp39-win_amd64.whl", hash = "sha256:32e1a26d5ade11b547721a72f9bfc4bd113396947606e00d5b4a5b79b3dcb006"},
-    {file = "pandas-1.3.5.tar.gz", hash = "sha256:1e4285f5de1012de20ca46b188ccf33521bff61ba5c5ebd78b4fb28e5416a9f1"},
-]
-
-[package.dependencies]
-numpy = [
-    {version = ">=1.17.3", markers = "(platform_machine != \"aarch64\" and platform_machine != \"arm64\") and python_version < \"3.10\""},
-    {version = ">=1.19.2", markers = "platform_machine == \"aarch64\" and python_version < \"3.10\""},
-    {version = ">=1.20.0", markers = "platform_machine == \"arm64\" and python_version < \"3.10\""},
-]
-python-dateutil = ">=2.7.3"
-pytz = ">=2017.3"
-
-[package.extras]
-test = ["hypothesis (>=3.58)", "pytest (>=6.0)", "pytest-xdist"]
 
 [[package]]
 name = "pandas"
@@ -886,26 +783,20 @@ files = [
     {file = "platformdirs-3.11.0.tar.gz", hash = "sha256:cf8ee52a3afdb965072dcc652433e0c7e3e40cf5ea1477cd4b3b1d2eb75495b3"},
 ]
 
-[package.dependencies]
-typing-extensions = {version = ">=4.7.1", markers = "python_version < \"3.8\""}
-
 [package.extras]
 docs = ["furo (>=2023.7.26)", "proselint (>=0.13)", "sphinx (>=7.1.1)", "sphinx-autodoc-typehints (>=1.24)"]
 test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=7.4)", "pytest-cov (>=4.1)", "pytest-mock (>=3.11.1)"]
 
 [[package]]
 name = "pluggy"
-version = "1.2.0"
+version = "1.3.0"
 description = "plugin and hook calling mechanisms for python"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "pluggy-1.2.0-py3-none-any.whl", hash = "sha256:c2fd55a7d7a3863cba1a013e4e2414658b1d07b6bc57b3919e0c63c9abb99849"},
-    {file = "pluggy-1.2.0.tar.gz", hash = "sha256:d12f0c4b579b15f5e054301bb226ee85eeeba08ffec228092f8defbaa3a4c4b3"},
+    {file = "pluggy-1.3.0-py3-none-any.whl", hash = "sha256:d89c696a773f8bd377d18e5ecda92b7a3793cbe66c87060a6fb58c7b6e1061f7"},
+    {file = "pluggy-1.3.0.tar.gz", hash = "sha256:cf61ae8f126ac6f7c451172cf30e3e43d3ca77615509771b3a984a0730651e12"},
 ]
-
-[package.dependencies]
-importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 
 [package.extras]
 dev = ["pre-commit", "tox"]
@@ -913,77 +804,47 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "pyarrow"
-version = "12.0.1"
-description = "Python library for Apache Arrow"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "pyarrow-12.0.1-cp310-cp310-macosx_10_14_x86_64.whl", hash = "sha256:6d288029a94a9bb5407ceebdd7110ba398a00412c5b0155ee9813a40d246c5df"},
-    {file = "pyarrow-12.0.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:345e1828efdbd9aa4d4de7d5676778aba384a2c3add896d995b23d368e60e5af"},
-    {file = "pyarrow-12.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8d6009fdf8986332b2169314da482baed47ac053311c8934ac6651e614deacd6"},
-    {file = "pyarrow-12.0.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2d3c4cbbf81e6dd23fe921bc91dc4619ea3b79bc58ef10bce0f49bdafb103daf"},
-    {file = "pyarrow-12.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:cdacf515ec276709ac8042c7d9bd5be83b4f5f39c6c037a17a60d7ebfd92c890"},
-    {file = "pyarrow-12.0.1-cp311-cp311-macosx_10_14_x86_64.whl", hash = "sha256:749be7fd2ff260683f9cc739cb862fb11be376de965a2a8ccbf2693b098db6c7"},
-    {file = "pyarrow-12.0.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:6895b5fb74289d055c43db3af0de6e16b07586c45763cb5e558d38b86a91e3a7"},
-    {file = "pyarrow-12.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1887bdae17ec3b4c046fcf19951e71b6a619f39fa674f9881216173566c8f718"},
-    {file = "pyarrow-12.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e2c9cb8eeabbadf5fcfc3d1ddea616c7ce893db2ce4dcef0ac13b099ad7ca082"},
-    {file = "pyarrow-12.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:ce4aebdf412bd0eeb800d8e47db854f9f9f7e2f5a0220440acf219ddfddd4f63"},
-    {file = "pyarrow-12.0.1-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:e0d8730c7f6e893f6db5d5b86eda42c0a130842d101992b581e2138e4d5663d3"},
-    {file = "pyarrow-12.0.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:43364daec02f69fec89d2315f7fbfbeec956e0d991cbbef471681bd77875c40f"},
-    {file = "pyarrow-12.0.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:051f9f5ccf585f12d7de836e50965b3c235542cc896959320d9776ab93f3b33d"},
-    {file = "pyarrow-12.0.1-cp37-cp37m-win_amd64.whl", hash = "sha256:be2757e9275875d2a9c6e6052ac7957fbbfc7bc7370e4a036a9b893e96fedaba"},
-    {file = "pyarrow-12.0.1-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:cf812306d66f40f69e684300f7af5111c11f6e0d89d6b733e05a3de44961529d"},
-    {file = "pyarrow-12.0.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:459a1c0ed2d68671188b2118c63bac91eaef6fc150c77ddd8a583e3c795737bf"},
-    {file = "pyarrow-12.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:85e705e33eaf666bbe508a16fd5ba27ca061e177916b7a317ba5a51bee43384c"},
-    {file = "pyarrow-12.0.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9120c3eb2b1f6f516a3b7a9714ed860882d9ef98c4b17edcdc91d95b7528db60"},
-    {file = "pyarrow-12.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:c780f4dc40460015d80fcd6a6140de80b615349ed68ef9adb653fe351778c9b3"},
-    {file = "pyarrow-12.0.1-cp39-cp39-macosx_10_14_x86_64.whl", hash = "sha256:a3c63124fc26bf5f95f508f5d04e1ece8cc23a8b0af2a1e6ab2b1ec3fdc91b24"},
-    {file = "pyarrow-12.0.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:b13329f79fa4472324f8d32dc1b1216616d09bd1e77cfb13104dec5463632c36"},
-    {file = "pyarrow-12.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bb656150d3d12ec1396f6dde542db1675a95c0cc8366d507347b0beed96e87ca"},
-    {file = "pyarrow-12.0.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6251e38470da97a5b2e00de5c6a049149f7b2bd62f12fa5dbb9ac674119ba71a"},
-    {file = "pyarrow-12.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:3de26da901216149ce086920547dfff5cd22818c9eab67ebc41e863a5883bac7"},
-    {file = "pyarrow-12.0.1.tar.gz", hash = "sha256:cce317fc96e5b71107bf1f9f184d5e54e2bd14bbf3f9a3d62819961f0af86fec"},
-]
-
-[package.dependencies]
-numpy = ">=1.16.6"
-
-[[package]]
-name = "pyarrow"
-version = "13.0.0"
+version = "14.0.0"
 description = "Python library for Apache Arrow"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pyarrow-13.0.0-cp310-cp310-macosx_10_14_x86_64.whl", hash = "sha256:1afcc2c33f31f6fb25c92d50a86b7a9f076d38acbcb6f9e74349636109550148"},
-    {file = "pyarrow-13.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:70fa38cdc66b2fc1349a082987f2b499d51d072faaa6b600f71931150de2e0e3"},
-    {file = "pyarrow-13.0.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cd57b13a6466822498238877892a9b287b0a58c2e81e4bdb0b596dbb151cbb73"},
-    {file = "pyarrow-13.0.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f8ce69f7bf01de2e2764e14df45b8404fc6f1a5ed9871e8e08a12169f87b7a26"},
-    {file = "pyarrow-13.0.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:588f0d2da6cf1b1680974d63be09a6530fd1bd825dc87f76e162404779a157dc"},
-    {file = "pyarrow-13.0.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:6241afd72b628787b4abea39e238e3ff9f34165273fad306c7acf780dd850956"},
-    {file = "pyarrow-13.0.0-cp310-cp310-win_amd64.whl", hash = "sha256:fda7857e35993673fcda603c07d43889fca60a5b254052a462653f8656c64f44"},
-    {file = "pyarrow-13.0.0-cp311-cp311-macosx_10_14_x86_64.whl", hash = "sha256:aac0ae0146a9bfa5e12d87dda89d9ef7c57a96210b899459fc2f785303dcbb67"},
-    {file = "pyarrow-13.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d7759994217c86c161c6a8060509cfdf782b952163569606bb373828afdd82e8"},
-    {file = "pyarrow-13.0.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:868a073fd0ff6468ae7d869b5fc1f54de5c4255b37f44fb890385eb68b68f95d"},
-    {file = "pyarrow-13.0.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:51be67e29f3cfcde263a113c28e96aa04362ed8229cb7c6e5f5c719003659d33"},
-    {file = "pyarrow-13.0.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:d1b4e7176443d12610874bb84d0060bf080f000ea9ed7c84b2801df851320295"},
-    {file = "pyarrow-13.0.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:69b6f9a089d116a82c3ed819eea8fe67dae6105f0d81eaf0fdd5e60d0c6e0944"},
-    {file = "pyarrow-13.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:ab1268db81aeb241200e321e220e7cd769762f386f92f61b898352dd27e402ce"},
-    {file = "pyarrow-13.0.0-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:ee7490f0f3f16a6c38f8c680949551053c8194e68de5046e6c288e396dccee80"},
-    {file = "pyarrow-13.0.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:e3ad79455c197a36eefbd90ad4aa832bece7f830a64396c15c61a0985e337287"},
-    {file = "pyarrow-13.0.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:68fcd2dc1b7d9310b29a15949cdd0cb9bc34b6de767aff979ebf546020bf0ba0"},
-    {file = "pyarrow-13.0.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dc6fd330fd574c51d10638e63c0d00ab456498fc804c9d01f2a61b9264f2c5b2"},
-    {file = "pyarrow-13.0.0-cp38-cp38-manylinux_2_28_aarch64.whl", hash = "sha256:e66442e084979a97bb66939e18f7b8709e4ac5f887e636aba29486ffbf373763"},
-    {file = "pyarrow-13.0.0-cp38-cp38-manylinux_2_28_x86_64.whl", hash = "sha256:0f6eff839a9e40e9c5610d3ff8c5bdd2f10303408312caf4c8003285d0b49565"},
-    {file = "pyarrow-13.0.0-cp38-cp38-win_amd64.whl", hash = "sha256:8b30a27f1cddf5c6efcb67e598d7823a1e253d743d92ac32ec1eb4b6a1417867"},
-    {file = "pyarrow-13.0.0-cp39-cp39-macosx_10_14_x86_64.whl", hash = "sha256:09552dad5cf3de2dc0aba1c7c4b470754c69bd821f5faafc3d774bedc3b04bb7"},
-    {file = "pyarrow-13.0.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:3896ae6c205d73ad192d2fc1489cd0edfab9f12867c85b4c277af4d37383c18c"},
-    {file = "pyarrow-13.0.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6647444b21cb5e68b593b970b2a9a07748dd74ea457c7dadaa15fd469c48ada1"},
-    {file = "pyarrow-13.0.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47663efc9c395e31d09c6aacfa860f4473815ad6804311c5433f7085415d62a7"},
-    {file = "pyarrow-13.0.0-cp39-cp39-manylinux_2_28_aarch64.whl", hash = "sha256:b9ba6b6d34bd2563345488cf444510588ea42ad5613df3b3509f48eb80250afd"},
-    {file = "pyarrow-13.0.0-cp39-cp39-manylinux_2_28_x86_64.whl", hash = "sha256:d00d374a5625beeb448a7fa23060df79adb596074beb3ddc1838adb647b6ef09"},
-    {file = "pyarrow-13.0.0-cp39-cp39-win_amd64.whl", hash = "sha256:c51afd87c35c8331b56f796eff954b9c7f8d4b7fef5903daf4e05fcf017d23a8"},
-    {file = "pyarrow-13.0.0.tar.gz", hash = "sha256:83333726e83ed44b0ac94d8d7a21bbdee4a05029c3b1e8db58a863eec8fd8a33"},
+    {file = "pyarrow-14.0.0-cp310-cp310-macosx_10_14_x86_64.whl", hash = "sha256:4fce1db17efbc453080c5b306f021926de7c636456a128328797e574c151f81a"},
+    {file = "pyarrow-14.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:28de7c05b4d7a71ec660360639cc9b65ceb1175e0e9d4dfccd879a1545bc38f7"},
+    {file = "pyarrow-14.0.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1541e9209c094e7f4d7b43fdd9de3a8c71d3069cf6fc03b59bf5774042411849"},
+    {file = "pyarrow-14.0.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8c05e6c45d303c80e41ab04996430a0251321f70986ed51213903ea7bc0b7efd"},
+    {file = "pyarrow-14.0.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:426ffec63ab9b4dff23dec51be2150e3a4a99eb38e66c10a70e2c48779fe9c9d"},
+    {file = "pyarrow-14.0.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:968844f591902160bd3c9ee240ce8822a3b4e7de731e91daea76ad43fe0ff062"},
+    {file = "pyarrow-14.0.0-cp310-cp310-win_amd64.whl", hash = "sha256:dcedbc0b4ea955c530145acfe99e324875c386419a09db150291a24cb01aeb81"},
+    {file = "pyarrow-14.0.0-cp311-cp311-macosx_10_14_x86_64.whl", hash = "sha256:97993a12aacc781efad9c92d4545a877e803c4d106d34237ec4ce987bec825a3"},
+    {file = "pyarrow-14.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:80225768d94024d59a31320374f5e6abf8899866c958dfb4f4ea8e2d9ec91bde"},
+    {file = "pyarrow-14.0.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b61546977a8bd7e3d0c697ede723341ef4737e761af2239aef6e1db447f97727"},
+    {file = "pyarrow-14.0.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:42509e6c93b4a1c8ae8ccd939a43f437097783fe130a1991497a6a1abbba026f"},
+    {file = "pyarrow-14.0.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:3eccce331a1392e46573f2ce849a9ee3c074e0d7008e9be0b44566ac149fd6a1"},
+    {file = "pyarrow-14.0.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:ecc463c45f2b6b36431f5f2025842245e8c15afe4d42072230575785f3bb00c6"},
+    {file = "pyarrow-14.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:4362ed90def81640addcd521811dd16a13015f0a8255bec324a41262c1524b6c"},
+    {file = "pyarrow-14.0.0-cp312-cp312-macosx_10_14_x86_64.whl", hash = "sha256:2fbb7ab62537782c5ab31aa08db0e1f6de92c2c515fdfc0790128384e919adcb"},
+    {file = "pyarrow-14.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ad7095f8f0fe0bfa3d3fca1909b8fa15c70e630b0cc1ff8d35e143f5e2704064"},
+    {file = "pyarrow-14.0.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e6602272fce71c0fb64f266e7cdbe51b93b00c22fc1bb57f2b0cb681c4aeedf4"},
+    {file = "pyarrow-14.0.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5b2b8f87951b08a3e72265c8963da3fe4f737bb81290269037e047dd172aa591"},
+    {file = "pyarrow-14.0.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:a1c9675966662a042caebbaafa1ae7fc26291287ebc3da06aa63ad74c323ec30"},
+    {file = "pyarrow-14.0.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:771079fddc0b4440c41af541dbdebc711a7062c93d3c4764476a9442606977db"},
+    {file = "pyarrow-14.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:c4096136318de1c4937370c0c365f949961c371201c396d8cc94a353f342069d"},
+    {file = "pyarrow-14.0.0-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:6c94056fb5f0ee0bae2206c3f776881e1db2bd0d133d06805755ae7ac5145349"},
+    {file = "pyarrow-14.0.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:687d0df1e08876b2d24d42abae129742fc655367e3fe6700aa4d79fcf2e3215e"},
+    {file = "pyarrow-14.0.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0f4054e5ee6c88ca256a67fc8b27f9c59bcd385216346265831d462a6069033f"},
+    {file = "pyarrow-14.0.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:768b962e4c042ab2c96576ca0757935472e220d11af855c7d0be3279d7fced5f"},
+    {file = "pyarrow-14.0.0-cp38-cp38-manylinux_2_28_aarch64.whl", hash = "sha256:77293b1319c7044f68ebfa43db8c929a0a5254ce371f1a0873d343f1460171d0"},
+    {file = "pyarrow-14.0.0-cp38-cp38-manylinux_2_28_x86_64.whl", hash = "sha256:d2bc7c53941d85f0133b1bd5a814bca0af213922f50d8a8dc0eed4d9ed477845"},
+    {file = "pyarrow-14.0.0-cp38-cp38-win_amd64.whl", hash = "sha256:378955365dd087c285ef4f34ad939d7e551b7715326710e8cd21cfa2ce511bd7"},
+    {file = "pyarrow-14.0.0-cp39-cp39-macosx_10_14_x86_64.whl", hash = "sha256:f05e81b4c621e6ad4bcd8f785e3aa1d6c49a935818b809ea6e7bf206a5b1a4e8"},
+    {file = "pyarrow-14.0.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:6867f6a8057eaef5a7ac6d27fe5518133f67973c5d4295d79a943458350e7c61"},
+    {file = "pyarrow-14.0.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ca54b87c46abdfe027f18f959ca388102bd7326c344838f72244807462d091b2"},
+    {file = "pyarrow-14.0.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:35abf61bd0cc9daca3afc715f6ba74ea83d792fa040025352624204bec66bf6a"},
+    {file = "pyarrow-14.0.0-cp39-cp39-manylinux_2_28_aarch64.whl", hash = "sha256:65c377523b369f7ef1ba02be814e832443bb3b15065010838f02dae5bdc0f53c"},
+    {file = "pyarrow-14.0.0-cp39-cp39-manylinux_2_28_x86_64.whl", hash = "sha256:e8a1e470e4b5f7bda7bede0410291daec55ab69f346d77795d34fd6a45b41579"},
+    {file = "pyarrow-14.0.0-cp39-cp39-win_amd64.whl", hash = "sha256:466c1a5a7a4b279cfa363ac34dedd0c3c6af388cec9e6a468ffc095a6627849a"},
+    {file = "pyarrow-14.0.0.tar.gz", hash = "sha256:45d3324e1c9871a07de6b4d514ebd73225490963a6dd46c64c465c4b6079fe1e"},
 ]
 
 [package.dependencies]
@@ -991,27 +852,33 @@ numpy = ">=1.16.6"
 
 [[package]]
 name = "pylint"
-version = "2.13.9"
+version = "3.0.2"
 description = "python code static checker"
 optional = false
-python-versions = ">=3.6.2"
+python-versions = ">=3.8.0"
 files = [
-    {file = "pylint-2.13.9-py3-none-any.whl", hash = "sha256:705c620d388035bdd9ff8b44c5bcdd235bfb49d276d488dd2c8ff1736aa42526"},
-    {file = "pylint-2.13.9.tar.gz", hash = "sha256:095567c96e19e6f57b5b907e67d265ff535e588fe26b12b5ebe1fc5645b2c731"},
+    {file = "pylint-3.0.2-py3-none-any.whl", hash = "sha256:60ed5f3a9ff8b61839ff0348b3624ceeb9e6c2a92c514d81c9cc273da3b6bcda"},
+    {file = "pylint-3.0.2.tar.gz", hash = "sha256:0d4c286ef6d2f66c8bfb527a7f8a629009e42c99707dec821a03e1b51a4c1496"},
 ]
 
 [package.dependencies]
-astroid = ">=2.11.5,<=2.12.0-dev0"
-colorama = {version = "*", markers = "sys_platform == \"win32\""}
-dill = ">=0.2"
+astroid = ">=3.0.1,<=3.1.0-dev0"
+colorama = {version = ">=0.4.5", markers = "sys_platform == \"win32\""}
+dill = [
+    {version = ">=0.2", markers = "python_version < \"3.11\""},
+    {version = ">=0.3.6", markers = "python_version >= \"3.11\""},
+    {version = ">=0.3.7", markers = "python_version >= \"3.12\""},
+]
 isort = ">=4.2.5,<6"
 mccabe = ">=0.6,<0.8"
 platformdirs = ">=2.2.0"
 tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
+tomlkit = ">=0.10.1"
 typing-extensions = {version = ">=3.10.0", markers = "python_version < \"3.10\""}
 
 [package.extras]
-testutil = ["gitpython (>3)"]
+spelling = ["pyenchant (>=3.2,<4.0)"]
+testutils = ["gitpython (>3)"]
 
 [[package]]
 name = "pytest"
@@ -1027,7 +894,6 @@ files = [
 [package.dependencies]
 colorama = {version = "*", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1.0.0rc8", markers = "python_version < \"3.11\""}
-importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 iniconfig = "*"
 packaging = "*"
 pluggy = ">=0.12,<2.0"
@@ -1067,13 +933,13 @@ six = ">=1.5"
 
 [[package]]
 name = "python-dotenv"
-version = "0.21.1"
+version = "1.0.0"
 description = "Read key-value pairs from a .env file and set them as environment variables"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "python-dotenv-0.21.1.tar.gz", hash = "sha256:1c93de8f636cde3ce377292818d0e440b6e45a82f215c3744979151fa8151c49"},
-    {file = "python_dotenv-0.21.1-py3-none-any.whl", hash = "sha256:41e12e0318bebc859fcc4d97d4db8d20ad21721a6aa5047dd59f090391cb549a"},
+    {file = "python-dotenv-1.0.0.tar.gz", hash = "sha256:a8df96034aae6d2d50a4ebe8216326c61c3eb64836776504fcca410e5937a3ba"},
+    {file = "python_dotenv-1.0.0-py3-none-any.whl", hash = "sha256:f5971a9226b701070a4bf2c38c89e5a3f0d64de8debda981d1db98583009122a"},
 ]
 
 [package.extras]
@@ -1110,22 +976,6 @@ urllib3 = ">=1.21.1,<3"
 [package.extras]
 socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
-
-[[package]]
-name = "setuptools"
-version = "68.0.0"
-description = "Easily download, build, install, upgrade, and uninstall Python packages"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "setuptools-68.0.0-py3-none-any.whl", hash = "sha256:11e52c67415a381d10d6b462ced9cfb97066179f0e871399e006c4ab101fc85f"},
-    {file = "setuptools-68.0.0.tar.gz", hash = "sha256:baf1fdb41c6da4cd2eae722e135500da913332ab3f2f5c7d33af9b492acb5235"},
-]
-
-[package.extras]
-docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-hoverxref (<2)", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (==0.8.3)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
-testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pip (>=19.1)", "pip-run (>=8.8)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-ruff", "pytest-timeout", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
-testing-integration = ["build[virtualenv]", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
 
 [[package]]
 name = "six"
@@ -1198,7 +1048,6 @@ files = [
 
 [package.dependencies]
 greenlet = {version = "!=0.4.17", markers = "platform_machine == \"win32\" or platform_machine == \"WIN32\" or platform_machine == \"AMD64\" or platform_machine == \"amd64\" or platform_machine == \"x86_64\" or platform_machine == \"ppc64le\" or platform_machine == \"aarch64\""}
-importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 typing-extensions = ">=4.2.0"
 
 [package.extras]
@@ -1255,64 +1104,25 @@ files = [
 ]
 
 [[package]]
-name = "typed-ast"
-version = "1.5.5"
-description = "a fork of Python 2 and 3 ast modules with type comment support"
+name = "tomlkit"
+version = "0.12.1"
+description = "Style preserving TOML library"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 files = [
-    {file = "typed_ast-1.5.5-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:4bc1efe0ce3ffb74784e06460f01a223ac1f6ab31c6bc0376a21184bf5aabe3b"},
-    {file = "typed_ast-1.5.5-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:5f7a8c46a8b333f71abd61d7ab9255440d4a588f34a21f126bbfc95f6049e686"},
-    {file = "typed_ast-1.5.5-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:597fc66b4162f959ee6a96b978c0435bd63791e31e4f410622d19f1686d5e769"},
-    {file = "typed_ast-1.5.5-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d41b7a686ce653e06c2609075d397ebd5b969d821b9797d029fccd71fdec8e04"},
-    {file = "typed_ast-1.5.5-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:5fe83a9a44c4ce67c796a1b466c270c1272e176603d5e06f6afbc101a572859d"},
-    {file = "typed_ast-1.5.5-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:d5c0c112a74c0e5db2c75882a0adf3133adedcdbfd8cf7c9d6ed77365ab90a1d"},
-    {file = "typed_ast-1.5.5-cp310-cp310-win_amd64.whl", hash = "sha256:e1a976ed4cc2d71bb073e1b2a250892a6e968ff02aa14c1f40eba4f365ffec02"},
-    {file = "typed_ast-1.5.5-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:c631da9710271cb67b08bd3f3813b7af7f4c69c319b75475436fcab8c3d21bee"},
-    {file = "typed_ast-1.5.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:b445c2abfecab89a932b20bd8261488d574591173d07827c1eda32c457358b18"},
-    {file = "typed_ast-1.5.5-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cc95ffaaab2be3b25eb938779e43f513e0e538a84dd14a5d844b8f2932593d88"},
-    {file = "typed_ast-1.5.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:61443214d9b4c660dcf4b5307f15c12cb30bdfe9588ce6158f4a005baeb167b2"},
-    {file = "typed_ast-1.5.5-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:6eb936d107e4d474940469e8ec5b380c9b329b5f08b78282d46baeebd3692dc9"},
-    {file = "typed_ast-1.5.5-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:e48bf27022897577d8479eaed64701ecaf0467182448bd95759883300ca818c8"},
-    {file = "typed_ast-1.5.5-cp311-cp311-win_amd64.whl", hash = "sha256:83509f9324011c9a39faaef0922c6f720f9623afe3fe220b6d0b15638247206b"},
-    {file = "typed_ast-1.5.5-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:44f214394fc1af23ca6d4e9e744804d890045d1643dd7e8229951e0ef39429b5"},
-    {file = "typed_ast-1.5.5-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:118c1ce46ce58fda78503eae14b7664163aa735b620b64b5b725453696f2a35c"},
-    {file = "typed_ast-1.5.5-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:be4919b808efa61101456e87f2d4c75b228f4e52618621c77f1ddcaae15904fa"},
-    {file = "typed_ast-1.5.5-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:fc2b8c4e1bc5cd96c1a823a885e6b158f8451cf6f5530e1829390b4d27d0807f"},
-    {file = "typed_ast-1.5.5-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:16f7313e0a08c7de57f2998c85e2a69a642e97cb32f87eb65fbfe88381a5e44d"},
-    {file = "typed_ast-1.5.5-cp36-cp36m-win_amd64.whl", hash = "sha256:2b946ef8c04f77230489f75b4b5a4a6f24c078be4aed241cfabe9cbf4156e7e5"},
-    {file = "typed_ast-1.5.5-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:2188bc33d85951ea4ddad55d2b35598b2709d122c11c75cffd529fbc9965508e"},
-    {file = "typed_ast-1.5.5-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0635900d16ae133cab3b26c607586131269f88266954eb04ec31535c9a12ef1e"},
-    {file = "typed_ast-1.5.5-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:57bfc3cf35a0f2fdf0a88a3044aafaec1d2f24d8ae8cd87c4f58d615fb5b6311"},
-    {file = "typed_ast-1.5.5-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:fe58ef6a764de7b4b36edfc8592641f56e69b7163bba9f9c8089838ee596bfb2"},
-    {file = "typed_ast-1.5.5-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:d09d930c2d1d621f717bb217bf1fe2584616febb5138d9b3e8cdd26506c3f6d4"},
-    {file = "typed_ast-1.5.5-cp37-cp37m-win_amd64.whl", hash = "sha256:d40c10326893ecab8a80a53039164a224984339b2c32a6baf55ecbd5b1df6431"},
-    {file = "typed_ast-1.5.5-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:fd946abf3c31fb50eee07451a6aedbfff912fcd13cf357363f5b4e834cc5e71a"},
-    {file = "typed_ast-1.5.5-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:ed4a1a42df8a3dfb6b40c3d2de109e935949f2f66b19703eafade03173f8f437"},
-    {file = "typed_ast-1.5.5-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:045f9930a1550d9352464e5149710d56a2aed23a2ffe78946478f7b5416f1ede"},
-    {file = "typed_ast-1.5.5-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:381eed9c95484ceef5ced626355fdc0765ab51d8553fec08661dce654a935db4"},
-    {file = "typed_ast-1.5.5-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:bfd39a41c0ef6f31684daff53befddae608f9daf6957140228a08e51f312d7e6"},
-    {file = "typed_ast-1.5.5-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:8c524eb3024edcc04e288db9541fe1f438f82d281e591c548903d5b77ad1ddd4"},
-    {file = "typed_ast-1.5.5-cp38-cp38-win_amd64.whl", hash = "sha256:7f58fabdde8dcbe764cef5e1a7fcb440f2463c1bbbec1cf2a86ca7bc1f95184b"},
-    {file = "typed_ast-1.5.5-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:042eb665ff6bf020dd2243307d11ed626306b82812aba21836096d229fdc6a10"},
-    {file = "typed_ast-1.5.5-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:622e4a006472b05cf6ef7f9f2636edc51bda670b7bbffa18d26b255269d3d814"},
-    {file = "typed_ast-1.5.5-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1efebbbf4604ad1283e963e8915daa240cb4bf5067053cf2f0baadc4d4fb51b8"},
-    {file = "typed_ast-1.5.5-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f0aefdd66f1784c58f65b502b6cf8b121544680456d1cebbd300c2c813899274"},
-    {file = "typed_ast-1.5.5-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:48074261a842acf825af1968cd912f6f21357316080ebaca5f19abbb11690c8a"},
-    {file = "typed_ast-1.5.5-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:429ae404f69dc94b9361bb62291885894b7c6fb4640d561179548c849f8492ba"},
-    {file = "typed_ast-1.5.5-cp39-cp39-win_amd64.whl", hash = "sha256:335f22ccb244da2b5c296e6f96b06ee9bed46526db0de38d2f0e5a6597b81155"},
-    {file = "typed_ast-1.5.5.tar.gz", hash = "sha256:94282f7a354f36ef5dbce0ef3467ebf6a258e370ab33d5b40c249fa996e590dd"},
+    {file = "tomlkit-0.12.1-py3-none-any.whl", hash = "sha256:712cbd236609acc6a3e2e97253dfc52d4c2082982a88f61b640ecf0817eab899"},
+    {file = "tomlkit-0.12.1.tar.gz", hash = "sha256:38e1ff8edb991273ec9f6181244a6a391ac30e9f5098e7535640ea6be97a7c86"},
 ]
 
 [[package]]
 name = "typing-extensions"
-version = "4.7.1"
-description = "Backported and Experimental Type Hints for Python 3.7+"
+version = "4.8.0"
+description = "Backported and Experimental Type Hints for Python 3.8+"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "typing_extensions-4.7.1-py3-none-any.whl", hash = "sha256:440d5dd3af93b060174bf433bccd69b0babc3b15b1a8dca43789fd7f61514b36"},
-    {file = "typing_extensions-4.7.1.tar.gz", hash = "sha256:b75ddc264f0ba5615db7ba217daeb99701ad295353c45f9e95963337ceeeffb2"},
+    {file = "typing_extensions-4.8.0-py3-none-any.whl", hash = "sha256:8f92fc8806f9a6b641eaa5318da32b44d401efaac0f6678c9bc448ba3605faa0"},
+    {file = "typing_extensions-4.8.0.tar.gz", hash = "sha256:df8e4339e9cb77357558cbdbceca33c303714cf861d1eef15e1070055ae8b7ef"},
 ]
 
 [[package]]
@@ -1344,103 +1154,19 @@ socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
 zstd = ["zstandard (>=0.18.0)"]
 
 [[package]]
-name = "wrapt"
-version = "1.15.0"
-description = "Module for decorators, wrappers and monkey patching."
-optional = false
-python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
-files = [
-    {file = "wrapt-1.15.0-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:ca1cccf838cd28d5a0883b342474c630ac48cac5df0ee6eacc9c7290f76b11c1"},
-    {file = "wrapt-1.15.0-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:e826aadda3cae59295b95343db8f3d965fb31059da7de01ee8d1c40a60398b29"},
-    {file = "wrapt-1.15.0-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:5fc8e02f5984a55d2c653f5fea93531e9836abbd84342c1d1e17abc4a15084c2"},
-    {file = "wrapt-1.15.0-cp27-cp27m-manylinux2010_i686.whl", hash = "sha256:96e25c8603a155559231c19c0349245eeb4ac0096fe3c1d0be5c47e075bd4f46"},
-    {file = "wrapt-1.15.0-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:40737a081d7497efea35ab9304b829b857f21558acfc7b3272f908d33b0d9d4c"},
-    {file = "wrapt-1.15.0-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:f87ec75864c37c4c6cb908d282e1969e79763e0d9becdfe9fe5473b7bb1e5f09"},
-    {file = "wrapt-1.15.0-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:1286eb30261894e4c70d124d44b7fd07825340869945c79d05bda53a40caa079"},
-    {file = "wrapt-1.15.0-cp27-cp27mu-manylinux2010_i686.whl", hash = "sha256:493d389a2b63c88ad56cdc35d0fa5752daac56ca755805b1b0c530f785767d5e"},
-    {file = "wrapt-1.15.0-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:58d7a75d731e8c63614222bcb21dd992b4ab01a399f1f09dd82af17bbfc2368a"},
-    {file = "wrapt-1.15.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:21f6d9a0d5b3a207cdf7acf8e58d7d13d463e639f0c7e01d82cdb671e6cb7923"},
-    {file = "wrapt-1.15.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ce42618f67741d4697684e501ef02f29e758a123aa2d669e2d964ff734ee00ee"},
-    {file = "wrapt-1.15.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:41d07d029dd4157ae27beab04d22b8e261eddfc6ecd64ff7000b10dc8b3a5727"},
-    {file = "wrapt-1.15.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:54accd4b8bc202966bafafd16e69da9d5640ff92389d33d28555c5fd4f25ccb7"},
-    {file = "wrapt-1.15.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2fbfbca668dd15b744418265a9607baa970c347eefd0db6a518aaf0cfbd153c0"},
-    {file = "wrapt-1.15.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:76e9c727a874b4856d11a32fb0b389afc61ce8aaf281ada613713ddeadd1cfec"},
-    {file = "wrapt-1.15.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:e20076a211cd6f9b44a6be58f7eeafa7ab5720eb796975d0c03f05b47d89eb90"},
-    {file = "wrapt-1.15.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:a74d56552ddbde46c246b5b89199cb3fd182f9c346c784e1a93e4dc3f5ec9975"},
-    {file = "wrapt-1.15.0-cp310-cp310-win32.whl", hash = "sha256:26458da5653aa5b3d8dc8b24192f574a58984c749401f98fff994d41d3f08da1"},
-    {file = "wrapt-1.15.0-cp310-cp310-win_amd64.whl", hash = "sha256:75760a47c06b5974aa5e01949bf7e66d2af4d08cb8c1d6516af5e39595397f5e"},
-    {file = "wrapt-1.15.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:ba1711cda2d30634a7e452fc79eabcadaffedf241ff206db2ee93dd2c89a60e7"},
-    {file = "wrapt-1.15.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:56374914b132c702aa9aa9959c550004b8847148f95e1b824772d453ac204a72"},
-    {file = "wrapt-1.15.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a89ce3fd220ff144bd9d54da333ec0de0399b52c9ac3d2ce34b569cf1a5748fb"},
-    {file = "wrapt-1.15.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3bbe623731d03b186b3d6b0d6f51865bf598587c38d6f7b0be2e27414f7f214e"},
-    {file = "wrapt-1.15.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3abbe948c3cbde2689370a262a8d04e32ec2dd4f27103669a45c6929bcdbfe7c"},
-    {file = "wrapt-1.15.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:b67b819628e3b748fd3c2192c15fb951f549d0f47c0449af0764d7647302fda3"},
-    {file = "wrapt-1.15.0-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:7eebcdbe3677e58dd4c0e03b4f2cfa346ed4049687d839adad68cc38bb559c92"},
-    {file = "wrapt-1.15.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:74934ebd71950e3db69960a7da29204f89624dde411afbfb3b4858c1409b1e98"},
-    {file = "wrapt-1.15.0-cp311-cp311-win32.whl", hash = "sha256:bd84395aab8e4d36263cd1b9308cd504f6cf713b7d6d3ce25ea55670baec5416"},
-    {file = "wrapt-1.15.0-cp311-cp311-win_amd64.whl", hash = "sha256:a487f72a25904e2b4bbc0817ce7a8de94363bd7e79890510174da9d901c38705"},
-    {file = "wrapt-1.15.0-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:4ff0d20f2e670800d3ed2b220d40984162089a6e2c9646fdb09b85e6f9a8fc29"},
-    {file = "wrapt-1.15.0-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:9ed6aa0726b9b60911f4aed8ec5b8dd7bf3491476015819f56473ffaef8959bd"},
-    {file = "wrapt-1.15.0-cp35-cp35m-manylinux2010_i686.whl", hash = "sha256:896689fddba4f23ef7c718279e42f8834041a21342d95e56922e1c10c0cc7afb"},
-    {file = "wrapt-1.15.0-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:75669d77bb2c071333417617a235324a1618dba66f82a750362eccbe5b61d248"},
-    {file = "wrapt-1.15.0-cp35-cp35m-win32.whl", hash = "sha256:fbec11614dba0424ca72f4e8ba3c420dba07b4a7c206c8c8e4e73f2e98f4c559"},
-    {file = "wrapt-1.15.0-cp35-cp35m-win_amd64.whl", hash = "sha256:fd69666217b62fa5d7c6aa88e507493a34dec4fa20c5bd925e4bc12fce586639"},
-    {file = "wrapt-1.15.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:b0724f05c396b0a4c36a3226c31648385deb6a65d8992644c12a4963c70326ba"},
-    {file = "wrapt-1.15.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bbeccb1aa40ab88cd29e6c7d8585582c99548f55f9b2581dfc5ba68c59a85752"},
-    {file = "wrapt-1.15.0-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:38adf7198f8f154502883242f9fe7333ab05a5b02de7d83aa2d88ea621f13364"},
-    {file = "wrapt-1.15.0-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:578383d740457fa790fdf85e6d346fda1416a40549fe8db08e5e9bd281c6a475"},
-    {file = "wrapt-1.15.0-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:a4cbb9ff5795cd66f0066bdf5947f170f5d63a9274f99bdbca02fd973adcf2a8"},
-    {file = "wrapt-1.15.0-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:af5bd9ccb188f6a5fdda9f1f09d9f4c86cc8a539bd48a0bfdc97723970348418"},
-    {file = "wrapt-1.15.0-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:b56d5519e470d3f2fe4aa7585f0632b060d532d0696c5bdfb5e8319e1d0f69a2"},
-    {file = "wrapt-1.15.0-cp36-cp36m-win32.whl", hash = "sha256:77d4c1b881076c3ba173484dfa53d3582c1c8ff1f914c6461ab70c8428b796c1"},
-    {file = "wrapt-1.15.0-cp36-cp36m-win_amd64.whl", hash = "sha256:077ff0d1f9d9e4ce6476c1a924a3332452c1406e59d90a2cf24aeb29eeac9420"},
-    {file = "wrapt-1.15.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:5c5aa28df055697d7c37d2099a7bc09f559d5053c3349b1ad0c39000e611d317"},
-    {file = "wrapt-1.15.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3a8564f283394634a7a7054b7983e47dbf39c07712d7b177b37e03f2467a024e"},
-    {file = "wrapt-1.15.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:780c82a41dc493b62fc5884fb1d3a3b81106642c5c5c78d6a0d4cbe96d62ba7e"},
-    {file = "wrapt-1.15.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e169e957c33576f47e21864cf3fc9ff47c223a4ebca8960079b8bd36cb014fd0"},
-    {file = "wrapt-1.15.0-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:b02f21c1e2074943312d03d243ac4388319f2456576b2c6023041c4d57cd7019"},
-    {file = "wrapt-1.15.0-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:f2e69b3ed24544b0d3dbe2c5c0ba5153ce50dcebb576fdc4696d52aa22db6034"},
-    {file = "wrapt-1.15.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:d787272ed958a05b2c86311d3a4135d3c2aeea4fc655705f074130aa57d71653"},
-    {file = "wrapt-1.15.0-cp37-cp37m-win32.whl", hash = "sha256:02fce1852f755f44f95af51f69d22e45080102e9d00258053b79367d07af39c0"},
-    {file = "wrapt-1.15.0-cp37-cp37m-win_amd64.whl", hash = "sha256:abd52a09d03adf9c763d706df707c343293d5d106aea53483e0ec8d9e310ad5e"},
-    {file = "wrapt-1.15.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:cdb4f085756c96a3af04e6eca7f08b1345e94b53af8921b25c72f096e704e145"},
-    {file = "wrapt-1.15.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:230ae493696a371f1dbffaad3dafbb742a4d27a0afd2b1aecebe52b740167e7f"},
-    {file = "wrapt-1.15.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:63424c681923b9f3bfbc5e3205aafe790904053d42ddcc08542181a30a7a51bd"},
-    {file = "wrapt-1.15.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d6bcbfc99f55655c3d93feb7ef3800bd5bbe963a755687cbf1f490a71fb7794b"},
-    {file = "wrapt-1.15.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c99f4309f5145b93eca6e35ac1a988f0dc0a7ccf9ccdcd78d3c0adf57224e62f"},
-    {file = "wrapt-1.15.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:b130fe77361d6771ecf5a219d8e0817d61b236b7d8b37cc045172e574ed219e6"},
-    {file = "wrapt-1.15.0-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:96177eb5645b1c6985f5c11d03fc2dbda9ad24ec0f3a46dcce91445747e15094"},
-    {file = "wrapt-1.15.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:d5fe3e099cf07d0fb5a1e23d399e5d4d1ca3e6dfcbe5c8570ccff3e9208274f7"},
-    {file = "wrapt-1.15.0-cp38-cp38-win32.whl", hash = "sha256:abd8f36c99512755b8456047b7be10372fca271bf1467a1caa88db991e7c421b"},
-    {file = "wrapt-1.15.0-cp38-cp38-win_amd64.whl", hash = "sha256:b06fa97478a5f478fb05e1980980a7cdf2712015493b44d0c87606c1513ed5b1"},
-    {file = "wrapt-1.15.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:2e51de54d4fb8fb50d6ee8327f9828306a959ae394d3e01a1ba8b2f937747d86"},
-    {file = "wrapt-1.15.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:0970ddb69bba00670e58955f8019bec4a42d1785db3faa043c33d81de2bf843c"},
-    {file = "wrapt-1.15.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:76407ab327158c510f44ded207e2f76b657303e17cb7a572ffe2f5a8a48aa04d"},
-    {file = "wrapt-1.15.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cd525e0e52a5ff16653a3fc9e3dd827981917d34996600bbc34c05d048ca35cc"},
-    {file = "wrapt-1.15.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9d37ac69edc5614b90516807de32d08cb8e7b12260a285ee330955604ed9dd29"},
-    {file = "wrapt-1.15.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:078e2a1a86544e644a68422f881c48b84fef6d18f8c7a957ffd3f2e0a74a0d4a"},
-    {file = "wrapt-1.15.0-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:2cf56d0e237280baed46f0b5316661da892565ff58309d4d2ed7dba763d984b8"},
-    {file = "wrapt-1.15.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:7dc0713bf81287a00516ef43137273b23ee414fe41a3c14be10dd95ed98a2df9"},
-    {file = "wrapt-1.15.0-cp39-cp39-win32.whl", hash = "sha256:46ed616d5fb42f98630ed70c3529541408166c22cdfd4540b88d5f21006b0eff"},
-    {file = "wrapt-1.15.0-cp39-cp39-win_amd64.whl", hash = "sha256:eef4d64c650f33347c1f9266fa5ae001440b232ad9b98f1f43dfe7a79435c0a6"},
-    {file = "wrapt-1.15.0-py3-none-any.whl", hash = "sha256:64b1df0f83706b4ef4cfb4fb0e4c2669100fd7ecacfb59e091fad300d4e04640"},
-    {file = "wrapt-1.15.0.tar.gz", hash = "sha256:d06730c6aed78cee4126234cf2d071e01b44b915e725a6cb439a879ec9754a3a"},
-]
-
-[[package]]
 name = "zipp"
-version = "3.15.0"
+version = "3.17.0"
 description = "Backport of pathlib-compatible object wrapper for zip files"
-optional = false
-python-versions = ">=3.7"
+optional = true
+python-versions = ">=3.8"
 files = [
-    {file = "zipp-3.15.0-py3-none-any.whl", hash = "sha256:48904fc76a60e542af151aded95726c1a5c34ed43ab4134b597665c86d7ad556"},
-    {file = "zipp-3.15.0.tar.gz", hash = "sha256:112929ad649da941c23de50f356a2b5570c954b65150642bccdd66bf194d224b"},
+    {file = "zipp-3.17.0-py3-none-any.whl", hash = "sha256:0e923e726174922dce09c53c59ad483ff7bbb8e572e00c7f7c46b88556409f31"},
+    {file = "zipp-3.17.0.tar.gz", hash = "sha256:84e64a1c28cf7e91ed2078bb8cc8c259cb19b76942096c8d7b84947690cabaf0"},
 ]
 
 [package.extras]
-docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
-testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more-itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)"]
+docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (<7.2.5)", "sphinx (>=3.5)", "sphinx-lint"]
+testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-ignore-flaky", "pytest-mypy (>=0.9.1)", "pytest-ruff"]
 
 [extras]
 alembic = ["alembic", "sqlalchemy"]
@@ -1448,5 +1174,5 @@ sqlalchemy = ["sqlalchemy"]
 
 [metadata]
 lock-version = "2.0"
-python-versions = "^3.7.1"
-content-hash = "d12c174c529fbf8e5b469f7b98baac24b4bc91b61100d154eab9110fea100372"
+python-versions = "^3.8.0"
+content-hash = "429987828e0fd6f5342a33da723857583ff31367260e3326f3f18146100b4896"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ packages = [{ include = "databricks", from = "src" }]
 include = ["CHANGELOG.md"]
 
 [tool.poetry.dependencies]
-python = "^3.7.1"
+python = "^3.8.0"
 thrift = "^0.16.0"
 pandas = [
     { version = ">=1.2.5,<1.4.0", python = ">=3.7,<3.8" },

--- a/src/databricks/sql/__init__.py
+++ b/src/databricks/sql/__init__.py
@@ -6,9 +6,7 @@ from databricks.sql.exc import *
 apilevel = "2.0"
 threadsafety = 1  # Threads may share the module, but not connections.
 
-# Python extended format codes, e.g. ...WHERE name=%(name)s
-# Note that when we switch to ParameterApproach.NATIVE, paramstyle will be `named`
-paramstyle = "pyformat"
+paramstyle = "named"
 
 
 class DBAPITypeObject(object):

--- a/src/databricks/sql/client.py
+++ b/src/databricks/sql/client.py
@@ -1,4 +1,4 @@
-from typing import Dict, Tuple, List, Optional, Any, Union, get_args, Type
+from typing import Dict, Tuple, List, Optional, Any, Union, Sequence
 
 import pandas
 import pyarrow
@@ -26,7 +26,7 @@ from databricks.sql.parameters.native import (
     DbsqlParameterBase,
     TDbsqlParameter,
     TParameterDict,
-    TParameterList,
+    TParameterSequence,
     TParameterCollection,
     ParameterStructure,
     dbsql_parameter_from_primitive,
@@ -448,8 +448,8 @@ class Cursor:
         """Return True if all members of the list have a non-null .name attribute"""
         return all([i.name is not None for i in params])
 
-    def _normalize_tparameterlist(
-        self, params: TParameterList
+    def _normalize_tparametersequence(
+        self, params: TParameterSequence
     ) -> List[TDbsqlParameter]:
         """Retains the same order as the input list."""
 
@@ -477,8 +477,8 @@ class Cursor:
             return []
         if isinstance(params, dict):
             return self._normalize_tparameterdict(params)
-        if isinstance(params, list):
-            return self._normalize_tparameterlist(params)
+        if isinstance(params, Sequence):
+            return self._normalize_tparametersequence(list(params))
 
     def _determine_parameter_structure(
         self,
@@ -491,7 +491,7 @@ class Cursor:
             return ParameterStructure.POSITIONAL
 
     def _prepare_inline_parameters(
-        self, stmt: str, params: Optional[Union[List, Dict[str, Any]]]
+        self, stmt: str, params: Optional[Union[Sequence, Dict[str, Any]]]
     ) -> Tuple[str, List]:
         """Return a statement and list of native parameters to be passed to thrift_backend for execution
 

--- a/src/databricks/sql/client.py
+++ b/src/databricks/sql/client.py
@@ -21,6 +21,7 @@ from databricks.sql.utils import (
     named_parameters_to_tsparkparams,
     inject_parameters,
     ParameterApproach,
+    transform_paramstyle,
 )
 from databricks.sql.types import Row
 from databricks.sql.auth.auth import get_python_sql_connector_auth_provider
@@ -651,6 +652,8 @@ class Cursor:
         Both will result in the query equivalent to "SELECT * FROM table WHERE field = 'foo'
         being sent to the server
 
+        Note: if you pass a sequence of parameters in native mode, your query must use the `named` paramstyle
+
         :returns self
         """
 
@@ -664,8 +667,12 @@ class Cursor:
                 operation, parameters
             )
         elif param_approach == ParameterApproach.NATIVE:
+            if isinstance(parameters, dict):
+                transformed_operation = transform_paramstyle(operation, parameters)
+            else:
+                transformed_operation = operation
             prepared_operation, prepared_params = self._prepare_native_parameters(
-                operation, parameters
+                transformed_operation, parameters
             )
 
         self._check_not_closed()

--- a/src/databricks/sql/client.py
+++ b/src/databricks/sql/client.py
@@ -413,12 +413,8 @@ class Cursor:
                 )
             return ParameterApproach.INLINE
 
-        elif server_supports_native_approach:
-            return ParameterApproach.NATIVE
         else:
-            raise NotSupportedError(
-                "Parameterized operations are not supported by this server. DBR 14.1 is required."
-            )
+            return ParameterApproach.NATIVE
 
     def _prepare_inline_parameters(
         self, stmt: str, params: Optional[Union[List, Dict[str, Any]]]

--- a/src/databricks/sql/parameters/__init__.py
+++ b/src/databricks/sql/parameters/__init__.py
@@ -1,0 +1,15 @@
+from databricks.sql.parameters.native import (
+    IntegerParameter,
+    StringParameter,
+    BigIntegerParameter,
+    BooleanParameter,
+    DateParameter,
+    DoubleParameter,
+    FloatParameter,
+    VoidParameter,
+    SmallIntParameter,
+    TimestampParameter,
+    TimestampNTZParameter,
+    TinyIntParameter,
+    DecimalParameter,
+)

--- a/src/databricks/sql/parameters/native.py
+++ b/src/databricks/sql/parameters/native.py
@@ -1,7 +1,7 @@
 import datetime
 import decimal
 from enum import Enum, auto
-from typing import Optional, TYPE_CHECKING
+from typing import Optional, Sequence
 
 from databricks.sql.exc import NotSupportedError
 from databricks.sql.thrift_api.TCLIService.ttypes import (
@@ -584,9 +584,9 @@ TDbsqlParameter = Union[
 ]
 
 
-TParameterList = List[Union[TDbsqlParameter, TAllowedParameterValue]]
+TParameterSequence = Sequence[Union[TDbsqlParameter, TAllowedParameterValue]]
 TParameterDict = Dict[str, TAllowedParameterValue]
-TParameterCollection = Union[TParameterList, TParameterDict]
+TParameterCollection = Union[TParameterSequence, TParameterDict]
 
 
 _all__ = [

--- a/src/databricks/sql/parameters/native.py
+++ b/src/databricks/sql/parameters/native.py
@@ -1,0 +1,606 @@
+import datetime
+import decimal
+from enum import Enum, auto
+from typing import Optional, TYPE_CHECKING
+
+from databricks.sql.exc import NotSupportedError
+from databricks.sql.thrift_api.TCLIService.ttypes import (
+    TSparkParameter,
+    TSparkParameterValue,
+)
+
+import datetime
+import decimal
+from enum import Enum, auto
+from typing import Dict, List, Union
+
+
+class ParameterApproach(Enum):
+    INLINE = 1
+    NATIVE = 2
+    NONE = 3
+
+
+class ParameterStructure(Enum):
+    NAMED = 1
+    POSITIONAL = 2
+    NONE = 3
+
+
+class DatabricksSupportedType(Enum):
+    """Enumerate every supported Databricks SQL type shown here:
+
+    https://docs.databricks.com/en/sql/language-manual/sql-ref-datatypes.html
+    """
+
+    BIGINT = auto()
+    BINARY = auto()
+    BOOLEAN = auto()
+    DATE = auto()
+    DECIMAL = auto()
+    DOUBLE = auto()
+    FLOAT = auto()
+    INT = auto()
+    INTERVAL = auto()
+    VOID = auto()
+    SMALLINT = auto()
+    STRING = auto()
+    TIMESTAMP = auto()
+    TIMESTAMP_NTZ = auto()
+    TINYINT = auto()
+    ARRAY = auto()
+    MAP = auto()
+    STRUCT = auto()
+
+
+TAllowedParameterValue = Union[
+    str, int, float, datetime.datetime, datetime.date, bool, decimal.Decimal, None
+]
+
+
+class DbsqlParameterBase:
+    """Parent class for IntegerParameter, DecimalParameter etc..
+
+    Each each instance that extends this base class should be capable of generating a TSparkParameter
+    It should know how to generate a cast expression based off its DatabricksSupportedType.
+
+    By default the cast expression should render the string value of it's `value` and the literal
+    name of its Databricks Supported Type
+
+    Interface should be:
+
+    from databricks.sql.parameters import DecimalParameter
+    param = DecimalParameter(value, scale=None, precision=None)
+    cursor.execute("SELECT ?",[param])
+
+    Or
+
+    from databricks.sql.parameters import IntegerParameter
+    param = IntegerParameter(42)
+    cursor.execute("SELECT ?", [param])
+    """
+
+    CAST_EXPR: str
+
+    def as_tspark_param(self, named: bool) -> TSparkParameter:
+        """Returns a TSparkParameter object that can be passed to the DBR thrift server."""
+
+        tsp = TSparkParameter(value=self._tspark_param_value(), type=self._cast_expr())
+
+        if named:
+            tsp.name = self.name
+            tsp.ordinal = False
+        elif not named:
+            tsp.ordinal = True
+        return tsp
+
+    def _tspark_param_value(self):
+        return TSparkParameterValue(stringValue=str(self.value))
+
+    def _cast_expr(self):
+        return self.CAST_EXPR
+
+    def __str__(self):
+        return f"{self.__class__}(name={self.name}, value={self.value})"
+
+    def __repr__(self):
+        return self.__str__()
+
+    def __eq__(self, other):
+        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
+
+
+class IntegerParameter(DbsqlParameterBase):
+    """Wrap a Python `int` that will be bound to a Databricks SQL INT column."""
+
+    def __init__(self, value: int, name: Optional[str] = None):
+        """
+        :value:
+            The value to bind for this parameter. This will be casted to an INT.
+        :name:
+            If None, your query must contain a `?` marker. Like:
+
+            ```sql
+               SELECT * FROM table WHERE field = ?
+            ```
+            If not None, your query should contain a named parameter marker. Like:
+            ```sql
+                SELECT * FROM table WHERE field = :my_param
+            ```
+
+            The `name` argument to this function would be `my_param`.
+        """
+        self.value = value
+        self.name = name
+
+    CAST_EXPR = DatabricksSupportedType.INT.name
+
+
+class StringParameter(DbsqlParameterBase):
+    """Wrap a Python `str` that will be bound to a Databricks SQL STRING column."""
+
+    def __init__(self, value: str, name: Optional[str] = None):
+        """
+        :value:
+            The value to bind for this parameter. This will be casted to a STRING.
+        :name:
+            If None, your query must contain a `?` marker. Like:
+
+            ```sql
+               SELECT * FROM table WHERE field = ?
+            ```
+            If not None, your query should contain a named parameter marker. Like:
+            ```sql
+                SELECT * FROM table WHERE field = :my_param
+            ```
+
+            The `name` argument to this function would be `my_param`.
+        """
+        self.value = value
+        self.name = name
+
+    CAST_EXPR = DatabricksSupportedType.STRING.name
+
+
+class BigIntegerParameter(DbsqlParameterBase):
+    """Wrap a Python `int` that will be bound to a Databricks SQL BIGINT column."""
+
+    def __init__(self, value: int, name: Optional[str] = None):
+        """
+        :value:
+            The value to bind for this parameter. This will be casted to a BIGINT.
+        :name:
+            If None, your query must contain a `?` marker. Like:
+
+            ```sql
+               SELECT * FROM table WHERE field = ?
+            ```
+            If not None, your query should contain a named parameter marker. Like:
+            ```sql
+                SELECT * FROM table WHERE field = :my_param
+            ```
+
+            The `name` argument to this function would be `my_param`.
+        """
+        self.value = value
+        self.name = name
+
+    CAST_EXPR = DatabricksSupportedType.BIGINT.name
+
+
+class BooleanParameter(DbsqlParameterBase):
+    """Wrap a Python `bool` that will be bound to a Databricks SQL BOOLEAN column."""
+
+    def __init__(self, value: bool, name: Optional[str] = None):
+        """
+        :value:
+            The value to bind for this parameter. This will be casted to a BOOLEAN.
+        :name:
+            If None, your query must contain a `?` marker. Like:
+
+            ```sql
+               SELECT * FROM table WHERE field = ?
+            ```
+            If not None, your query should contain a named parameter marker. Like:
+            ```sql
+                SELECT * FROM table WHERE field = :my_param
+            ```
+
+            The `name` argument to this function would be `my_param`.
+        """
+        self.value = value
+        self.name = name
+
+    CAST_EXPR = DatabricksSupportedType.BOOLEAN.name
+
+
+class DateParameter(DbsqlParameterBase):
+    """Wrap a Python `date` that will be bound to a Databricks SQL DATE column."""
+
+    def __init__(self, value: datetime.date, name: Optional[str] = None):
+        """
+        :value:
+            The value to bind for this parameter. This will be casted to a DATE.
+        :name:
+            If None, your query must contain a `?` marker. Like:
+
+            ```sql
+               SELECT * FROM table WHERE field = ?
+            ```
+            If not None, your query should contain a named parameter marker. Like:
+            ```sql
+                SELECT * FROM table WHERE field = :my_param
+            ```
+
+            The `name` argument to this function would be `my_param`.
+        """
+        self.value = value
+        self.name = name
+
+    CAST_EXPR = DatabricksSupportedType.DATE.name
+
+
+class DoubleParameter(DbsqlParameterBase):
+    """Wrap a Python `float` that will be bound to a Databricks SQL DOUBLE column."""
+
+    def __init__(self, value: float, name: Optional[str] = None):
+        """
+        :value:
+            The value to bind for this parameter. This will be casted to a DOUBLE.
+        :name:
+            If None, your query must contain a `?` marker. Like:
+
+            ```sql
+               SELECT * FROM table WHERE field = ?
+            ```
+            If not None, your query should contain a named parameter marker. Like:
+            ```sql
+                SELECT * FROM table WHERE field = :my_param
+            ```
+
+            The `name` argument to this function would be `my_param`.
+        """
+        self.value = value
+        self.name = name
+
+    CAST_EXPR = DatabricksSupportedType.DOUBLE.name
+
+
+class FloatParameter(DbsqlParameterBase):
+    """Wrap a Python `float` that will be bound to a Databricks SQL FLOAT column."""
+
+    def __init__(self, value: float, name: Optional[str] = None):
+        """
+        :value:
+            The value to bind for this parameter. This will be casted to a FLOAT.
+        :name:
+            If None, your query must contain a `?` marker. Like:
+
+            ```sql
+               SELECT * FROM table WHERE field = ?
+            ```
+            If not None, your query should contain a named parameter marker. Like:
+            ```sql
+                SELECT * FROM table WHERE field = :my_param
+            ```
+
+            The `name` argument to this function would be `my_param`.
+        """
+        self.value = value
+        self.name = name
+
+    CAST_EXPR = DatabricksSupportedType.FLOAT.name
+
+
+class VoidParameter(DbsqlParameterBase):
+    """Wrap a Python `None` that will be bound to a Databricks SQL VOID type."""
+
+    def __init__(self, value: None, name: Optional[str] = None):
+        """
+        :value:
+            The value to bind for this parameter. This will be casted to a VOID.
+        :name:
+            If None, your query must contain a `?` marker. Like:
+
+            ```sql
+               SELECT * FROM table WHERE field = ?
+            ```
+            If not None, your query should contain a named parameter marker. Like:
+            ```sql
+                SELECT * FROM table WHERE field = :my_param
+            ```
+
+            The `name` argument to this function would be `my_param`.
+        """
+        self.value = value
+        self.name = name
+
+    CAST_EXPR = DatabricksSupportedType.VOID.name
+
+    def _tspark_param_value(self):
+        """For Void types, the TSparkParameter.value should be a Python NoneType"""
+        return None
+
+
+class SmallIntParameter(DbsqlParameterBase):
+    """Wrap a Python `int` that will be bound to a Databricks SQL SMALLINT type."""
+
+    def __init__(self, value: int, name: Optional[str] = None):
+        """
+        :value:
+            The value to bind for this parameter. This will be casted to a SMALLINT.
+        :name:
+            If None, your query must contain a `?` marker. Like:
+
+            ```sql
+               SELECT * FROM table WHERE field = ?
+            ```
+            If not None, your query should contain a named parameter marker. Like:
+            ```sql
+                SELECT * FROM table WHERE field = :my_param
+            ```
+
+            The `name` argument to this function would be `my_param`.
+        """
+        self.value = value
+        self.name = name
+
+    CAST_EXPR = DatabricksSupportedType.SMALLINT.name
+
+
+class TimestampParameter(DbsqlParameterBase):
+    """Wrap a Python `datetime` that will be bound to a Databricks SQL TIMESTAMP type."""
+
+    def __init__(self, value: datetime.datetime, name: Optional[str] = None):
+        """
+        :value:
+            The value to bind for this parameter. This will be casted to a TIMESTAMP.
+        :name:
+            If None, your query must contain a `?` marker. Like:
+
+            ```sql
+               SELECT * FROM table WHERE field = ?
+            ```
+            If not None, your query should contain a named parameter marker. Like:
+            ```sql
+                SELECT * FROM table WHERE field = :my_param
+            ```
+
+            The `name` argument to this function would be `my_param`.
+        """
+        self.value = value
+        self.name = name
+
+    CAST_EXPR = DatabricksSupportedType.TIMESTAMP.name
+
+
+class TimestampNTZParameter(DbsqlParameterBase):
+    """Wrap a Python `datetime` that will be bound to a Databricks SQL TIMESTAMP_NTZ type."""
+
+    def __init__(self, value: datetime.datetime, name: Optional[str] = None):
+        """
+        :value:
+            The value to bind for this parameter. This will be casted to a TIMESTAMP_NTZ.
+            If it contains a timezone, that info will be lost.
+        :name:
+            If None, your query must contain a `?` marker. Like:
+
+            ```sql
+               SELECT * FROM table WHERE field = ?
+            ```
+            If not None, your query should contain a named parameter marker. Like:
+            ```sql
+                SELECT * FROM table WHERE field = :my_param
+            ```
+
+            The `name` argument to this function would be `my_param`.
+        """
+        self.value = value
+        self.name = name
+
+    CAST_EXPR = DatabricksSupportedType.TIMESTAMP_NTZ.name
+
+
+class TinyIntParameter(DbsqlParameterBase):
+    """Wrap a Python `int` that will be bound to a Databricks SQL TINYINT type."""
+
+    def __init__(self, value: int, name: Optional[str] = None):
+        """
+        :value:
+            The value to bind for this parameter. This will be casted to a TINYINT.
+        :name:
+            If None, your query must contain a `?` marker. Like:
+
+            ```sql
+               SELECT * FROM table WHERE field = ?
+            ```
+            If not None, your query should contain a named parameter marker. Like:
+            ```sql
+                SELECT * FROM table WHERE field = :my_param
+            ```
+
+            The `name` argument to this function would be `my_param`.
+        """
+        self.value = value
+        self.name = name
+
+    CAST_EXPR = DatabricksSupportedType.TINYINT.name
+
+
+class DecimalParameter(DbsqlParameterBase):
+    """Wrap a Python `Decimal` that will be bound to a Databricks SQL DECIMAL type."""
+
+    CAST_EXPR = "DECIMAL({},{})"
+
+    def __init__(
+        self,
+        value: decimal.Decimal,
+        name: Optional[str] = None,
+        scale: Optional[int] = None,
+        precision: Optional[int] = None,
+    ):
+        """
+        If set, `scale` and `precision` must both be set. If neither is set, the value
+        will be casted to the smallest possible DECIMAL type that can contain it.
+
+        :value:
+            The value to bind for this parameter. This will be casted to a DECIMAL.
+        :name:
+            If None, your query must contain a `?` marker. Like:
+
+            ```sql
+               SELECT * FROM table WHERE field = ?
+            ```
+            If not None, your query should contain a named parameter marker. Like:
+            ```sql
+                SELECT * FROM table WHERE field = :my_param
+            ```
+
+            The `name` argument to this function would be `my_param`.
+        :scale:
+            The maximum precision (total number of digits) of the number between 1 and 38.
+        :precision:
+            The number of digits to the right of the decimal point.
+        """
+        self.value = value
+        self.name = name
+        self.value: decimal.Decimal = value
+        self.scale = scale
+        self.precision = precision
+
+        if not self.valid_scale_and_precision():
+            raise ValueError(
+                "DecimalParameter requires both or none of scale and precision to be set"
+            )
+
+    def valid_scale_and_precision(self):
+        if (self.scale is None and self.precision is None) or (
+            isinstance(self.scale, int) and isinstance(self.precision, int)
+        ):
+            return True
+        else:
+            return False
+
+    def _cast_expr(self):
+        if self.scale and self.precision:
+            return self.CAST_EXPR.format(self.scale, self.precision)
+        else:
+            return self.calculate_decimal_cast_string(self.value)
+
+    def calculate_decimal_cast_string(self, input: decimal.Decimal) -> str:
+        """Returns the smallest SQL cast argument that can contain the passed decimal
+
+        Example:
+            Input:   Decimal("1234.5678")
+            Output:  DECIMAL(8,4)
+        """
+
+        string_decimal = str(input)
+
+        if string_decimal.startswith("0."):
+            # This decimal is less than 1
+            overall = after = len(string_decimal) - 2
+        elif "." not in string_decimal:
+            # This decimal has no fractional component
+            overall = len(string_decimal)
+            after = 0
+        else:
+            # This decimal has both whole and fractional parts
+            parts = string_decimal.split(".")
+            parts_lengths = [len(i) for i in parts]
+            before, after = parts_lengths[:2]
+            overall = before + after
+
+        return self.CAST_EXPR.format(overall, after)
+
+
+def dbsql_parameter_from_int(value: int, name: Optional[str] = None):
+    """Returns IntegerParameter unless the passed int() requires a BIGINT.
+
+    Note: TinyIntegerParameter is never inferred here because it is a rarely used type and clauses like LIMIT and OFFSET
+    cannot accept TINYINT bound parameter values.
+    """
+    if -128 <= value <= 127:
+        # If DBR is ever updated to permit TINYINT values passed to LIMIT and OFFSET
+        # then we can change this line to return TinyIntParameter
+        return IntegerParameter(value=value, name=name)
+    elif -2147483648 <= value <= 2147483647:
+        return IntegerParameter(value=value, name=name)
+    else:
+        return BigIntegerParameter(value=value, name=name)
+
+
+def dbsql_parameter_from_primitive(
+    value: TAllowedParameterValue, name: Optional[str] = None
+) -> "TDbsqlParameter":
+    """Returns a DbsqlParameter subclass given an inferrable value
+
+    This is a convenience function that can be used to create a DbsqlParameter subclass
+    without having to explicitly import a subclass of DbsqlParameter.
+    """
+
+    # This series of type checks are required for mypy not to raise
+    # havoc. We can't use TYPE_INFERRENCE_MAP because mypy doesn't trust
+    # its logic
+
+    if type(value) is int:
+        return dbsql_parameter_from_int(value, name=name)
+    elif type(value) is str:
+        return StringParameter(value=value, name=name)
+    elif type(value) is float:
+        return FloatParameter(value=value, name=name)
+    elif type(value) is datetime.datetime:
+        return TimestampParameter(value=value, name=name)
+    elif type(value) is datetime.date:
+        return DateParameter(value=value, name=name)
+    elif type(value) is bool:
+        return BooleanParameter(value=value, name=name)
+    elif type(value) is decimal.Decimal:
+        return DecimalParameter(value=value, name=name)
+    elif value is None:
+        return VoidParameter(value=value, name=name)
+
+    else:
+        raise NotSupportedError(
+            f"Could not infer parameter type from value: {value} - {type(value)} \n"
+            "Please specify the type explicitly."
+        )
+
+
+TDbsqlParameter = Union[
+    IntegerParameter,
+    StringParameter,
+    BigIntegerParameter,
+    BooleanParameter,
+    DateParameter,
+    DoubleParameter,
+    FloatParameter,
+    VoidParameter,
+    SmallIntParameter,
+    TimestampParameter,
+    TimestampNTZParameter,
+    TinyIntParameter,
+    DecimalParameter,
+]
+
+
+TParameterList = List[Union[TDbsqlParameter, TAllowedParameterValue]]
+TParameterDict = Dict[str, TAllowedParameterValue]
+TParameterCollection = Union[TParameterList, TParameterDict]
+
+
+_all__ = [
+    "IntegerParameter",
+    "StringParameter",
+    "BigIntegerParameter",
+    "BooleanParameter",
+    "DateParameter",
+    "DoubleParameter",
+    "FloatParameter",
+    "VoidParameter",
+    "SmallIntParameter",
+    "TimestampParameter",
+    "TimestampNTZParameter",
+    "TinyIntParameter",
+    "DecimalParameter",
+]

--- a/src/databricks/sql/thrift_api/TCLIService/ttypes.py
+++ b/src/databricks/sql/thrift_api/TCLIService/ttypes.py
@@ -796,7 +796,7 @@ class TTypeQualifiers(object):
         return not (self == other)
 
 
-class TPrimitiveTypeEntry(object):
+class TTAllowedParameterValueEntry(object):
     """
     Attributes:
      - type
@@ -838,7 +838,7 @@ class TPrimitiveTypeEntry(object):
         if oprot._fast_encode is not None and self.thrift_spec is not None:
             oprot.trans.write(oprot._fast_encode(self, [self.__class__, self.thrift_spec]))
             return
-        oprot.writeStructBegin('TPrimitiveTypeEntry')
+        oprot.writeStructBegin('TTAllowedParameterValueEntry')
         if self.type is not None:
             oprot.writeFieldBegin('type', TType.I32, 1)
             oprot.writeI32(self.type)
@@ -1227,7 +1227,7 @@ class TTypeEntry(object):
                 break
             if fid == 1:
                 if ftype == TType.STRUCT:
-                    self.primitiveEntry = TPrimitiveTypeEntry()
+                    self.primitiveEntry = TTAllowedParameterValueEntry()
                     self.primitiveEntry.read(iprot)
                 else:
                     iprot.skip(ftype)
@@ -10502,8 +10502,8 @@ TTypeQualifiers.thrift_spec = (
     None,  # 0
     (1, TType.MAP, 'qualifiers', (TType.STRING, 'UTF8', TType.STRUCT, [TTypeQualifierValue, None], False), None, ),  # 1
 )
-all_structs.append(TPrimitiveTypeEntry)
-TPrimitiveTypeEntry.thrift_spec = (
+all_structs.append(TTAllowedParameterValueEntry)
+TTAllowedParameterValueEntry.thrift_spec = (
     None,  # 0
     (1, TType.I32, 'type', None, None, ),  # 1
     (2, TType.STRUCT, 'typeQualifiers', [TTypeQualifiers, None], None, ),  # 2
@@ -10537,7 +10537,7 @@ TUserDefinedTypeEntry.thrift_spec = (
 all_structs.append(TTypeEntry)
 TTypeEntry.thrift_spec = (
     None,  # 0
-    (1, TType.STRUCT, 'primitiveEntry', [TPrimitiveTypeEntry, None], None, ),  # 1
+    (1, TType.STRUCT, 'primitiveEntry', [TTAllowedParameterValueEntry, None], None, ),  # 1
     (2, TType.STRUCT, 'arrayEntry', [TArrayTypeEntry, None], None, ),  # 2
     (3, TType.STRUCT, 'mapEntry', [TMapTypeEntry, None], None, ),  # 3
     (4, TType.STRUCT, 'structEntry', [TStructTypeEntry, None], None, ),  # 4

--- a/src/databricks/sql/types.py
+++ b/src/databricks/sql/types.py
@@ -16,7 +16,9 @@
 #
 # Row class was taken from Apache Spark pyspark.
 
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union, TypeVar
+import datetime
+import decimal
 
 
 class Row(tuple):

--- a/src/databricks/sqlalchemy/test/_future.py
+++ b/src/databricks/sqlalchemy/test/_future.py
@@ -298,6 +298,26 @@ class ComponentReflectionTest(ComponentReflectionTest):
     def test_get_multi_pk_constraint(self):
         pass
 
+    @pytest.mark.skip(render_future_feature(FutureFeature.CHECK))
+    def test_get_multi_check_constraints(self):
+        pass
+
+    @pytest.mark.skip(reason=render_future_feature(FutureFeature.TBL_COMMENTS))
+    def test_get_comments(self):
+        pass
+
+    @pytest.mark.skip(reason=render_future_feature(FutureFeature.TBL_COMMENTS))
+    def test_get_comments_with_schema(self):
+        pass
+
+    @pytest.mark.skip(reason=render_future_feature(FutureFeature.TBL_COMMENTS))
+    def test_comments_unicode(self):
+        pass
+
+    @pytest.mark.skip(reason=render_future_feature(FutureFeature.TBL_COMMENTS))
+    def test_comments_unicode_full(self):
+        pass
+
 
 class ComponentReflectionTestExtra(ComponentReflectionTestExtra):
     @pytest.mark.skip(render_future_feature(FutureFeature.CHECK))

--- a/src/databricks/sqlalchemy/test/_regression.py
+++ b/src/databricks/sqlalchemy/test/_regression.py
@@ -5,11 +5,9 @@ from sqlalchemy.testing.suite import (
     ArgSignatureTest,
     BooleanTest,
     CastTypeDecoratorTest,
-    ComponentReflectionTest,
     ComponentReflectionTestExtra,
     CompositeKeyReflectionTest,
     CompoundSelectTest,
-    CTETest,
     DateHistoricTest,
     DateTest,
     DateTimeCoercedToDateTimeTest,
@@ -51,6 +49,11 @@ from sqlalchemy.testing.suite import (
     UnicodeVarcharTest,
     UuidTest,
     ValuesExpressionTest,
+)
+
+from databricks.sqlalchemy.test.overrides._ctetest import CTETest
+from databricks.sqlalchemy.test.overrides._componentreflectiontest import (
+    ComponentReflectionTest,
 )
 
 

--- a/src/databricks/sqlalchemy/test/_unsupported.py
+++ b/src/databricks/sqlalchemy/test/_unsupported.py
@@ -292,6 +292,22 @@ class ComponentReflectionTest(ComponentReflectionTest):
     def test_reflect_table_temp_table(self):
         pass
 
+    @pytest.mark.skip(render_skip_reason(SkipReason.INDEXES))
+    def test_get_indexes(self):
+        pass
+
+    @pytest.mark.skip(render_skip_reason(SkipReason.INDEXES))
+    def test_multi_indexes(self):
+        pass
+
+    @pytest.mark.skip(render_skip_reason(SkipReason.INDEXES))
+    def get_noncol_index(self):
+        pass
+
+    @pytest.mark.skip(render_skip_reason(SkipReason.UNIQUE))
+    def test_get_unique_constraints(self):
+        pass
+
 
 class NumericTest(NumericTest):
     @pytest.mark.skip(render_skip_reason(SkipReason.DECIMAL_FEAT))

--- a/src/databricks/sqlalchemy/test/overrides/_componentreflectiontest.py
+++ b/src/databricks/sqlalchemy/test/overrides/_componentreflectiontest.py
@@ -18,7 +18,7 @@ from sqlalchemy import testing
 from sqlalchemy.testing.suite.test_reflection import ComponentReflectionTest
 
 
-class ComponentReflectionTest(ComponentReflectionTest): # type: ignore
+class ComponentReflectionTest(ComponentReflectionTest):  # type: ignore
     @classmethod
     def define_reflected_tables(cls, metadata, schema):
         if schema:

--- a/src/databricks/sqlalchemy/test/overrides/_componentreflectiontest.py
+++ b/src/databricks/sqlalchemy/test/overrides/_componentreflectiontest.py
@@ -18,7 +18,7 @@ from sqlalchemy import testing
 from sqlalchemy.testing.suite.test_reflection import ComponentReflectionTest
 
 
-class ComponentReflectionTest(ComponentReflectionTest):
+class ComponentReflectionTest(ComponentReflectionTest): # type: ignore
     @classmethod
     def define_reflected_tables(cls, metadata, schema):
         if schema:

--- a/src/databricks/sqlalchemy/test/overrides/_componentreflectiontest.py
+++ b/src/databricks/sqlalchemy/test/overrides/_componentreflectiontest.py
@@ -1,0 +1,189 @@
+"""The default test setup uses self-referential foreign keys and indexes for a test table.
+We override to remove these assumptions.
+
+Note that test_multi_foreign_keys currently does not pass for all combinations due to 
+an ordering issue. The dialect returns the expected information. But this test makes assertions
+on the order of the returned results. We can't guarantee that order at the moment.
+
+The test fixture actually tries to sort the outputs, but this sort isn't working. Will need
+to follow-up on this later.
+"""
+import sqlalchemy as sa
+from sqlalchemy.testing import config
+from sqlalchemy.testing.schema import Column
+from sqlalchemy.testing.schema import Table
+from sqlalchemy import ForeignKey
+from sqlalchemy import testing
+
+from sqlalchemy.testing.suite.test_reflection import ComponentReflectionTest
+
+
+class ComponentReflectionTest(ComponentReflectionTest):
+    @classmethod
+    def define_reflected_tables(cls, metadata, schema):
+        if schema:
+            schema_prefix = schema + "."
+        else:
+            schema_prefix = ""
+
+        if testing.requires.self_referential_foreign_keys.enabled:
+            parent_id_args = (
+                ForeignKey(
+                    "%susers.user_id" % schema_prefix, name="user_id_fk", use_alter=True
+                ),
+            )
+        else:
+            parent_id_args = ()
+        users = Table(
+            "users",
+            metadata,
+            Column("user_id", sa.INT, primary_key=True),
+            Column("test1", sa.CHAR(5), nullable=False),
+            Column("test2", sa.Float(), nullable=False),
+            Column("parent_user_id", sa.Integer, *parent_id_args),
+            sa.CheckConstraint(
+                "test2 > 0",
+                name="zz_test2_gt_zero",
+                comment="users check constraint",
+            ),
+            sa.CheckConstraint("test2 <= 1000"),
+            schema=schema,
+            test_needs_fk=True,
+        )
+
+        Table(
+            "dingalings",
+            metadata,
+            Column("dingaling_id", sa.Integer, primary_key=True),
+            Column(
+                "address_id",
+                sa.Integer,
+                ForeignKey(
+                    "%semail_addresses.address_id" % schema_prefix,
+                    name="zz_email_add_id_fg",
+                    comment="di fk comment",
+                ),
+            ),
+            Column(
+                "id_user",
+                sa.Integer,
+                ForeignKey("%susers.user_id" % schema_prefix),
+            ),
+            Column("data", sa.String(30), unique=True),
+            sa.CheckConstraint(
+                "address_id > 0 AND address_id < 1000",
+                name="address_id_gt_zero",
+            ),
+            sa.UniqueConstraint(
+                "address_id",
+                "dingaling_id",
+                name="zz_dingalings_multiple",
+                comment="di unique comment",
+            ),
+            schema=schema,
+            test_needs_fk=True,
+        )
+        Table(
+            "email_addresses",
+            metadata,
+            Column("address_id", sa.Integer),
+            Column("remote_user_id", sa.Integer, ForeignKey(users.c.user_id)),
+            Column("email_address", sa.String(20)),
+            sa.PrimaryKeyConstraint(
+                "address_id", name="email_ad_pk", comment="ea pk comment"
+            ),
+            schema=schema,
+            test_needs_fk=True,
+        )
+        Table(
+            "comment_test",
+            metadata,
+            Column("id", sa.Integer, primary_key=True, comment="id comment"),
+            Column("data", sa.String(20), comment="data % comment"),
+            Column(
+                "d2",
+                sa.String(20),
+                comment=r"""Comment types type speedily ' " \ '' Fun!""",
+            ),
+            Column("d3", sa.String(42), comment="Comment\nwith\rescapes"),
+            schema=schema,
+            comment=r"""the test % ' " \ table comment""",
+        )
+        Table(
+            "no_constraints",
+            metadata,
+            Column("data", sa.String(20)),
+            schema=schema,
+            comment="no\nconstraints\rhas\fescaped\vcomment",
+        )
+
+        if testing.requires.cross_schema_fk_reflection.enabled:
+            if schema is None:
+                Table(
+                    "local_table",
+                    metadata,
+                    Column("id", sa.Integer, primary_key=True),
+                    Column("data", sa.String(20)),
+                    Column(
+                        "remote_id",
+                        ForeignKey("%s.remote_table_2.id" % testing.config.test_schema),
+                    ),
+                    test_needs_fk=True,
+                    schema=config.db.dialect.default_schema_name,
+                )
+            else:
+                Table(
+                    "remote_table",
+                    metadata,
+                    Column("id", sa.Integer, primary_key=True),
+                    Column(
+                        "local_id",
+                        ForeignKey(
+                            "%s.local_table.id" % config.db.dialect.default_schema_name
+                        ),
+                    ),
+                    Column("data", sa.String(20)),
+                    schema=schema,
+                    test_needs_fk=True,
+                )
+                Table(
+                    "remote_table_2",
+                    metadata,
+                    Column("id", sa.Integer, primary_key=True),
+                    Column("data", sa.String(20)),
+                    schema=schema,
+                    test_needs_fk=True,
+                )
+
+        if testing.requires.index_reflection.enabled:
+            Index("users_t_idx", users.c.test1, users.c.test2, unique=True)
+            Index("users_all_idx", users.c.user_id, users.c.test2, users.c.test1)
+
+            if not schema:
+                # test_needs_fk is at the moment to force MySQL InnoDB
+                noncol_idx_test_nopk = Table(
+                    "noncol_idx_test_nopk",
+                    metadata,
+                    Column("q", sa.String(5)),
+                    test_needs_fk=True,
+                )
+
+                noncol_idx_test_pk = Table(
+                    "noncol_idx_test_pk",
+                    metadata,
+                    Column("id", sa.Integer, primary_key=True),
+                    Column("q", sa.String(5)),
+                    test_needs_fk=True,
+                )
+
+                if (
+                    testing.requires.indexes_with_ascdesc.enabled
+                    and testing.requires.reflect_indexes_with_ascdesc.enabled
+                ):
+                    Index("noncol_idx_nopk", noncol_idx_test_nopk.c.q.desc())
+                    Index("noncol_idx_pk", noncol_idx_test_pk.c.q.desc())
+
+        if testing.requires.view_column_reflection.enabled:
+            cls.define_views(metadata, schema)
+        if not schema and testing.requires.temp_table_reflection.enabled:
+            cls.define_temp_tables(metadata)

--- a/src/databricks/sqlalchemy/test/overrides/_ctetest.py
+++ b/src/databricks/sqlalchemy/test/overrides/_ctetest.py
@@ -11,7 +11,7 @@ from sqlalchemy import Integer
 from sqlalchemy import String
 
 
-class CTETest(CTETest):
+class CTETest(CTETest): # type: ignore
     @classmethod
     def define_tables(cls, metadata):
         Table(

--- a/src/databricks/sqlalchemy/test/overrides/_ctetest.py
+++ b/src/databricks/sqlalchemy/test/overrides/_ctetest.py
@@ -1,0 +1,33 @@
+"""The default test setup uses a self-referential foreign key. With our dialect this requires
+`use_alter=True` and the fk constraint to be named. So we override this to make the test pass.
+"""
+
+from sqlalchemy.testing.suite import CTETest
+
+from sqlalchemy.testing.schema import Column
+from sqlalchemy.testing.schema import Table
+from sqlalchemy import ForeignKey
+from sqlalchemy import Integer
+from sqlalchemy import String
+
+
+class CTETest(CTETest):
+    @classmethod
+    def define_tables(cls, metadata):
+        Table(
+            "some_table",
+            metadata,
+            Column("id", Integer, primary_key=True),
+            Column("data", String(50)),
+            Column(
+                "parent_id", ForeignKey("some_table.id", name="fk_test", use_alter=True)
+            ),
+        )
+
+        Table(
+            "some_other_table",
+            metadata,
+            Column("id", Integer, primary_key=True),
+            Column("data", String(50)),
+            Column("parent_id", Integer),
+        )

--- a/src/databricks/sqlalchemy/test/overrides/_ctetest.py
+++ b/src/databricks/sqlalchemy/test/overrides/_ctetest.py
@@ -11,7 +11,7 @@ from sqlalchemy import Integer
 from sqlalchemy import String
 
 
-class CTETest(CTETest): # type: ignore
+class CTETest(CTETest):  # type: ignore
     @classmethod
     def define_tables(cls, metadata):
         Table(

--- a/src/databricks/sqlalchemy/test/test_suite.py
+++ b/src/databricks/sqlalchemy/test/test_suite.py
@@ -4,19 +4,6 @@ then are overridden by our local skip markers in _regression, _unsupported, and 
 """
 
 
-def start_protocol_patch():
-    """See tests/test_parameterized_queries.py for more information about this patch."""
-    from unittest.mock import patch
-
-    native_support_patcher = patch(
-        "databricks.sql.client.Connection.server_parameterized_queries_enabled",
-        return_value=True,
-    )
-    native_support_patcher.start()
-
-
-start_protocol_patch()
-
 # type: ignore
 # fmt: off
 from sqlalchemy.testing.suite import *

--- a/src/databricks/sqlalchemy/test_local/e2e/test_basic.py
+++ b/src/databricks/sqlalchemy/test_local/e2e/test_basic.py
@@ -22,10 +22,6 @@ try:
 except ImportError:
     from sqlalchemy.ext.declarative import declarative_base
 
-from databricks.sqlalchemy.test.test_suite import start_protocol_patch
-
-start_protocol_patch()
-
 
 USER_AGENT_TOKEN = "PySQL e2e Tests"
 

--- a/tests/e2e/test_parameterized_queries.py
+++ b/tests/e2e/test_parameterized_queries.py
@@ -271,11 +271,11 @@ class TestParameterizedQueries(PySQLPytestTestCase):
                     cursor.execute("SELECT %(p)s", parameters={"p": 1})
                     if explicit_inline:
                         assert (
-                            "Consider using native parameters." not in caplog.text
+                            "Consider using native parameters." in caplog.text
                         ), "Log message should be suppressed"
                     else:
                         assert (
-                            "Consider using native parameters." in caplog.text
+                            "Consider using native parameters." not in caplog.text
                         ), "Log message should not be supressed"
 
 

--- a/tests/e2e/test_parameterized_queries.py
+++ b/tests/e2e/test_parameterized_queries.py
@@ -350,6 +350,13 @@ class TestParameterizedQueries(PySQLPytestTestCase):
 
         assert set(outcome) == set(expected)
 
+    def test_readme_example(self):
+        with self.cursor() as cursor:
+            result = cursor.execute('SELECT :param `p`, * FROM RANGE(10)', {"param": "foo"}).fetchall()
+        
+        assert len(result) == 10
+        assert result[0].p == "foo"
+
 
 class TestInlineParameterSyntax(PySQLPytestTestCase):
     """The inline parameter approach uses pyformat markers"""

--- a/tests/e2e/test_parameterized_queries.py
+++ b/tests/e2e/test_parameterized_queries.py
@@ -8,7 +8,6 @@ from unittest.mock import patch
 import pytest
 import pytz
 
-from databricks.sql.exc import DatabaseError
 from databricks.sql.parameters.native import (
     BigIntegerParameter,
     BooleanParameter,
@@ -361,7 +360,6 @@ class TestParameterizedQueries(PySQLPytestTestCase):
 class TestInlineParameterSyntax(PySQLPytestTestCase):
     """The inline parameter approach uses pyformat markers"""
 
-    # @pytest.mark.parametrize("use_inline_params", (True, False))
     def test_params_as_dict(self):
         query = "SELECT %(foo)s foo, %(bar)s bar, %(baz)s baz"
         params = {"foo": 1, "bar": 2, "baz": 3}

--- a/tests/e2e/test_parameterized_queries.py
+++ b/tests/e2e/test_parameterized_queries.py
@@ -1,37 +1,76 @@
 import datetime
+from contextlib import contextmanager
 from decimal import Decimal
 from enum import Enum
-from typing import Dict, List, Tuple, Union
-from unittest.mock import Mock, patch, MagicMock
-from databricks.sql import Error
+from typing import Dict, List, Union
+from unittest.mock import patch
 
-from databricks.sql.thrift_api.TCLIService import ttypes
-from contextlib import contextmanager
+from databricks.sql.exc import DatabaseError
 
-import pytz
 import pytest
+import pytz
 
+from databricks.sql import Error
 from databricks.sql.exc import NotSupportedError
+from databricks.sql.thrift_api.TCLIService import ttypes
 from databricks.sql.utils import (
+    TYPE_INFERRENCE_LOOKUP_TABLE,
     DbSqlParameter,
     DbSqlType,
-    calculate_decimal_cast_string,
     ParameterApproach,
+    calculate_decimal_cast_string,
 )
-
-from functools import wraps
-
 from tests.e2e.test_driver import PySQLPytestTestCase
 
 
-class MyCustomDecimalType(Enum):
+class ParamStyle(Enum):
+    NAMED = 1
+    PYFORMAT = 2
+    NONE = 3
+
+
+class Primitive(Enum):
+    """These are the inferrable types. This Enum is used for parametrized tests."""
+
+    NONE = None
+    BOOL = True
+    INT = 1
+    STRING = "Hello"
+    DECIMAL = Decimal("1234.56")
+    DATE = datetime.date(2023, 9, 6)
+    TIMESTAMP = datetime.datetime(2023, 9, 6, 3, 14, 27, 843, tzinfo=pytz.UTC)
+    DOUBLE = 3.14
+
+
+class T(Enum):
+    """This is a utility Enum for the explicit dbsqlparam tests"""
+
     DECIMAL_38_0 = "DECIMAL(38,0)"
     DECIMAL_38_2 = "DECIMAL(38,2)"
     DECIMAL_18_9 = "DECIMAL(18,9)"
 
 
-both_approaches = pytest.mark.parametrize(
-    "approach", (ParameterApproach.INLINE, ParameterApproach.NATIVE)
+# We don't test inline approach with named paramstyle because it's never supported
+approach_paramstyle_combinations = [
+    (ParameterApproach.INLINE, ParamStyle.PYFORMAT),
+    (ParameterApproach.NATIVE, ParamStyle.PYFORMAT),
+    (ParameterApproach.NATIVE, ParamStyle.NAMED),
+]
+
+# Each of these decimals requries the specified type string to be expressed in delta table
+decimal_value_custom_type_combinations = [
+    (Decimal("123456789.123456789"), T.DECIMAL_18_9),
+    (Decimal("123456789123456789123456789123456789.12"), T.DECIMAL_38_2),
+    (Decimal("12345678912345678912345678912345678912"), T.DECIMAL_38_0),
+]
+
+# This generates a list of tuples of (Primtive, DbSqlType)
+primitive_dbsqltype_combinations = [
+    (prim, TYPE_INFERRENCE_LOOKUP_TABLE.get(type(prim))) for prim in Primitive
+]
+
+both_paramstyles = pytest.mark.parametrize(
+    "paramstyle", (ParamStyle.PYFORMAT, ParamStyle.NAMED)
 )
 
 
@@ -52,7 +91,8 @@ class TestParameterizedQueries(PySQLPytestTestCase):
     for @both_approaches.
     """
 
-    NATIVE_QUERY = "SELECT :p AS col"
+    NAMED_PARAMSTYLE_QUERY = "SELECT :p AS col"
+    PYFORMAT_PARAMSTYLE_QUERY = "SELECT %(p)s AS col"
 
     inline_type_map = {
         int: "int_col",
@@ -107,13 +147,16 @@ class TestParameterizedQueries(PySQLPytestTestCase):
             finally:
                 pass
 
-    def _inline_roundtrip(self, params: dict):
+    def _inline_roundtrip(self, params: dict, paramstyle: ParamStyle):
         """This INSERT, SELECT, DELETE dance is necessary because simply selecting
         ```
         "SELECT %(param)s"
         ```
         in INLINE mode would always return a str and the nature of the test is to
         confirm that types are maintained.
+
+        :paramstyle:
+            This is a no-op but is included to make the test-code easier to read.
         """
         target_column = self.inline_type_map[type(params.get("p"))]
         INSERT_QUERY = f"INSERT INTO pysql_e2e_inline_param_test_table (`{target_column}`) VALUES (%(p)s)"
@@ -130,24 +173,86 @@ class TestParameterizedQueries(PySQLPytestTestCase):
 
         return to_return
 
-    def _native_roundtrip(self, parameters: Union[Dict, List[Dict]]):
+    def _native_roundtrip(
+        self,
+        parameters: Union[Dict, List[Dict]],
+        paramstyle: ParamStyle,
+    ):
+        if paramstyle == ParamStyle.NAMED:
+            _query = self.NAMED_PARAMSTYLE_QUERY
+        elif paramstyle == ParamStyle.PYFORMAT:
+            _query = self.PYFORMAT_PARAMSTYLE_QUERY
         with self.connection(extra_params={"use_inline_params": False}) as conn:
             with conn.cursor() as cursor:
-                cursor.execute(self.NATIVE_QUERY, parameters=parameters)
+                cursor.execute(_query, parameters=parameters)
                 return cursor.fetchone()
 
-    def _get_one_result(self, approach: ParameterApproach, params):
+    def _get_one_result(
+        self,
+        params,
+        approach: ParameterApproach = ParameterApproach.NONE,
+        paramstyle: ParamStyle = ParamStyle.NONE,
+    ):
         """When approach is INLINE then we use %(param)s paramstyle and a connection with use_inline_params=True
         When approach is NATIVE then we use :param paramstyle and a connection with use_inline_params=False
         """
 
         if approach == ParameterApproach.INLINE:
-            return self._inline_roundtrip(params)
+            # inline mode always uses ParamStyle.PYFORMAT
+            return self._inline_roundtrip(params, paramstyle=ParamStyle.PYFORMAT)
         elif approach == ParameterApproach.NATIVE:
-            return self._native_roundtrip(params)
+            # native mode can use either ParamStyle.NAMED or ParamStyle.PYFORMAT
+            return self._native_roundtrip(params, paramstyle=paramstyle)
 
     def _quantize(self, input: Union[float, int], place_value=2) -> Decimal:
         return Decimal(str(input)).quantize(Decimal("0." + "0" * place_value))
+
+    def _eq(self, actual, expected: Primitive):
+        """This is a helper function to make the test code more readable.
+
+        If primitive is Primitive.DOUBLE than an extra quantize step is performed before
+        making the assertion.
+        """
+        if expected == Primitive.DOUBLE:
+            return self._quantize(actual) == self._quantize(expected.value)
+
+        return actual == expected.value
+
+    @pytest.mark.parametrize("primitive", Primitive)
+    @pytest.mark.parametrize("approach,paramstyle", approach_paramstyle_combinations)
+    def test_primitive_with_inferrence(
+        self, approach, paramstyle, primitive: Primitive
+    ):
+        """When ParameterApproach.INLINE is passed, inferrence will not be used.
+        When ParameterApproach.NATIVE is passed, primitive inputs will be inferred.
+        """
+
+        params = {"p": primitive.value}
+        result = self._get_one_result(params, approach, paramstyle)
+
+        assert self._eq(result.col, primitive)
+
+    @pytest.mark.parametrize("primitive", Primitive)
+    def test_dbsqlparam_with_inferrence(self, primitive: Primitive):
+        params = [DbSqlParameter(name="p", value=primitive.value, type=None)]
+        result = self._get_one_result(params, ParameterApproach.NATIVE, ParamStyle.NAMED)
+        assert self._eq(result.col, primitive)
+
+    @pytest.mark.parametrize("primitive,dbsqltype", primitive_dbsqltype_combinations)
+    def test_dbsqlparam_explicit(
+        self, primitive: Primitive, dbsqltype: DbSqlType
+    ):
+        params = [DbSqlParameter(name="p", value=primitive.value, type=dbsqltype)]
+        result = self._get_one_result(params, ParameterApproach.NATIVE, ParamStyle.NAMED)
+        assert self._eq(result.col, primitive)
+
+    @pytest.mark.parametrize("value, dbsqltype", decimal_value_custom_type_combinations)
+    def test_dbsqlparam_custom_type(self, value, dbsqltype):
+        params = [DbSqlParameter(name="p", value=value, type=dbsqltype)]
+        result = self._get_one_result(
+            params, ParameterApproach.NATIVE, ParamStyle.NAMED
+        )
+        assert result.col == value
 
     @pytest.mark.parametrize("explicit_inline", (True, False))
     def test_use_inline_by_default_with_warning(self, explicit_inline, caplog):
@@ -158,7 +263,7 @@ class TestParameterizedQueries(PySQLPytestTestCase):
 
         extra_args = {"use_inline_params": True} if explicit_inline else {}
 
-        with self.connection(extra_args) as conn:
+        with self.connection(extra_params=extra_args) as conn:
             with conn.cursor() as cursor:
                 with self.patch_server_supports_native_params(
                     supports_native_params=True
@@ -173,185 +278,55 @@ class TestParameterizedQueries(PySQLPytestTestCase):
                             "Consider using native parameters." in caplog.text
                         ), "Log message should not be supressed"
 
-    @both_approaches
-    def test_primitive_inferred_none(self, approach: ParameterApproach, inline_table):
-        params = {"p": None}
-        result = self._get_one_result(approach, params)
-        assert result.col == None
 
-    @both_approaches
-    def test_primitive_inferred_bool(self, approach: ParameterApproach, inline_table):
-        params = {"p": True}
-        result = self._get_one_result(approach, params)
-        assert result.col == True
+def test_calculate_decimal_cast_string():
+    assert calculate_decimal_cast_string(Decimal("10.00")) == "DECIMAL(4,2)"
+    assert (
+        calculate_decimal_cast_string(Decimal("123456789123456789.123456789123456789"))
+        == "DECIMAL(36,18)"
+    )
 
-    @both_approaches
-    def test_primitive_inferred_integer(
-        self, approach: ParameterApproach, inline_table
-    ):
-        params = {"p": 1}
-        result = self._get_one_result(approach, params)
-        assert result.col == 1
 
-    def test_primitive_inferred_double(self):
-        params = {"p": 3.14}
-        result = self._get_one_result(ParameterApproach.NATIVE, params)
-        assert self._quantize(result.col) == self._quantize(3.14)
+class TestInlineParameterSyntax(PySQLPytestTestCase):
+    """The inline parameter approach use s"""
 
-    @both_approaches
-    def test_primitive_inferred_date(self, approach: ParameterApproach, inline_table):
-        # DATE in Databricks is mapped into a datetime.date object in Python
-        date_value = datetime.date(2023, 9, 6)
-        params = {"p": date_value}
-        result = self._get_one_result(approach, params)
-        assert result.col == date_value
+    @pytest.mark.parametrize("use_inline_params", (True, False))
+    def test_params_as_dict(self, use_inline_params):
+        query = "SELECT %(foo)s foo, %(bar)s bar, %(baz)s baz"
+        params = {"foo": 1, "bar": 2, "baz": 3}
 
-    @both_approaches
-    def test_primitive_inferred_timestamp(
-        self, approach: ParameterApproach, inline_table
-    ):
-        # TIMESTAMP in Databricks is mapped into a datetime.datetime object in Python
-        date_value = datetime.datetime(2023, 9, 6, 3, 14, 27, 843, tzinfo=pytz.UTC)
-        params = {"p": date_value}
-        result = self._get_one_result(approach, params)
-        assert result.col == date_value
+        with self.connection(
+            extra_params={"use_inline_params": use_inline_params}
+        ) as conn:
+            with conn.cursor() as cursor:
+                result = cursor.execute(query, parameters=params).fetchone()
 
-    @both_approaches
-    def test_primitive_inferred_string(self, approach: ParameterApproach, inline_table):
-        params = {"p": "Hello"}
-        result = self._get_one_result(approach, params)
-        assert result.col == "Hello"
+        assert result.foo == 1
+        assert result.bar == 2
+        assert result.baz == 3
 
-    @both_approaches
-    def test_primitive_inferred_decimal(
-        self, approach: ParameterApproach, inline_table
-    ):
-        params = {"p": Decimal("1234.56")}
-        result = self._get_one_result(approach, params)
-        assert result.col == Decimal("1234.56")
+    @pytest.mark.parametrize("use_inline_params", (True, False))
+    def test_params_as_sequence(self, use_inline_params):
+        """One side-effect of ParamEscaper using Python string interpolation to inline the values
+        is that it can work with "ordinal" parameters, but only if a user writes parameter markers
+        that are not defined with PEP-249. This test exists to prove that it works.
 
-    def test_dbsqlparam_inferred_none(self):
-        params = [DbSqlParameter(name="p", value=None, type=None)]
-        result = self._get_one_result(ParameterApproach.NATIVE, params)
-        assert result.col == None
+        But this test is expected to fail when using native approach because we haven't implemented
+        ordinal parameters under the native approach (yet).
+        """
 
-    def test_dbsqlparam_inferred_bool(self):
-        params = [DbSqlParameter(name="p", value=True, type=None)]
-        result = self._get_one_result(ParameterApproach.NATIVE, params)
-        assert result.col == True
+        query = "SELECT %s foo, %s bar, %s baz"
+        params = (1, 2, 3)
 
-    def test_dbsqlparam_inferred_integer(self):
-        params = [DbSqlParameter(name="p", value=1, type=None)]
-        result = self._get_one_result(ParameterApproach.NATIVE, params)
-        assert result.col == 1
-
-    def test_dbsqlparam_inferred_double(self):
-        params = [DbSqlParameter(name="p", value=3.14, type=None)]
-        result = self._get_one_result(ParameterApproach.NATIVE, params)
-        assert self._quantize(result.col) == self._quantize(3.14)
-
-    def test_dbsqlparam_inferred_date(self):
-        # DATE in Databricks is mapped into a datetime.date object in Python
-        date_value = datetime.date(2023, 9, 6)
-        params = [DbSqlParameter(name="p", value=date_value, type=None)]
-        result = self._get_one_result(ParameterApproach.NATIVE, params)
-        assert result.col == date_value
-
-    def test_dbsqlparam_inferred_timestamp(self):
-        # TIMESTAMP in Databricks is mapped into a datetime.datetime object in Python
-        date_value = datetime.datetime(2023, 9, 6, 3, 14, 27, 843, tzinfo=pytz.UTC)
-        params = [DbSqlParameter(name="p", value=date_value, type=None)]
-        result = self._get_one_result(ParameterApproach.NATIVE, params)
-        assert result.col == date_value
-
-    def test_dbsqlparam_inferred_string(self):
-        params = [DbSqlParameter(name="p", value="Hello", type=None)]
-        result = self._get_one_result(ParameterApproach.NATIVE, params)
-        assert result.col == "Hello"
-
-    def test_dbsqlparam_inferred_decimal(self):
-        params = [DbSqlParameter(name="p", value=Decimal("1234.56"), type=None)]
-        result = self._get_one_result(ParameterApproach.NATIVE, params)
-        assert result.col == Decimal("1234.56")
-
-    def test_dbsqlparam_explicit_none(self):
-        params = [DbSqlParameter(name="p", value=None, type=DbSqlType.VOID)]
-        result = self._get_one_result(ParameterApproach.NATIVE, params)
-        assert result.col == None
-
-    def test_dbsqlparam_explicit_bool(self):
-        params = [DbSqlParameter(name="p", value=True, type=DbSqlType.BOOLEAN)]
-        result = self._get_one_result(ParameterApproach.NATIVE, params)
-        assert result.col == True
-
-    def test_dbsqlparam_explicit_integer(self):
-        params = [DbSqlParameter(name="p", value=1, type=DbSqlType.INTEGER)]
-        result = self._get_one_result(ParameterApproach.NATIVE, params)
-        assert result.col == 1
-
-    def test_dbsqlparam_explicit_double(self):
-        params = [DbSqlParameter(name="p", value=3.14, type=DbSqlType.FLOAT)]
-        result = self._get_one_result(ParameterApproach.NATIVE, params)
-        assert self._quantize(result.col) == self._quantize(3.14)
-
-    def test_dbsqlparam_explicit_date(self):
-        # DATE in Databricks is mapped into a datetime.date object in Python
-        date_value = datetime.date(2023, 9, 6)
-        params = [DbSqlParameter(name="p", value=date_value, type=DbSqlType.DATE)]
-        result = self._get_one_result(ParameterApproach.NATIVE, params)
-        assert result.col == date_value
-
-    def test_dbsqlparam_explicit_timestamp(self):
-        # TIMESTAMP in Databricks is mapped into a datetime.datetime object in Python
-        date_value = datetime.datetime(2023, 9, 6, 3, 14, 27, 843, tzinfo=pytz.UTC)
-        params = [DbSqlParameter(name="p", value=date_value, type=DbSqlType.TIMESTAMP)]
-        result = self._get_one_result(ParameterApproach.NATIVE, params)
-        assert result.col == date_value
-
-    def test_dbsqlparam_explicit_string(self):
-        params = [DbSqlParameter(name="p", value="Hello", type=DbSqlType.STRING)]
-        result = self._get_one_result(ParameterApproach.NATIVE, params)
-        assert result.col == "Hello"
-
-    def test_dbsqlparam_explicit_decimal(self):
-        params = [
-            DbSqlParameter(name="p", value=Decimal("1234.56"), type=DbSqlType.DECIMAL)
-        ]
-        result = self._get_one_result(ParameterApproach.NATIVE, params)
-        assert result.col == Decimal("1234.56")
-
-    def test_dbsqlparam_custom_explicit_decimal_38_0(self):
-        # This DECIMAL can be contained in a DECIMAL(38,0) column in Databricks
-        value = Decimal("12345678912345678912345678912345678912")
-        params = [
-            DbSqlParameter(name="p", value=value, type=MyCustomDecimalType.DECIMAL_38_0)
-        ]
-        result = self._get_one_result(ParameterApproach.NATIVE, params)
-        assert result.col == value
-
-    def test_dbsqlparam_custom_explicit_decimal_38_2(self):
-        # This DECIMAL can be contained in a DECIMAL(38,2) column in Databricks
-        value = Decimal("123456789123456789123456789123456789.12")
-        params = [
-            DbSqlParameter(name="p", value=value, type=MyCustomDecimalType.DECIMAL_38_2)
-        ]
-        result = self._get_one_result(ParameterApproach.NATIVE, params)
-        assert result.col == value
-
-    def test_dbsqlparam_custom_explicit_decimal_18_9(self):
-        # This DECIMAL can be contained in a DECIMAL(18,9) column in Databricks
-        value = Decimal("123456789.123456789")
-        params = [
-            DbSqlParameter(name="p", value=value, type=MyCustomDecimalType.DECIMAL_18_9)
-        ]
-        result = self._get_one_result(ParameterApproach.NATIVE, params)
-        assert result.col == value
-
-    def test_calculate_decimal_cast_string(self):
-        assert calculate_decimal_cast_string(Decimal("10.00")) == "DECIMAL(4,2)"
-        assert (
-            calculate_decimal_cast_string(
-                Decimal("123456789123456789.123456789123456789")
-            )
-            == "DECIMAL(36,18)"
-        )
+        with self.connection(
+            extra_params={"use_inline_params": use_inline_params}
+        ) as conn:
+            with conn.cursor() as cursor:
+                if not use_inline_params:
+                    with pytest.raises(DatabaseError):
+                        cursor.execute(query, parameters=params).fetchone()
+                else:
+                    result = cursor.execute(query, parameters=params).fetchone()
+                    assert result.foo == 1
+                    assert result.bar == 2
+                    assert result.baz == 3

--- a/tests/e2e/test_parameterized_queries.py
+++ b/tests/e2e/test_parameterized_queries.py
@@ -94,35 +94,13 @@ class TestParameterizedQueries(PySQLPytestTestCase):
             with conn.cursor() as cursor:
                 cursor.execute(query)
 
-    def compute_says_it_doesnt_support_native_params(self):
-        """we test against dogfood. dogfood exposes a protocol version that suggests it can't handle
-        native queries, even though it does. for test coverage, we can mock the local protocol check.
-        but we want to remove this mock once dogfood properly advertises its version.
-        """
-
-        with self.connection() as conn:
-            return (
-                conn.protocol_version
-                < ttypes.TProtocolVersion.SPARK_CLI_SERVICE_PROTOCOL_V8
-            )
-
     @contextmanager
-    def conditional_protocol_patch(self, bypass=False):
-        """This fixture will be removed once dogfood advertises its protocol version correctly.
-
-        Note that there is an equivalent patch in sqlalchemy/test/test_suite.py which should be
-        removed at the same time as this one. That one is encapsulated in a function called
-        start_protocol_patch()"""
-
-        if bypass:
-            yield None
-
-        if not self.compute_says_it_doesnt_support_native_params():
-            yield None
+    def patch_server_supports_native_params(self, supports_native_params: bool = True):
+        """Applies a patch so we can test the connector's behaviour under different SPARK_CLI_SERVICE_PROTOCOL_VERSION conditions."""
 
         with patch(
             "databricks.sql.client.Connection.server_parameterized_queries_enabled",
-            return_value=True,
+            return_value=supports_native_params,
         ) as mock_parameterized_queries_enabled:
             try:
                 yield mock_parameterized_queries_enabled
@@ -152,16 +130,13 @@ class TestParameterizedQueries(PySQLPytestTestCase):
 
         return to_return
 
-    def _native_roundtrip(
-        self, parameters: Union[Dict, List[Dict]], bypass_patch=False
-    ):
+    def _native_roundtrip(self, parameters: Union[Dict, List[Dict]]):
         with self.connection(extra_params={"use_inline_params": False}) as conn:
             with conn.cursor() as cursor:
-                with self.conditional_protocol_patch(bypass_patch):
-                    cursor.execute(self.NATIVE_QUERY, parameters=parameters)
-                    return cursor.fetchone()
+                cursor.execute(self.NATIVE_QUERY, parameters=parameters)
+                return cursor.fetchone()
 
-    def _get_one_result(self, approach: ParameterApproach, params, bypass_patch=False):
+    def _get_one_result(self, approach: ParameterApproach, params):
         """When approach is INLINE then we use %(param)s paramstyle and a connection with use_inline_params=True
         When approach is NATIVE then we use :param paramstyle and a connection with use_inline_params=False
         """
@@ -169,46 +144,15 @@ class TestParameterizedQueries(PySQLPytestTestCase):
         if approach == ParameterApproach.INLINE:
             return self._inline_roundtrip(params)
         elif approach == ParameterApproach.NATIVE:
-            return self._native_roundtrip(params, bypass_patch)
+            return self._native_roundtrip(params)
 
     def _quantize(self, input: Union[float, int], place_value=2) -> Decimal:
         return Decimal(str(input)).quantize(Decimal("0." + "0" * place_value))
 
-    def test_compute_says_it_doesnt_support_native_params(self):
-        """This is a canary test case that will should be removed when it begins to fail.
-
-        It asserts that the target compute resource returns a protocol_version that _should_ mean it can't support
-        ParameterApproach.NATIVE.
-
-        We added this test case because the DBR we use for testing returns a protocol version that is too
-        low to support the native approach, but it does in fact support this approach. Without this patch
-        we'd have no way to run tests of the native approach because the connector would raise an exception.
-
-        Once the target compute accurately advertises the right protocol version, this test will begin
-        to fail and we can remove the conditional_protocol_patch.
-        """
-        assert (
-            self.compute_says_it_doesnt_support_native_params()
-        ), "Compute no longer says it doesn't support native params. Remove conditional_protocol_patch from this file."
-
-    @patch(
-        "databricks.sql.client.Connection.server_parameterized_queries_enabled",
-        return_value=False,
-    )
-    def test_protocol_too_low(self, mock_parameterized_queries_enabled):
-        params = {"p": None}
-        with pytest.raises(
-            NotSupportedError,
-            match="Parameterized operations are not supported by this server. DBR 14.1 is required.",
-        ):
-            result = self._get_one_result(
-                ParameterApproach.NATIVE, params, bypass_patch=True
-            )
-
     @pytest.mark.parametrize("explicit_inline", (True, False))
     def test_use_inline_by_default_with_warning(self, explicit_inline, caplog):
         """
-        use_inline_params should be True by default.
+        use_inline_params should be True by default. Warn the user if server supports native parameters.
         If a user explicitly sets use_inline_params, don't warn them about it.
         """
 
@@ -216,7 +160,9 @@ class TestParameterizedQueries(PySQLPytestTestCase):
 
         with self.connection(extra_args) as conn:
             with conn.cursor() as cursor:
-                with self.conditional_protocol_patch():
+                with self.patch_server_supports_native_params(
+                    supports_native_params=True
+                ):
                     cursor.execute("SELECT %(p)s", parameters={"p": 1})
                     if explicit_inline:
                         assert (

--- a/tests/unit/test_param_escaper.py
+++ b/tests/unit/test_param_escaper.py
@@ -1,8 +1,9 @@
 from datetime import date, datetime
 import unittest, pytest, decimal
 from typing import Any, Dict
+from databricks.sql.parameters.native import dbsql_parameter_from_primitive
 
-from databricks.sql.utils import ParamEscaper, inject_parameters, transform_paramstyle
+from databricks.sql.utils import ParamEscaper, inject_parameters, transform_paramstyle, ParameterStructure
 
 pe = ParamEscaper()
 
@@ -198,7 +199,9 @@ class TestInlineToNativeTransformer(object):
         ),
     )
     def test_transformer(
-        self, label: str, query: str, params: Dict[str, Any], expected
+        self, label: str, query: str, params: Dict[str, Any], expected: str
     ):
-        output = transform_paramstyle(query, params)
+        
+        _params = [dbsql_parameter_from_primitive(value=value, name=name) for name, value in params.items()]
+        output = transform_paramstyle(query, _params, param_structure=ParameterStructure.NAMED)
         assert output == expected

--- a/tests/unit/test_param_escaper.py
+++ b/tests/unit/test_param_escaper.py
@@ -1,104 +1,129 @@
 from datetime import date, datetime
 import unittest, pytest, decimal
+from typing import Any, Dict
 
-from databricks.sql.utils import ParamEscaper, inject_parameters
+from databricks.sql.utils import ParamEscaper, inject_parameters, transform_paramstyle
 
 pe = ParamEscaper()
 
-class TestIndividualFormatters(object):
 
+class TestIndividualFormatters(object):
     # Test individual type escapers
     def test_escape_number_integer(self):
-        """This behaviour falls back to Python's default string formatting of numbers
-        """
+        """This behaviour falls back to Python's default string formatting of numbers"""
         assert pe.escape_number(100) == 100
 
     def test_escape_number_float(self):
-        """This behaviour falls back to Python's default string formatting of numbers
-        """
+        """This behaviour falls back to Python's default string formatting of numbers"""
         assert pe.escape_number(100.1234) == 100.1234
 
     def test_escape_number_decimal(self):
-        """This behaviour uses the string representation of a decimal
-        """
+        """This behaviour uses the string representation of a decimal"""
         assert pe.escape_decimal(decimal.Decimal("124.32")) == "124.32"
 
     def test_escape_string_normal(self):
-        """
-        """
+        """ """
 
         assert pe.escape_string("golly bob howdy") == "'golly bob howdy'"
 
     def test_escape_string_that_includes_special_characters(self):
-      """Tests for how special characters are treated.
+        """Tests for how special characters are treated.
 
-      When passed a string, the `escape_string` method wraps it in single quotes
-      and escapes any special characters with a back stroke (\)
+        When passed a string, the `escape_string` method wraps it in single quotes
+        and escapes any special characters with a back stroke (\)
 
-      Example:
+        Example:
 
-      IN : his name was 'robert palmer'
-      OUT: 'his name was \'robert palmer\''
-      """
+        IN : his name was 'robert palmer'
+        OUT: 'his name was \'robert palmer\''
+        """
 
-      # Testing for the presence of these characters: '"/\😂
+        # Testing for the presence of these characters: '"/\😂
 
-      assert pe.escape_string("his name was 'robert palmer'") == r"'his name was \'robert palmer\''"
+        assert (
+            pe.escape_string("his name was 'robert palmer'")
+            == r"'his name was \'robert palmer\''"
+        )
 
-      # These tests represent the same user input in the several ways it can be written in Python
-      # Each argument to `escape_string` evaluates to the same bytes. But Python lets us write it differently.
-      assert pe.escape_string("his name was \"robert palmer\"") == "'his name was \"robert palmer\"'"
-      assert pe.escape_string('his name was "robert palmer"') == "'his name was \"robert palmer\"'"
-      assert pe.escape_string('his name was {}'.format('"robert palmer"')) == "'his name was \"robert palmer\"'"
+        # These tests represent the same user input in the several ways it can be written in Python
+        # Each argument to `escape_string` evaluates to the same bytes. But Python lets us write it differently.
+        assert (
+            pe.escape_string('his name was "robert palmer"')
+            == "'his name was \"robert palmer\"'"
+        )
+        assert (
+            pe.escape_string('his name was "robert palmer"')
+            == "'his name was \"robert palmer\"'"
+        )
+        assert (
+            pe.escape_string("his name was {}".format('"robert palmer"'))
+            == "'his name was \"robert palmer\"'"
+        )
 
-      assert pe.escape_string("his name was robert / palmer") == r"'his name was robert / palmer'"
+        assert (
+            pe.escape_string("his name was robert / palmer")
+            == r"'his name was robert / palmer'"
+        )
 
-      # If you need to include a single backslash, use an r-string to prevent Python from raising a
-      # DeprecationWarning for an invalid escape sequence
-      assert pe.escape_string("his name was robert \\/ palmer") == r"'his name was robert \\/ palmer'"
-      assert pe.escape_string("his name was robert \\ palmer") == r"'his name was robert \\ palmer'"
-      assert pe.escape_string("his name was robert \\\\ palmer") == r"'his name was robert \\\\ palmer'"
+        # If you need to include a single backslash, use an r-string to prevent Python from raising a
+        # DeprecationWarning for an invalid escape sequence
+        assert (
+            pe.escape_string("his name was robert \\/ palmer")
+            == r"'his name was robert \\/ palmer'"
+        )
+        assert (
+            pe.escape_string("his name was robert \\ palmer")
+            == r"'his name was robert \\ palmer'"
+        )
+        assert (
+            pe.escape_string("his name was robert \\\\ palmer")
+            == r"'his name was robert \\\\ palmer'"
+        )
 
-      assert pe.escape_string("his name was robert palmer 😂") == r"'his name was robert palmer 😂'"
+        assert (
+            pe.escape_string("his name was robert palmer 😂")
+            == r"'his name was robert palmer 😂'"
+        )
 
-      # Adding the test from PR #56 to prove escape behaviour
+        # Adding the test from PR #56 to prove escape behaviour
 
-      assert pe.escape_string("you're") == r"'you\'re'"
+        assert pe.escape_string("you're") == r"'you\'re'"
 
-      # Adding this test from #51 to prove escape behaviour when the target string involves repeated SQL escape chars
-      assert pe.escape_string("cat\\'s meow") == r"'cat\\\'s meow'"
+        # Adding this test from #51 to prove escape behaviour when the target string involves repeated SQL escape chars
+        assert pe.escape_string("cat\\'s meow") == r"'cat\\\'s meow'"
 
-      # Tests from the docs: https://docs.databricks.com/sql/language-manual/data-types/string-type.html
+        # Tests from the docs: https://docs.databricks.com/sql/language-manual/data-types/string-type.html
 
-      assert pe.escape_string('Spark') == "'Spark'"
-      assert pe.escape_string("O'Connell") == r"'O\'Connell'"
-      assert pe.escape_string("Some\\nText") == r"'Some\\nText'"
-      assert pe.escape_string("Some\\\\nText") == r"'Some\\\\nText'"
-      assert pe.escape_string("서울시") == "'서울시'"
-      assert pe.escape_string("\\\\") == r"'\\\\'"
+        assert pe.escape_string("Spark") == "'Spark'"
+        assert pe.escape_string("O'Connell") == r"'O\'Connell'"
+        assert pe.escape_string("Some\\nText") == r"'Some\\nText'"
+        assert pe.escape_string("Some\\\\nText") == r"'Some\\\\nText'"
+        assert pe.escape_string("서울시") == "'서울시'"
+        assert pe.escape_string("\\\\") == r"'\\\\'"
 
     def test_escape_date_time(self):
-        INPUT = datetime(1991,8,3,21,55)
+        INPUT = datetime(1991, 8, 3, 21, 55)
         FORMAT = "%Y-%m-%d %H:%M:%S"
         OUTPUT = "'1991-08-03 21:55:00'"
         assert pe.escape_datetime(INPUT, FORMAT) == OUTPUT
 
     def test_escape_date(self):
-        INPUT = date(1991,8,3)
+        INPUT = date(1991, 8, 3)
         FORMAT = "%Y-%m-%d"
         OUTPUT = "'1991-08-03'"
         assert pe.escape_datetime(INPUT, FORMAT) == OUTPUT
 
     def test_escape_sequence_integer(self):
-        assert pe.escape_sequence([1,2,3,4]) == "(1,2,3,4)"
+        assert pe.escape_sequence([1, 2, 3, 4]) == "(1,2,3,4)"
 
     def test_escape_sequence_float(self):
-        assert pe.escape_sequence([1.1,2.2,3.3,4.4]) == "(1.1,2.2,3.3,4.4)"
+        assert pe.escape_sequence([1.1, 2.2, 3.3, 4.4]) == "(1.1,2.2,3.3,4.4)"
 
     def test_escape_sequence_string(self):
-        assert pe.escape_sequence(
-            ["his", "name", "was", "robert", "palmer"]) == \
-            "('his','name','was','robert','palmer')"
+        assert (
+            pe.escape_sequence(["his", "name", "was", "robert", "palmer"])
+            == "('his','name','was','robert','palmer')"
+        )
 
     def test_escape_sequence_sequence_of_strings(self):
         # This is not valid SQL.
@@ -109,9 +134,7 @@ class TestIndividualFormatters(object):
 
 
 class TestFullQueryEscaping(object):
-
     def test_simple(self):
-
         INPUT = """
         SELECT
           field1,
@@ -140,7 +163,6 @@ class TestFullQueryEscaping(object):
 
     @unittest.skipUnless(False, "Thrift server supports native parameter binding.")
     def test_only_bind_in_where_clause(self):
-
         INPUT = """
         SELECT
           %(field)s,
@@ -153,3 +175,30 @@ class TestFullQueryEscaping(object):
 
         with pytest.raises(Exception):
             inject_parameters(INPUT, pe.escape_args(args))
+
+
+class TestInlineToNativeTransformer(object):
+    @pytest.mark.parametrize(
+        ("label", "query", "params", "expected"),
+        (
+            ("no effect", "SELECT 1", {}, "SELECT 1"),
+            ("one marker", "%(param)s", {"param": ""}, ":param"),
+            (
+                "multiple markers",
+                "%(foo)s %(bar)s %(baz)s",
+                {"foo": None, "bar": None, "baz": None},
+                ":foo :bar :baz",
+            ),
+            (
+                "sql query",
+                "SELECT * FROM table WHERE field = %(param)s AND other_field IN (%(list)s)",
+                {"param": None, "list": None},
+                "SELECT * FROM table WHERE field = :param AND other_field IN (:list)",
+            ),
+        ),
+    )
+    def test_transformer(
+        self, label: str, query: str, params: Dict[str, Any], expected
+    ):
+        output = transform_paramstyle(query, params)
+        assert output == expected

--- a/tests/unit/test_param_escaper.py
+++ b/tests/unit/test_param_escaper.py
@@ -196,6 +196,24 @@ class TestInlineToNativeTransformer(object):
                 {"param": None, "list": None},
                 "SELECT * FROM table WHERE field = :param AND other_field IN (:list)",
             ),
+            (
+                "query with like wildcard",
+                'select * from table where field like "%"',
+                {},
+                'select * from table where field like "%"'
+            ),
+            (
+                "query with named param and like wildcard",
+                'select :param from table where field like "%"',
+                {"param": None},
+                'select :param from table where field like "%"'
+            ),
+            (
+                "query with doubled wildcards",
+                'select 1 where '' like "%%"',
+                {"param": None},
+                'select 1 where '' like "%%"',
+            )
         ),
     )
     def test_transformer(

--- a/tests/unit/test_parameters.py
+++ b/tests/unit/test_parameters.py
@@ -1,26 +1,38 @@
-from databricks.sql.utils import (
-    named_parameters_to_tsparkparams,
-    infer_types,
-    named_parameters_to_dbsqlparams_v1,
-    named_parameters_to_dbsqlparams_v2,
-    calculate_decimal_cast_string,
-    DbsqlDynamicDecimalType,
-)
-from databricks.sql.thrift_api.TCLIService.ttypes import (
-    TSparkParameter,
-    TSparkParameterValue,
-    TSessionHandle,
-    TOpenSessionResp,
-)
-from databricks.sql.utils import DbSqlParameter, DbSqlType
-import pytest
-
-from databricks.sql.thrift_backend import ThriftBackend
-from databricks.sql.thrift_api.TCLIService import ttypes
-
+import datetime
 from decimal import Decimal
+from enum import Enum
+from typing import Type
+
+import pytest
+import pytz
+
 from databricks.sql.client import Connection
-from typing import List
+from databricks.sql.parameters import (
+    BigIntegerParameter,
+    BooleanParameter,
+    DateParameter,
+    DecimalParameter,
+    DoubleParameter,
+    FloatParameter,
+    IntegerParameter,
+    SmallIntParameter,
+    StringParameter,
+    TimestampNTZParameter,
+    TimestampParameter,
+    TinyIntParameter,
+    VoidParameter,
+)
+from databricks.sql.parameters.native import (
+    TDbsqlParameter,
+    TSparkParameterValue,
+    dbsql_parameter_from_primitive,
+)
+from databricks.sql.thrift_api.TCLIService import ttypes
+from databricks.sql.thrift_api.TCLIService.ttypes import (
+    TOpenSessionResp,
+    TSessionHandle,
+    TSparkParameterValue,
+)
 
 
 class TestSessionHandleChecks(object):
@@ -70,147 +82,123 @@ class TestSessionHandleChecks(object):
         assert Connection.server_parameterized_queries_enabled(test_input) == expected
 
 
-class TestTSparkParameterConversion(object):
+@pytest.mark.parametrize(
+    "value,expected",
+    (
+        (Decimal("10.00"), "DECIMAL(4,2)"),
+        (Decimal("123456789123456789.123456789123456789"), "DECIMAL(36,18)"),
+        (Decimal(".12345678912345678912345678912345678912"), "DECIMAL(38,38)"),
+        (Decimal("123456789.123456789"), "DECIMAL(18,9)"),
+        (Decimal("12345678912345678912345678912345678912"), "DECIMAL(38,0)"),
+        (Decimal("1234.56"), "DECIMAL(6,2)"),
+    ),
+)
+def test_calculate_decimal_cast_string(value, expected):
+    p = DecimalParameter(value)
+    assert p._cast_expr() == expected
+
+
+class Primitive(Enum):
+    """These are the inferrable types. This Enum is used for parametrized tests."""
+
+    NONE = None
+    BOOL = True
+    INT = 50
+    BIGINT = 2147483648
+    STRING = "Hello"
+    DECIMAL = Decimal("1234.56")
+    DATE = datetime.date(2023, 9, 6)
+    TIMESTAMP = datetime.datetime(2023, 9, 6, 3, 14, 27, 843, tzinfo=pytz.UTC)
+    DOUBLE = 3.14
+    FLOAT = 3.15
+    SMALLINT = 51
+
+
+class TestDbsqlParameter:
     @pytest.mark.parametrize(
-        "input_value, expected_type",
-        [
-            ("a", "STRING"),
-            (1, "INTEGER"),
-            (1000, "INTEGER"),
-            (9223372036854775807, "BIGINT"),  # Max value of a signed 64-bit integer
-            (True, "BOOLEAN"),
-            (1.0, "FLOAT"),
-        ],
+        "_type, prim, expect_cast_expr",
+        (
+            (DecimalParameter, Primitive.DECIMAL, "DECIMAL(6,2)"),
+            (IntegerParameter, Primitive.INT, "INT"),
+            (StringParameter, Primitive.STRING, "STRING"),
+            (BigIntegerParameter, Primitive.BIGINT, "BIGINT"),
+            (BooleanParameter, Primitive.BOOL, "BOOLEAN"),
+            (DateParameter, Primitive.DATE, "DATE"),
+            (DoubleParameter, Primitive.DOUBLE, "DOUBLE"),
+            (FloatParameter, Primitive.FLOAT, "FLOAT"),
+            (VoidParameter, Primitive.NONE, "VOID"),
+            (SmallIntParameter, Primitive.INT, "SMALLINT"),
+            (TimestampParameter, Primitive.TIMESTAMP, "TIMESTAMP"),
+            (TimestampNTZParameter, Primitive.TIMESTAMP, "TIMESTAMP_NTZ"),
+            (TinyIntParameter, Primitive.INT, "TINYINT"),
+        ),
     )
-    def test_conversion_e2e(self, input_value, expected_type):
-        """This behaviour falls back to Python's default string formatting of numbers"""
-        output = named_parameters_to_tsparkparams([input_value])
-        expected = TSparkParameter(
-            name="",
-            type=expected_type,
-            value=TSparkParameterValue(stringValue=str(input_value)),
-        )
-        assert output == [expected]
-
-    def test_conversion_e2e_decimal(self):
-        input = DbSqlParameter(value="1.0", type=DbSqlType.DECIMAL)
-        output = named_parameters_to_tsparkparams([input])
-        assert output == [
-            TSparkParameter(
-                name="",
-                type="DECIMAL(2,1)",
-                value=TSparkParameterValue(stringValue="1.0"),
-            )
-        ]
-
-    def test_basic_conversions_v1(self):
-        # Test legacy codepath
-        assert named_parameters_to_dbsqlparams_v1({"1": 1, "2": "foo", "3": 2.0}) == [
-            DbSqlParameter("1", 1),
-            DbSqlParameter("2", "foo"),
-            DbSqlParameter("3", 2.0),
-        ]
-
-    def test_basic_conversions_v2(self):
-        # Test interspersing named params with unnamed
-        assert named_parameters_to_dbsqlparams_v2(
-            [DbSqlParameter("1", 1.0, DbSqlType.DECIMAL), 5, DbSqlParameter("3", "foo")]
-        ) == [
-            DbSqlParameter("1", 1.0, DbSqlType.DECIMAL),
-            DbSqlParameter("", 5),
-            DbSqlParameter("3", "foo"),
-        ]
-
-    def test_infer_types_none(self):
-        with pytest.raises(ValueError):
-            infer_types([DbSqlParameter("", None)])
-
-    def test_infer_types_dict(self):
-        with pytest.raises(ValueError):
-            infer_types([DbSqlParameter("", {1: 1})])
+    def test_cast_expression(
+        self, _type: TDbsqlParameter, prim: Primitive, expect_cast_expr: str
+    ):
+        p = _type(prim.value)
+        assert p._cast_expr() == expect_cast_expr
 
     @pytest.mark.parametrize(
-        "input_value, expected_type",
-        [
-            (-128, DbSqlType.INTEGER),
-            (127, DbSqlType.INTEGER),
-            (-2147483649, DbSqlType.BIGINT),
-            (-2147483648, DbSqlType.INTEGER),
-            (2147483647, DbSqlType.INTEGER),
-            (-9223372036854775808, DbSqlType.BIGINT),
-            (9223372036854775807, DbSqlType.BIGINT),
-        ],
+        "t, prim",
+        (
+            (DecimalParameter, Primitive.DECIMAL),
+            (IntegerParameter, Primitive.INT),
+            (StringParameter, Primitive.STRING),
+            (BigIntegerParameter, Primitive.BIGINT),
+            (BooleanParameter, Primitive.BOOL),
+            (DateParameter, Primitive.DATE),
+            (DoubleParameter, Primitive.DOUBLE),
+            (FloatParameter, Primitive.FLOAT),
+            (VoidParameter, Primitive.NONE),
+            (SmallIntParameter, Primitive.INT),
+            (TimestampParameter, Primitive.TIMESTAMP),
+            (TimestampNTZParameter, Primitive.TIMESTAMP),
+            (TinyIntParameter, Primitive.INT),
+        ),
     )
-    def test_infer_types_integer(self, input_value, expected_type):
-        input = DbSqlParameter("", input_value)
-        output = infer_types([input])
-        assert output == [
-            DbSqlParameter("", str(input_value), expected_type)
-        ], f"{output[0].type} received, expected {expected_type}"
+    def test_tspark_param_value(self, t: TDbsqlParameter, prim):
+        p: TDbsqlParameter = t(prim.value)
+        output = p._tspark_param_value()
 
-    def test_infer_types_boolean(self):
-        input = DbSqlParameter("", True)
-        output = infer_types([input])
-        assert output == [DbSqlParameter("", "True", DbSqlType.BOOLEAN)]
+        if prim == Primitive.NONE:
+            assert output == None
+        else:
+            assert output == TSparkParameterValue(stringValue=str(prim.value))
 
-    def test_infer_types_float(self):
-        input = DbSqlParameter("", 1.0)
-        output = infer_types([input])
-        assert output == [DbSqlParameter("", "1.0", DbSqlType.FLOAT)]
+    def test_tspark_param_named(self):
+        p = dbsql_parameter_from_primitive(Primitive.INT.value, name="p")
+        tsp = p.as_tspark_param(named=True)
 
-    def test_infer_types_string(self):
-        input = DbSqlParameter("", "foo")
-        output = infer_types([input])
-        assert output == [DbSqlParameter("", "foo", DbSqlType.STRING)]
+        assert tsp.name == "p"
+        assert tsp.ordinal is False
 
-    def test_infer_types_decimal(self):
-        # The output decimal will have a dynamically calculated decimal type with a value of DECIMAL(2,1)
-        input = DbSqlParameter("", Decimal("1.0"))
-        output: List[DbSqlParameter] = infer_types([input])
+    def test_tspark_param_ordinal(self):
+        p = dbsql_parameter_from_primitive(Primitive.INT.value, name="p")
+        tsp = p.as_tspark_param(named=False)
 
-        x = output[0]
+        assert tsp.name is None
+        assert tsp.ordinal is True
 
-        assert x.value == "1.0"
-        assert isinstance(x.type, DbsqlDynamicDecimalType)
-        assert x.type.value == "DECIMAL(2,1)"
+    @pytest.mark.parametrize(
+        "_type, prim",
+        (
+            (DecimalParameter, Primitive.DECIMAL),
+            (IntegerParameter, Primitive.INT),
+            (StringParameter, Primitive.STRING),
+            (BigIntegerParameter, Primitive.BIGINT),
+            (BooleanParameter, Primitive.BOOL),
+            (DateParameter, Primitive.DATE),
+            (FloatParameter, Primitive.FLOAT),
+            (VoidParameter, Primitive.NONE),
+            (TimestampParameter, Primitive.TIMESTAMP),
+        ),
+    )
+    def test_inference(self, _type: TDbsqlParameter, prim: Primitive):
+        """This method only tests inferrable types.
 
-    def test_infer_types_none(self):
-        input = DbSqlParameter("", None)
-        output: List[DbSqlParameter] = infer_types([input])
+        Not tested are TinyIntParameter, SmallIntParameter DoubleParameter and TimestampNTZParameter
+        """
 
-        x = output[0]
-
-        assert x.value == None
-        assert x.type == DbSqlType.VOID
-        assert x.type.value == "VOID"
-
-    def test_infer_types_unsupported(self):
-        class ArbitraryType:
-            pass
-
-        input = DbSqlParameter("", ArbitraryType())
-
-        with pytest.raises(ValueError, match="Could not infer parameter type from"):
-            infer_types([input])
-
-
-class TestCalculateDecimalCast(object):
-    def test_38_38(self):
-        input = Decimal(".12345678912345678912345678912345678912")
-        output = calculate_decimal_cast_string(input)
-        assert output == "DECIMAL(38,38)"
-
-    def test_18_9(self):
-        input = Decimal("123456789.123456789")
-        output = calculate_decimal_cast_string(input)
-        assert output == "DECIMAL(18,9)"
-
-    def test_38_0(self):
-        input = Decimal("12345678912345678912345678912345678912")
-        output = calculate_decimal_cast_string(input)
-        assert output == "DECIMAL(38,0)"
-
-    def test_6_2(self):
-        input = Decimal("1234.56")
-        output = calculate_decimal_cast_string(input)
-        assert output == "DECIMAL(6,2)"
+        inferred_type = dbsql_parameter_from_primitive(prim.value)
+        assert isinstance(inferred_type, _type)

--- a/tests/unit/test_thrift_backend.py
+++ b/tests/unit/test_thrift_backend.py
@@ -66,7 +66,7 @@ class ThriftBackendTestSuite(unittest.TestCase):
             thrift_backend.make_request(mock_method, Mock())
 
     def _make_type_desc(self, type):
-        return ttypes.TTypeDesc(types=[ttypes.TTypeEntry(ttypes.TPrimitiveTypeEntry(type=type))])
+        return ttypes.TTypeDesc(types=[ttypes.TTypeEntry(ttypes.TTAllowedParameterValueEntry(type=type))])
 
     def _make_fake_thrift_backend(self):
         thrift_backend = ThriftBackend("foobar", 443, "path", [], auth_provider=AuthProvider())
@@ -270,7 +270,7 @@ class ThriftBackendTestSuite(unittest.TestCase):
                 columnName="column 1",
                 typeDesc=ttypes.TTypeDesc(types=[
                     ttypes.TTypeEntry(
-                        ttypes.TPrimitiveTypeEntry(
+                        ttypes.TTAllowedParameterValueEntry(
                             type=ttypes.TTypeId.DECIMAL_TYPE,
                             typeQualifiers=ttypes.TTypeQualifiers(
                                 qualifiers={


### PR DESCRIPTION
## Description

Over the past week, we've completely rewritten the native parameter support and tests. Each step of the way has undergone discussion and review in pull requests against the `native-query-params-staging` branch. This PR exists to merge those changes into `main` in advance of the release.

Apart from those changes, this PR also performs a little cleanup of the code:
1. I found that there was an untested case around users passing SQL LIKE wildcards (`%`). I implemented the fix and added tests for it.
2. I found that running the SQLAlchemy reusable test suite was not possible without a few overrides for CTETest and ComponentReflection test. I added these. The test suite now passes 👍 
3. I removed some commented-out code that I missed during native parameters development
4. I refined the type declaration for `TParameterList` → `TParameterSequence` as this was necessary for SQLAlchemy tests and is consistent with the previous behaviour of the connector and PEP-249

The commit history on this branch is self-explanatory.

### Steps

- [x] Verify unit tests pass
- [x] Verify e2e tests pass
- [x] Verify SQLAlchemy reusable dialect tests pass