### PR TITLE
Fix componentreflection test

### DIFF
--- a/src/databricks/sqlalchemy/_parse.py
+++ b/src/databricks/sqlalchemy/_parse.py
@@ -354,7 +354,7 @@ def parse_column_info_from_tgetcolumnsresponse(thrift_resp_row) -> ReflectedColu
         "type": final_col_type,
         "nullable": bool(thrift_resp_row.NULLABLE),
         "default": thrift_resp_row.COLUMN_DEF,
-        "comment": thrift_resp_row.REMARKS,
+        "comment": thrift_resp_row.REMARKS or None,
     }
 
     # TODO: figure out how to return sqlalchemy.interfaces in a way that mypy respects


### PR DESCRIPTION
## Description

This is a quick fix follow-up to #306 which fixes the `ComponentReflectionTest`. Since SQLAlchemy expects an empty column to be a `NoneType` rather than `''`. In actual usage, this doesn't change user behaviour since both `''` and `NoneType` evaluate false-y.