### PR TITLE
[PECO-1297] sqlalchemy: fix: can't read columns for tables containing a TIMESTAMP_NTZ column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+## 3.0.1 (unreleased)
+
+- Fix: SQLAlchemy dialect could not reflect TIMESTAMP_NTZ columns (#296)
+
 ## 3.0.0 (2023-11-17)
 
 - Remove support for Python 3.7

--- a/src/databricks/sqlalchemy/_parse.py
+++ b/src/databricks/sqlalchemy/_parse.py
@@ -5,6 +5,8 @@ import sqlalchemy
 from sqlalchemy.engine import CursorResult
 from sqlalchemy.engine.interfaces import ReflectedColumn
 
+from databricks.sqlalchemy import _types as type_overrides
+
 """
 This module contains helper functions that can parse the contents
 of metadata and exceptions received from DBR. These are mostly just
@@ -293,7 +295,8 @@ GET_COLUMNS_TYPE_MAP = {
     "struct": sqlalchemy.types.String,
     "uniontype": sqlalchemy.types.String,
     "decimal": sqlalchemy.types.Numeric,
-    "timestamp": sqlalchemy.types.DateTime,
+    "timestamp": type_overrides.TIMESTAMP,
+    "timestamp_ntz": type_overrides.TIMESTAMP_NTZ,
     "date": sqlalchemy.types.Date,
 }
 

--- a/src/databricks/sqlalchemy/test_local/e2e/test_basic.py
+++ b/src/databricks/sqlalchemy/test_local/e2e/test_basic.py
@@ -1,21 +1,24 @@
-import os, datetime, decimal
-import pytest
+import datetime
+import decimal
+import os
+from typing import Tuple, Union
 from unittest import skipIf
+
+import pytest
 from sqlalchemy import (
-    create_engine,
-    select,
-    insert,
     Column,
     MetaData,
     Table,
     Text,
+    create_engine,
+    insert,
+    select,
     text,
 )
-from sqlalchemy.orm import Session, DeclarativeBase, Mapped, mapped_column
-from sqlalchemy.types import SMALLINT, Integer, BOOLEAN, String, DECIMAL, Date
 from sqlalchemy.engine import Engine
-
-from typing import Tuple, Union
+from sqlalchemy.engine.reflection import Inspector
+from sqlalchemy.orm import DeclarativeBase, Mapped, Session, mapped_column
+from sqlalchemy.types import BOOLEAN, DECIMAL, Date, DateTime, Integer, String
 
 try:
     from sqlalchemy.orm import declarative_base
@@ -344,8 +347,6 @@ def test_dialect_type_mappings(db_engine, metadata_obj: MetaData):
 def test_inspector_smoke_test(samples_engine: Engine):
     """It does not appear that 3L namespace is supported here"""
 
-    from sqlalchemy.engine.reflection import Inspector
-
     schema, table = "nyctaxi", "trips"
 
     try:
@@ -431,22 +432,20 @@ def test_user_agent_adjustment(db_engine):
     c2.close()
 
     assert same_ua, f"User agents didn't match \n {ua1} \n {ua2}"
+
+
 @pytest.fixture
 def sample_table(metadata_obj: MetaData, db_engine: Engine):
-    """Creates a sample table and returns its table name"""
+    """This fixture creates a sample table and cleans it up after the test is complete."""
+    from databricks.sqlalchemy._parse import GET_COLUMNS_TYPE_MAP
 
     table_name = "PySQLTest_{}".format(datetime.datetime.utcnow().strftime("%s"))
 
-    SampleTable = Table(
-        table_name,
-        metadata_obj,
-        Column("string_example", String(255)),
-        Column("integer_example", Integer),
-        Column("boolean_example", BOOLEAN),
-        Column("decimal_example", DECIMAL(10, 2)),
-        Column("date_example", Date),
-        Column("datetime_example", DateTime)
-    )
+    args = [
+        Column(colname, coltype) for colname, coltype in GET_COLUMNS_TYPE_MAP.items()
+    ]
+
+    SampleTable = Table(table_name, metadata_obj, *args)
 
     metadata_obj.create_all(db_engine)
 
@@ -454,12 +453,13 @@ def sample_table(metadata_obj: MetaData, db_engine: Engine):
 
     metadata_obj.drop_all(db_engine)
 
-def test_get_columns(db_engine, metadata_obj: MetaData, sample_table: str):
-    """Confirms that we get back the same time we declared in a model and inserted using Core"""
 
-    
-    from sqlalchemy.engine.reflection import Inspector
+def test_get_columns(db_engine, sample_table: str):
+    """Created after PECO-1297 and Github Issue #295 to verify that get_columsn behaves like it should for all known SQLAlchemy types"""
 
     inspector = Inspector.from_engine(db_engine)
 
+    # this raises an exception if `parse_column_info_from_tgetcolumnsresponse` fails a lookup
     columns = inspector.get_columns(sample_table)
+
+    assert True

--- a/src/databricks/sqlalchemy/test_local/e2e/test_basic.py
+++ b/src/databricks/sqlalchemy/test_local/e2e/test_basic.py
@@ -431,3 +431,35 @@ def test_user_agent_adjustment(db_engine):
     c2.close()
 
     assert same_ua, f"User agents didn't match \n {ua1} \n {ua2}"
+@pytest.fixture
+def sample_table(metadata_obj: MetaData, db_engine: Engine):
+    """Creates a sample table and returns its table name"""
+
+    table_name = "PySQLTest_{}".format(datetime.datetime.utcnow().strftime("%s"))
+
+    SampleTable = Table(
+        table_name,
+        metadata_obj,
+        Column("string_example", String(255)),
+        Column("integer_example", Integer),
+        Column("boolean_example", BOOLEAN),
+        Column("decimal_example", DECIMAL(10, 2)),
+        Column("date_example", Date),
+        Column("datetime_example", DateTime)
+    )
+
+    metadata_obj.create_all(db_engine)
+
+    yield table_name
+
+    metadata_obj.drop_all(db_engine)
+
+def test_get_columns(db_engine, metadata_obj: MetaData, sample_table: str):
+    """Confirms that we get back the same time we declared in a model and inserted using Core"""
+
+    
+    from sqlalchemy.engine.reflection import Inspector
+
+    inspector = Inspector.from_engine(db_engine)
+
+    columns = inspector.get_columns(sample_table)

--- a/src/databricks/sqlalchemy/test_local/test_parsing.py
+++ b/src/databricks/sqlalchemy/test_local/test_parsing.py
@@ -152,4 +152,3 @@ FMT_SAMPLE_DT_OUTPUT = [
 def test_filter_dict_by_value(match, output):
     result = match_dte_rows_by_value(FMT_SAMPLE_DT_OUTPUT, match)
     assert result == output
-

--- a/src/databricks/sqlalchemy/test_local/test_parsing.py
+++ b/src/databricks/sqlalchemy/test_local/test_parsing.py
@@ -152,3 +152,4 @@ FMT_SAMPLE_DT_OUTPUT = [
 def test_filter_dict_by_value(match, output):
     result = match_dte_rows_by_value(FMT_SAMPLE_DT_OUTPUT, match)
     assert result == output
+


### PR DESCRIPTION
## Description

Our sqlalchemy dialect contains a method that parses the contents of a Thrift `TGetColumnsResponse` and maps column types from Databricks → sqlalchemy types. This uses a dictionary, which prior to this PR didn't include an entry for `TIMESTAMP_NTZ` types. This was not caught by sqlalchemy's reusable dialect compliance tests because TIMESTAMP_NTZ is specific to Databricks and was therefore not covered. For this PR, I added an e2e test to capture this and wrote the fix to make the test pass.

This change only affects the sqlalchemy codepath. I reran the `ComponentReflectionTest` portion of the sqlalchemy dialect compliance test suite (which is the only test suite that uses the dialect's `get_columns` method). All tests pass.

All non sqlalchemy e2e tests pass as well.

## Related Tickets and Documents
Closes #295 