### PR TITLE
Added support for tinyint to _parse.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 # 3.1.0 (TBD)
 
-- SQLAlchemy: Added support for table and column comments (thanks @cbornet!)
+- SQLAlchemy dialect now supports table and column comments (thanks @cbornet!)
+- Fix: SQLAlchemy dialect now correctly reflects TINYINT types (thanks @TimTheinAtTabs!)
 - Fix: `server_hostname` URIs that included `https://` would raise an exception
 
 ## 3.0.1 (2023-12-01)

--- a/src/databricks/sqlalchemy/_parse.py
+++ b/src/databricks/sqlalchemy/_parse.py
@@ -282,6 +282,7 @@ def get_pk_strings_from_dte_output(
 GET_COLUMNS_TYPE_MAP = {
     "boolean": sqlalchemy.types.Boolean,
     "smallint": sqlalchemy.types.SmallInteger,
+    "tinyint": sqlalchemy.types.SmallInteger,
     "int": sqlalchemy.types.Integer,
     "bigint": sqlalchemy.types.BigInteger,
     "float": sqlalchemy.types.Float,

--- a/src/databricks/sqlalchemy/_parse.py
+++ b/src/databricks/sqlalchemy/_parse.py
@@ -282,7 +282,7 @@ def get_pk_strings_from_dte_output(
 GET_COLUMNS_TYPE_MAP = {
     "boolean": sqlalchemy.types.Boolean,
     "smallint": sqlalchemy.types.SmallInteger,
-    "tinyint": sqlalchemy.types.SmallInteger,
+    "tinyint": type_overrides.TINYINT,
     "int": sqlalchemy.types.Integer,
     "bigint": sqlalchemy.types.BigInteger,
     "float": sqlalchemy.types.Float,

--- a/src/databricks/sqlalchemy/_types.py
+++ b/src/databricks/sqlalchemy/_types.py
@@ -316,3 +316,7 @@ class TINYINT(sqlalchemy.types.TypeDecorator):
 
     impl = sqlalchemy.types.SmallInteger
     cache_ok = True
+
+@compiles(TINYINT, "databricks")
+def compile_tinyint(type_, compiler, **kw):
+    return "TINYINT"

--- a/src/databricks/sqlalchemy/test_local/test_types.py
+++ b/src/databricks/sqlalchemy/test_local/test_types.py
@@ -111,7 +111,7 @@ class TestCamelCaseTypesCompilation(CompilationTestBase):
         )
 
     def test_numeric_renders_as_decimal_with_precision_and_scale(self):
-        return self._assert_compiled_value_explicit(
+        self._assert_compiled_value_explicit(
             sqlalchemy.types.Numeric(10, 2), "DECIMAL(10, 2)"
         )
 
@@ -146,8 +146,9 @@ class TestUppercaseTypesCompilation(CompilationTestBase):
         if isinstance(type_, type(sqlalchemy.types.ARRAY)):
             # ARRAY cannot be initialised without passing an item definition so we test separately
             # I preserve it in the uppercase_type_map for clarity
-            return True
-        return self._assert_compiled_value(type_, expected)
+            assert True
+        else:
+            self._assert_compiled_value(type_, expected)
 
     def test_array_string_renders_as_array_of_string(self):
         """SQLAlchemy's ARRAY type requires an item definition. And their docs indicate that they've only tested
@@ -155,6 +156,6 @@ class TestUppercaseTypesCompilation(CompilationTestBase):
 
         https://docs.sqlalchemy.org/en/20/core/type_basics.html#sqlalchemy.types.ARRAY
         """
-        return self._assert_compiled_value_explicit(
+        self._assert_compiled_value_explicit(
             sqlalchemy.types.ARRAY(sqlalchemy.types.String), "ARRAY<STRING>"
         )


### PR DESCRIPTION
Using SqlAlchemy to reflect on a table having a tinyint column throws an error because tinyint type was missing from the type map. Adding a single line to the code seems to have fixed the bug.