### PR TITLE
[PECO-1263] Add get_async_execution method

### DIFF
--- a/src/databricks/sql/ae.py
+++ b/src/databricks/sql/ae.py
@@ -73,7 +73,7 @@ class AsyncExecution:
         connection: "Connection",
         query_id: UUID,
         query_secret: UUID,
-        status: AsyncExecutionStatus,
+        status: Optional[AsyncExecutionStatus] = None,
         execute_statement_response: Optional[ttypes.TExecuteStatementResp] = None,
     ):
         self._connection = connection
@@ -82,6 +82,9 @@ class AsyncExecution:
         self.query_id = query_id
         self.query_secret = query_secret
         self.status = status
+
+        if self.status is None:
+            self.poll_for_status()
 
     status: AsyncExecutionStatus
     query_id: UUID

--- a/src/databricks/sql/ae.py
+++ b/src/databricks/sql/ae.py
@@ -117,7 +117,7 @@ class AsyncExecution:
 
     def serialize(self) -> str:
         """Return a string representing the query_id and secret of this AsyncExecution.
-        
+
         Use this to preserve a reference to the query_id and query_secret."""
         return f"{self.query_id}:{self.query_secret}"
 
@@ -130,7 +130,10 @@ class AsyncExecution:
             _output = self._thrift_backend._poll_for_status(self.t_operation_handle)
         except RequestError as e:
             if "RESOURCE_DOES_NOT_EXIST" in e.message:
-                raise AsyncExecutionException("Query not found: %s" % self.query_id) from e
+                raise AsyncExecutionException(
+                    "Query not found: %s. Result may have already been fetched."
+                    % self.query_id
+                ) from e
         self.status = _toperationstate_to_ae_status(_output.operationState)
 
     def _thrift_fetch_result(self) -> None:

--- a/src/databricks/sql/ae.py
+++ b/src/databricks/sql/ae.py
@@ -115,6 +115,12 @@ class AsyncExecution:
         _output = self._thrift_backend.async_cancel_command(self.t_operation_handle)
         self.status = AsyncExecutionStatus.CANCELED
 
+    def serialize(self) -> str:
+        """Return a string representing the query_id and secret of this AsyncExecution.
+        
+        Use this to preserve a reference to the query_id and query_secret."""
+        return f"{self.query_id}:{self.query_secret}"
+
     def poll_for_status(self) -> None:
         """Check the thrift server for the status of this operation and set self.status
 

--- a/src/databricks/sql/client.py
+++ b/src/databricks/sql/client.py
@@ -427,9 +427,9 @@ class Connection:
         else:
             _qs = UUID(hex=query_secret)
 
-        return AsyncExecution(
-            thrift_backend=self.thrift_backend,
+        return AsyncExecution.from_query_id_and_secret(
             connection=self,
+            thrift_backend=self.thrift_backend,
             query_id=_qid,
             query_secret=_qs,
         )

--- a/src/databricks/sql/client.py
+++ b/src/databricks/sql/client.py
@@ -403,8 +403,10 @@ class Connection:
             thrift_backend=self.thrift_backend,
             resp=execute_statement_resp,
         )
-    
-    def get_async_execution(self, query_id: Union[str, UUID], query_secret: Union[str, UUID]) -> "AsyncExecution":
+
+    def get_async_execution(
+        self, query_id: Union[str, UUID], query_secret: Union[str, UUID]
+    ) -> "AsyncExecution":
         """Get an AsyncExecution object for an existing query.
 
         Args:

--- a/src/databricks/sql/client.py
+++ b/src/databricks/sql/client.py
@@ -27,6 +27,7 @@ from databricks.sql.results import ResultSet
 
 
 from databricks.sql.ae import AsyncExecution, AsyncExecutionStatus
+from uuid import UUID
 
 logger = logging.getLogger(__name__)
 
@@ -401,6 +402,34 @@ class Connection:
             connection=self,
             thrift_backend=self.thrift_backend,
             resp=execute_statement_resp,
+        )
+    
+    def get_async_execution(self, query_id: Union[str, UUID], query_secret: Union[str, UUID]) -> "AsyncExecution":
+        """Get an AsyncExecution object for an existing query.
+
+        Args:
+            query_id: The query id of the query to retrieve
+            query_secret: The query secret of the query to retrieve
+
+        Returns:
+            An AsyncExecution object that can be used to poll for status and retrieve results.
+        """
+
+        if isinstance(query_id, UUID):
+            _qid = query_id
+        else:
+            _qid = UUID(hex=query_id)
+
+        if isinstance(query_secret, UUID):
+            _qs = query_secret
+        else:
+            _qs = UUID(hex=query_secret)
+
+        return AsyncExecution(
+            thrift_backend=self.thrift_backend,
+            connection=self,
+            query_id=_qid,
+            query_secret=_qs,
         )
 
 

--- a/tests/e2e/test_execute_async.py
+++ b/tests/e2e/test_execute_async.py
@@ -10,11 +10,23 @@ import time
 
 import threading
 
-LONG_RUNNING_QUERY = """
+BASE_LONG_QUERY = """
 SELECT SUM(A.id - B.id)
-FROM range(1000000000) A CROSS JOIN range(100000000) B 
+FROM range({val}) A CROSS JOIN range({val}) B 
 GROUP BY (A.id - B.id)
 """
+GT_ONE_MINUTE_VALUE = 100000000
+
+# Arrived at this value through some manual testing on a serverless SQL warehouse
+# The goal here is to have a query that takes longer than five seconds (therefore bypassing directResults)
+# but not so long that I can't attempt to fetch its results in a reasonable amount of time
+GT_FIVE_SECONDS_VALUE = 75000
+
+LONG_RUNNING_QUERY = BASE_LONG_QUERY.format(val=GT_ONE_MINUTE_VALUE)
+LONG_ISH_QUERY = BASE_LONG_QUERY.format(val=GT_FIVE_SECONDS_VALUE)
+
+# This query should always return in < 5 seconds and therefore should be a direct result
+DIRECT_RESULTS_QUERY = "select :param `col`"
 
 
 class TestExecuteAsync(PySQLPytestTestCase):
@@ -28,12 +40,19 @@ class TestExecuteAsync(PySQLPytestTestCase):
             # cancellation is idempotent
             ae.cancel()
 
+    @pytest.fixture
+    def long_ish_ae(self, scope="function") -> AsyncExecution:
+        """Start a long-running query so we can make assertions about it."""
+        with self.connection() as conn:
+            ae = conn.execute_async(LONG_ISH_QUERY)
+            yield ae
+
     def test_execute_async(self):
         """This is a WIP test of the basic API defined in PECO-1263"""
         # This is taken directly from the design doc
 
         with self.connection() as conn:
-            ae = conn.execute_async("select :param `col`", {"param": 1})
+            ae = conn.execute_async(DIRECT_RESULTS_QUERY, {"param": 1})
             while ae.is_running:
                 ae.poll_for_status()
                 time.sleep(1)
@@ -41,6 +60,15 @@ class TestExecuteAsync(PySQLPytestTestCase):
             result = ae.get_result().fetchone()
 
         assert result.col == 1
+
+    def test_direct_results_query_canary(self):
+        """This test verifies that on the current endpoint, the DIRECT_RESULTS_QUERY returned a thrift operation state
+        other than FINISHED_STATE. If this test fails, it means the SQL warehouse got slower at executing this query
+        """
+
+        with self.connection() as conn:
+            ae = conn.execute_async(DIRECT_RESULTS_QUERY, {"param": 1})
+            assert not ae.is_running
 
     def test_cancel_running_query(self, long_running_ae: AsyncExecution):
         long_running_ae.cancel()
@@ -83,9 +111,29 @@ class TestExecuteAsync(PySQLPytestTestCase):
         long_running_ae.poll_for_status()
         assert long_running_ae.status == AsyncExecutionStatus.CANCELED
 
-    def test_staging_operation(self):
-        """We need to test what happens with a staging operation since this query won't have a result set
-        that user needs. It could be sufficient to notify users that they shouldn't use this API for staging/volumes
-        queries...
+    def test_long_ish_query_canary(self, long_ish_ae: AsyncExecution):
+        """This test verifies that on the current endpoint, the LONG_ISH_QUERY requires
+        at least one poll_for_status call before it is finished. If this test fails, it means
+        the SQL warehouse got faster at executing this query and we should increment the value
+        of GT_FIVE_SECONDS_VALUE
+
+        It would be easier to do this if Databricks SQL had a SLEEP() function :/
         """
-        assert False
+
+        poll_count = 0
+        while long_ish_ae.is_running:
+            time.sleep(1)
+            long_ish_ae.poll_for_status()
+            poll_count += 1
+
+        assert poll_count > 0
+
+    def test_get_async_execution_and_get_results_without_direct_results(
+        self, long_ish_ae: AsyncExecution
+    ):
+        while long_ish_ae.is_running:
+            time.sleep(1)
+            long_ish_ae.poll_for_status()
+
+        result = long_ish_ae.get_result().fetchone()
+        assert len(result) == 1

--- a/tests/e2e/test_execute_async.py
+++ b/tests/e2e/test_execute_async.py
@@ -137,3 +137,14 @@ class TestExecuteAsync(PySQLPytestTestCase):
 
         result = long_ish_ae.get_result().fetchone()
         assert len(result) == 1
+
+    def test_get_async_execution_with_bogus_query_id(self):
+
+        with self.connection() as conn:
+            with pytest.raises(AsyncExecutionException, match="Query not found"):
+                ae = conn.get_async_execution("bedc786d-64da-45d4-99da-5d3603525803", "ba469f82-cf3f-454e-b575-f4dcd58dd692")
+
+    def test_get_async_execution_with_badly_formed_query_id(self):
+        with self.connection() as conn:
+            with pytest.raises(ValueError, match="badly formed hexadecimal UUID string"):
+                ae = conn.get_async_execution("foo", "bar")

--- a/tests/e2e/test_execute_async.py
+++ b/tests/e2e/test_execute_async.py
@@ -148,3 +148,11 @@ class TestExecuteAsync(PySQLPytestTestCase):
         with self.connection() as conn:
             with pytest.raises(ValueError, match="badly formed hexadecimal UUID string"):
                 ae = conn.get_async_execution("foo", "bar")
+
+    def test_serialize(self, long_running_ae: AsyncExecution):
+        serialized = long_running_ae.serialize()
+        query_id, query_secret = serialized.split(":")
+
+        with self.connection() as conn:
+            ae = conn.get_async_execution(query_id, query_secret)
+            assert ae.is_running


### PR DESCRIPTION
## Description

This PR adds a way to "pick up" a running execution using only its `query_id` and `query_secret`. The interface looks like this:

```python
with self.connection() as conn:
    query_id = "01eeae6b-xxxx-1513-89a3-4668a032ed77"
    query_secret = "01eeae6b-xxxx-179d-8faf-0f39dc3788f8"
    ae = conn.get_async_execution(query_id, query_secret)
```

To achieve this I had to update `AsyncExecution`'s `__init__` method to accept `None` as its initial `status` value. Prior to this, `AsyncExecution` was always created with the `from_thrift_response` method which already knows the initial value.

I also had to introduce a new `FakeExecuteStatementResponse` dataclass. This is a workaround for the way `thrift_backend.py` is currently written. `thrift_backend.py` was written with the assumption that we have the original `TExecuteStatementResp` from when a query began by the time we fetch results of that query.

But for a "picked up" execution, we don't have the original `TExecuteStatementResp` because we only use the `query_id` and `query_secret` to pick up the running execution. This is a problem because result fetching depends on configuration data present in `TResultSetMetadata`. If we had the original `TExecuteStatementResp` then `thrift_backend.py` knows how to use its properties to gather the configuration it needs to fetch results. But since we don't have the original `TExecuteStatementResp` in the case of a "picked up" execution, we need a way to trick `thrift_backend.py` into thinking otherwise.

For this situation, the Thrift server includes the `TGetResultSetMetadataReq` and `TGetGetResultSetMetadataResp` messages and `thrift_backend.py` helpfully includes a way to invisibly fetch this if the original `TExecuteStatementResp.directResults` property is false-y.

To hook into this, I created the `FakeExecuteStatementResp` which only possesses the properties necessary to make `thrift_backend.py` use its normal code-path. It sets `.directResults=False` and sets `operationHandle` to the `THandleIdentifier` for the current `AsyncExecution`.

As discussed internally, we need to refactor `thrift_backend.py` to not depend on the assumption of synchronous execution within the same thread. But for now, the `FakeExecuteStatmentResp` makes `AsyncExecution` behave exactly the same way in the original thread as it does for a thread where the execution was "picked up". 


## What's next?

After this I need to add documentation for this feature and update the changelog.