### PR TITLE
[PECO-1414] Change AAD openid config url to Databricks workspace

### DIFF
--- a/src/databricks/sql/auth/endpoint.py
+++ b/src/databricks/sql/auth/endpoint.py
@@ -91,7 +91,10 @@ class AzureOAuthEndpointCollection(OAuthEndpointCollection):
         return f"{get_databricks_oidc_url(hostname)}/oauth2/v2.0/authorize"
 
     def get_openid_config_url(self, hostname: str):
-        return "https://login.microsoftonline.com/organizations/v2.0/.well-known/openid-configuration"
+        # This well known openid url wil return Azure well-known openid configuration response
+        # or Databricks OAuth well-known URL
+        idp_url = get_databricks_oidc_url(hostname)
+        return f"{idp_url}/.well-known/openid-configuration"
 
 
 class AwsOAuthEndpointCollection(OAuthEndpointCollection):

--- a/tests/unit/test_endpoint.py
+++ b/tests/unit/test_endpoint.py
@@ -36,7 +36,7 @@ class EndpointTest(unittest.TestCase):
                           CloudType.AZURE,
                           azure_host,
                           f"https://{azure_host}/oidc/oauth2/v2.0/authorize",
-                          "https://login.microsoftonline.com/organizations/v2.0/.well-known/openid-configuration",
+                          f"https://{azure_host}/oidc/.well-known/openid-configuration",
                           [azure_scope, "offline_access"],
                           [azure_scope]
                       )]


### PR DESCRIPTION
To make pysql work with Azure AD OAuth and Databricks OAuth in Azure, we have to use Databricks workspace OAuth well-known URL which works with both.