### PR TITLE
[PECO-1263] Implement an .is_available property for AsyncExecution status

### DIFF
--- a/src/databricks/sql/results.py
+++ b/src/databricks/sql/results.py
@@ -9,6 +9,7 @@ from databricks.sql import __version__
 from databricks.sql.exc import (
     CursorAlreadyClosedError,
 )
+from databricks.sql.thrift_api.TCLIService import ttypes
 from databricks.sql.types import Row
 from databricks.sql.utils import ExecuteResponse
 
@@ -223,3 +224,14 @@ class ResultSet:
             (column.name, map_col_type(column.datatype), None, None, None, None, None)
             for column in table_schema_message.columns
         ]
+
+
+def execute_response_contains_direct_results(
+    execute_response: ttypes.TExecuteStatementResp,
+) -> bool:
+    """
+    Returns True if the thrift TExecuteStatementResp contains metadata
+    This indicates the statement has finished executing at the server.
+    """
+
+    return bool(execute_response.directResults.resultSetMetadata)

--- a/tests/e2e/test_execute_async.py
+++ b/tests/e2e/test_execute_async.py
@@ -166,6 +166,9 @@ class TestExecuteAsync(PySQLPytestTestCase):
 
         with self.connection() as conn:
             ae = conn.execute_async(DIRECT_RESULTS_QUERY, {"param": 1})
+            assert (
+                not ae.is_available
+            ), "Queries that return direct results should not be available"
             query_id, query_secret = ae.serialize().split(":")
             ae.get_result()
 
@@ -193,9 +196,13 @@ class TestExecuteAsync(PySQLPytestTestCase):
         """
         with self.connection() as conn_1, self.connection() as conn_2:
             ae_1 = conn_1.execute_async(LONG_ISH_QUERY)
+            assert (
+                ae_1.is_available
+            ), "A long query does not return direct results so is_available should be True"
 
             query_id, query_secret = ae_1.serialize().split(":")
             ae_2 = conn_2.get_async_execution(query_id, query_secret)
+            assert ae_2.is_available
 
             while ae_1.is_running:
                 time.sleep(1)


### PR DESCRIPTION
## Description

This PR implements an additional boolean flag on `AsyncExecution` that indicates whether the result of this execution can be fetched from a separate thread.

I determined this is necessary while documenting the new `execute_async()` behaviour. For context, when we send a `TExecuteStatementReq` to the thrift server, there are **two** possible return conditions:

1. If the query completes within five seconds, the resulting `TExecuteStatementResp` will actually include the results! 
2. If the query takes longer than five seconds to complete, the resulting `TExecuteStatementResp` will only include the `query_id` for the query, which we can use to poll for the results until they are ready.

In case 1, the result is sent within the initial `TExecuteStatementResp` _and they cannot be fetched a second time. What this means for users is that if they are going to call `.serialize()` to persist a `query_id` and `secret` for use by another thread, they need a way to verify that the results will actually be available to another thread.

This new `.is_available` property makes that easier.