### PR TITLE
[PECO-1263] Extract asyncexecution from thrift backend

### DIFF
--- a/src/databricks/sql/client.py
+++ b/src/databricks/sql/client.py
@@ -25,8 +25,8 @@ from databricks.sql.utils import ExecuteResponse
 
 from databricks.sql.results import ResultSet
 
-if TYPE_CHECKING:
-    from databricks.sql.ae import AsyncExecution, AsyncExecutionStatus
+
+from databricks.sql.ae import AsyncExecution, AsyncExecutionStatus
 
 logger = logging.getLogger(__name__)
 
@@ -386,7 +386,7 @@ class Connection:
         )
 
         with self.cursor() as cursor:
-            ae: "AsyncExecution" = self.thrift_backend.async_execute_statement(
+            execute_statement_resp = self.thrift_backend.async_execute_statement(
                 statement=prepared_operation,
                 session_handle=self._session_handle,
                 max_rows=cursor.arraysize,
@@ -397,8 +397,11 @@ class Connection:
                 parameters=prepared_params,
             )
 
-        # should we log this?
-        return ae
+        return AsyncExecution.from_thrift_response(
+            connection=self,
+            thrift_backend=self.thrift_backend,
+            resp=execute_statement_resp,
+        )
 
 
 class Cursor:


### PR DESCRIPTION
## Description

**Note: This PR should merge _after_ #311 since it depends on the commits in that PR**

To clean up the dependencies between `client.py` → `thrift_backend.py` → `ae.py`, this PR makes it so that `AsyncExecution` knows how to hydrate itself from a `TExecuteStatementResp`.

This way, `thrift_backend.py` doesn't need to import anything from `ae.py`. In theory, `thrift_backend.py` should never care about the pep-249 interface or about the concept of `AsyncExecution`s. There is an exception to this already where thrift_backend doesn't know how to fetch results unless it is provided a `client.Cursor` object, which looks funky. To get around this without making an unneccessary roundtrip to create a new "cursor", I use a `FakeCursor()` object here. Once we refactor thrift_backend result fetching into a separate interface the `FakeCursor` will be removed.



## What's next

I'm going to clean up the user interface for this to separate `get_result_or_status` into separate methods. Also need to add tests for picking up a running execution that _doesn't_ return results immediately.
