### PR TITLE
Fix URI construction in ThriftBackend

### DIFF
--- a/src/databricks/sql/thrift_backend.py
+++ b/src/databricks/sql/thrift_backend.py
@@ -138,7 +138,7 @@ class ThriftBackend:
             uri = kwargs.get("_connection_uri")
         elif server_hostname and http_path:
             uri = "{host}:{port}/{path}".format(
-                host=server_hostname, port=port, path=http_path.lstrip("/")
+                host=server_hostname.rstrip("/"), port=port, path=http_path.lstrip("/")
             )
             if not uri.startswith("https://"):
                 uri = "https://" + uri

--- a/src/databricks/sql/thrift_backend.py
+++ b/src/databricks/sql/thrift_backend.py
@@ -1,40 +1,36 @@
-from decimal import Decimal
 import errno
 import logging
 import math
+import threading
 import time
 import uuid
-import threading
+from decimal import Decimal
 from ssl import CERT_NONE, CERT_REQUIRED, create_default_context
 from typing import List, Union
 
 import pyarrow
-import thrift.transport.THttpClient
 import thrift.protocol.TBinaryProtocol
+import thrift.transport.THttpClient
 import thrift.transport.TSocket
 import thrift.transport.TTransport
-
 import urllib3.exceptions
 
 import databricks.sql.auth.thrift_http_client
-from databricks.sql.auth.thrift_http_client import CommandType
-from databricks.sql.auth.authenticators import AuthProvider
-from databricks.sql.thrift_api.TCLIService import TCLIService, ttypes
 from databricks.sql import *
+from databricks.sql.auth.authenticators import AuthProvider
+from databricks.sql.auth.thrift_http_client import CommandType
 from databricks.sql.exc import MaxRetryDurationError
-from databricks.sql.thrift_api.TCLIService.TCLIService import (
-    Client as TCLIServiceClient,
-)
-
+from databricks.sql.thrift_api.TCLIService import TCLIService, ttypes
+from databricks.sql.thrift_api.TCLIService.TCLIService import Client as TCLIServiceClient
 from databricks.sql.utils import (
     ExecuteResponse,
-    _bound,
-    RequestErrorInfo,
     NoRetryReason,
+    RequestErrorInfo,
     ResultSetQueueFactory,
+    _bound,
     convert_arrow_based_set_to_arrow_table,
-    convert_decimals_in_arrow_table,
     convert_column_based_set_to_arrow_table,
+    convert_decimals_in_arrow_table,
 )
 
 logger = logging.getLogger(__name__)
@@ -141,9 +137,11 @@ class ThriftBackend:
         if kwargs.get("_connection_uri"):
             uri = kwargs.get("_connection_uri")
         elif server_hostname and http_path:
-            uri = "https://{host}:{port}/{path}".format(
+            uri = "{host}:{port}/{path}".format(
                 host=server_hostname, port=port, path=http_path.lstrip("/")
             )
+            if not uri.startswith("https://"):
+                uri = "https://" + uri
         else:
             raise ValueError("No valid connection settings.")
 

--- a/tests/unit/test_thrift_backend.py
+++ b/tests/unit/test_thrift_backend.py
@@ -217,6 +217,12 @@ class ThriftBackendTestSuite(unittest.TestCase):
         ThriftBackend("https://hostname", 123, "path_value", [], auth_provider=AuthProvider())
         self.assertEqual(t_http_client_class.call_args[1]["uri_or_host"],
                          "https://hostname:123/path_value")
+        
+    @patch("databricks.sql.auth.thrift_http_client.THttpClient")
+    def test_host_with_trailing_backslash_does_not_duplicate(self, t_http_client_class):
+        ThriftBackend("https://hostname/", 123, "path_value", [], auth_provider=AuthProvider())
+        self.assertEqual(t_http_client_class.call_args[1]["uri_or_host"],
+                         "https://hostname:123/path_value")        
 
     @patch("databricks.sql.auth.thrift_http_client.THttpClient")
     def test_socket_timeout_is_propagated(self, t_http_client_class):

--- a/tests/unit/test_thrift_backend.py
+++ b/tests/unit/test_thrift_backend.py
@@ -213,6 +213,12 @@ class ThriftBackendTestSuite(unittest.TestCase):
                          "https://hostname:123/path_value")
 
     @patch("databricks.sql.auth.thrift_http_client.THttpClient")
+    def test_host_with_https_does_not_duplicate(self, t_http_client_class):
+        ThriftBackend("https://hostname", 123, "path_value", [], auth_provider=AuthProvider())
+        self.assertEqual(t_http_client_class.call_args[1]["uri_or_host"],
+                         "https://hostname:123/path_value")
+
+    @patch("databricks.sql.auth.thrift_http_client.THttpClient")
     def test_socket_timeout_is_propagated(self, t_http_client_class):
         ThriftBackend("hostname", 123, "path_value", [], auth_provider=AuthProvider(), _socket_timeout=129)
         self.assertEqual(t_http_client_class.return_value.setTimeout.call_args[0][0], 129 * 1000)


### PR DESCRIPTION
closes #230 

This pull request fixes the URI construction in the `ThriftBackend` class of the `thrift_backend.py` file. The current implementation does not handle the case where the `server_hostname` is provided with the `https://` prefix, resulting in duplicate `https://` in the URI. This PR addresses that issue by checking if the `uri` starts with `https://` and adding it if necessary.

Additionally, this PR also fixes the case where the `server_hostname` is provided with a trailing backslash. The current implementation duplicates the trailing backslash in the URI, which is incorrect. This PR removes the duplicate backslash.

Lastly, this PR includes unit tests to verify the correctness of the URI construction.

Changes:
- Updated the URI construction logic in the `ThriftBackend` class.
- Added unit tests for the URI construction.

Please review and merge this pull request.