### PR TITLE
sqlalchemy: fix deprecation warning for dbapi classmethod

### DIFF
--- a/src/databricks/sqlalchemy/base.py
+++ b/src/databricks/sqlalchemy/base.py
@@ -82,7 +82,7 @@ class DatabricksDialect(default.DefaultDialect):
     EMPTY_FK = EMPTY_INDEX = []
 
     @classmethod
-    def dbapi(cls):
+    def import_dbapi(cls):
         return sql
 
     def _force_paramstyle_to_native_mode(self):


### PR DESCRIPTION
## Description

Simple name change. Dialect compliance tests pass with this change.

## Related Tickets & Documents

Closes #289