### PR TITLE
Make contents of `__init__.py` equal across projects

### DIFF
--- a/src/databricks/__init__.py
+++ b/src/databricks/__init__.py
@@ -1,4 +1,7 @@
-# https://packaging.python.org/guides/packaging-namespace-packages/#pkgutil-style-namespace-packages
-# This file should only contain the following line. Otherwise other sub-packages databricks.* namespace
-# may not be importable.
+# See: https://packaging.python.org/guides/packaging-namespace-packages/#pkgutil-style-namespace-packages
+#
+# This file must only contain the following line, or other packages in the databricks.* namespace
+# may not be importable. The contents of this file must be byte-for-byte equivalent across all packages.
+# If they are not, parallel package installation may lead to clobbered and invalid files.
+# Also see https://github.com/databricks/databricks-sdk-py/issues/343.
 __path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/tests/unit/test_init_file.py
+++ b/tests/unit/test_init_file.py
@@ -1,0 +1,24 @@
+import hashlib
+import unittest
+
+
+class InitFileTests(unittest.TestCase):
+    """
+    Micro test to confirm the contents of `databricks/__init__.py` does not change.
+
+    Also see https://github.com/databricks/databricks-sdk-py/issues/343#issuecomment-1866029118.
+    """
+
+    def test_init_file_contents(self):
+        with open('src/databricks/__init__.py') as f:
+            init_file_contents = f.read()
+
+        # This hash is the expected hash of the contents of `src/databricks/__init__.py`.
+        # It must not change, or else parallel package installation may lead to clobbered and invalid files.
+        expected_sha1 = '2772edbf52e517542acf8c039479c4b57b6ca2cd'
+        actual_sha1 = hashlib.sha1(init_file_contents.encode('utf-8')).hexdigest()
+        self.assertEqual(expected_sha1, actual_sha1)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit/test_init_file.py
+++ b/tests/unit/test_init_file.py
@@ -1,8 +1,7 @@
 import hashlib
-import unittest
 
 
-class InitFileTests(unittest.TestCase):
+class TestInitFile:
     """
     Micro test to confirm the contents of `databricks/__init__.py` does not change.
 
@@ -10,15 +9,11 @@ class InitFileTests(unittest.TestCase):
     """
 
     def test_init_file_contents(self):
-        with open('src/databricks/__init__.py') as f:
+        with open("src/databricks/__init__.py") as f:
             init_file_contents = f.read()
 
         # This hash is the expected hash of the contents of `src/databricks/__init__.py`.
         # It must not change, or else parallel package installation may lead to clobbered and invalid files.
-        expected_sha1 = '2772edbf52e517542acf8c039479c4b57b6ca2cd'
-        actual_sha1 = hashlib.sha1(init_file_contents.encode('utf-8')).hexdigest()
-        self.assertEqual(expected_sha1, actual_sha1)
-
-
-if __name__ == '__main__':
-    unittest.main()
+        expected_sha1 = "2772edbf52e517542acf8c039479c4b57b6ca2cd"
+        actual_sha1 = hashlib.sha1(init_file_contents.encode("utf-8")).hexdigest()
+        assert expected_sha1 == actual_sha1


### PR DESCRIPTION
## Changes

See https://github.com/databricks/databricks-sdk-py/issues/343#issuecomment-1866029118.

Corresponding PR for the Python SDK: https://github.com/databricks/databricks-sdk-py/pull/488.

## Tests

Unit test to confirm the SHA1 of the file contents.