### PR TITLE
Bump package version to 3.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Release History
 
-## 3.0.1 (unreleased)
+## 3.0.1 (2023-12-01)
 
+- Other: updated docstring comment about default parameterization approach (#287)
+- Other: added tests for reading complex types and revised docstrings and type hints (#293)
+- Fix: SQLAlchemy dialect raised DeprecationWarning due to `dbapi` classmethod (#294)
 - Fix: SQLAlchemy dialect could not reflect TIMESTAMP_NTZ columns (#296)
 
 ## 3.0.0 (2023-11-17)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "databricks-sql-connector"
-version = "3.0.0"
+version = "3.0.1"
 description = "Databricks SQL Connector for Python"
 authors = ["Databricks <databricks-sql-connector-maintainers@databricks.com>"]
 license = "Apache-2.0"

--- a/src/databricks/sql/__init__.py
+++ b/src/databricks/sql/__init__.py
@@ -29,7 +29,7 @@ DATETIME = DBAPITypeObject("timestamp")
 DATE = DBAPITypeObject("date")
 ROWID = DBAPITypeObject()
 
-__version__ = "3.0.0"
+__version__ = "3.0.1"
 USER_AGENT_NAME = "PyDatabricksSqlConnector"
 
 # These two functions are pyhive legacy


### PR DESCRIPTION
## Description

I'd like to release the fix to SQLAlchemy that merged today. This PR bumps to a patch version as all these changes are backwards compatible and introduce no new functionality.
