### PR TITLE
[PECO-1436] [sqlalchemy] Include sqlalchemy __version__ in user-agent

### DIFF
--- a/src/databricks/sqlalchemy/base.py
+++ b/src/databricks/sqlalchemy/base.py
@@ -411,14 +411,15 @@ def receive_do_connect(dialect, conn_rec, cargs, cparams):
     ua = cparams.get("_user_agent_entry", "")
 
     def add_sqla_tag_if_not_present(val: str):
+        tag = f"sqlalchemy=={sqlalchemy.__version__}"
         if not val:
-            output = "sqlalchemy"
+            output = tag
 
-        if val and "sqlalchemy" in val:
+        if val and tag in val:
             output = val
 
         else:
-            output = f"sqlalchemy + {val}"
+            output = f"{tag} + {val}"
 
         return output
 

--- a/src/databricks/sqlalchemy/test_local/e2e/test_basic.py
+++ b/src/databricks/sqlalchemy/test_local/e2e/test_basic.py
@@ -435,19 +435,17 @@ def test_has_table_across_schemas(db_engine: Engine, samples_engine: Engine):
                 conn.execute(text("DROP TABLE test_has_table;"))
 
 
-class TestSQLAlchemyUserAgent:
-
+class TestUserAgent:
     def get_conn_user_agent(self, conn):
         return conn.connection.dbapi_connection.thrift_backend._transport._headers.get(
             "User-Agent"
         )
-    
+
     def test_user_agent_adjustment(self, db_engine):
         # If .connect() is called multiple times on an engine, don't keep pre-pending the user agent
         # https://github.com/databricks/databricks-sql-python/issues/192
         c1 = db_engine.connect()
         c2 = db_engine.connect()
-
 
         ua1 = self.get_conn_user_agent(c1)
         ua2 = self.get_conn_user_agent(c2)
@@ -459,10 +457,10 @@ class TestSQLAlchemyUserAgent:
         assert same_ua, f"User agents didn't match \n {ua1} \n {ua2}"
 
     def test_sqlalchemy_user_agent_includes_version(self, db_engine):
-        """So that we know when we can safely deprecate support for sqlalchemy 1.x
-        """
+        """So that we know when we can safely deprecate support for sqlalchemy 1.x"""
 
         import sqlalchemy
+
         version_str = sqlalchemy.__version__
         c = db_engine.connect()
         ua = self.get_conn_user_agent(c)

--- a/src/databricks/sqlalchemy/test_local/e2e/test_basic.py
+++ b/src/databricks/sqlalchemy/test_local/e2e/test_basic.py
@@ -120,20 +120,6 @@ def test_can_connect(db_engine):
     assert len(result) == 1
 
 
-def test_connect_args(db_engine):
-    """Verify that extra connect args passed to sqlalchemy.create_engine are passed to DBAPI
-
-    This will most commonly happen when partners supply a user agent entry
-    """
-
-    conn = db_engine.connect()
-    connection_headers = conn.connection.thrift_backend._transport._headers
-    user_agent = connection_headers["User-Agent"]
-
-    expected = f"(sqlalchemy + {USER_AGENT_TOKEN})"
-    assert expected in user_agent
-
-
 @pytest.mark.skipif(sqlalchemy_1_3(), reason="Pandas requires SQLAlchemy >= 1.4")
 @pytest.mark.skip(
     reason="DBR is currently limited to 256 parameters per call to .execute(). Test cannot pass."
@@ -482,6 +468,19 @@ class TestSQLAlchemyUserAgent:
         ua = self.get_conn_user_agent(c)
 
         assert version_str in ua
+
+    def test_user_supplied_string(self, db_engine):
+        """Verify that extra connect args passed to sqlalchemy.create_engine are passed to DBAPI
+
+        This will most commonly happen when partners supply a user agent entry
+        """
+
+        conn = db_engine.connect()
+        connection_headers = conn.connection.thrift_backend._transport._headers
+        user_agent = connection_headers["User-Agent"]
+
+        assert USER_AGENT_TOKEN in user_agent
+
 
 @pytest.fixture
 def sample_table(metadata_obj: MetaData, db_engine: Engine):

--- a/src/databricks/sqlalchemy/test_local/e2e/test_basic.py
+++ b/src/databricks/sqlalchemy/test_local/e2e/test_basic.py
@@ -449,26 +449,39 @@ def test_has_table_across_schemas(db_engine: Engine, samples_engine: Engine):
                 conn.execute(text("DROP TABLE test_has_table;"))
 
 
-def test_user_agent_adjustment(db_engine):
-    # If .connect() is called multiple times on an engine, don't keep pre-pending the user agent
-    # https://github.com/databricks/databricks-sql-python/issues/192
-    c1 = db_engine.connect()
-    c2 = db_engine.connect()
+class TestSQLAlchemyUserAgent:
 
-    def get_conn_user_agent(conn):
+    def get_conn_user_agent(self, conn):
         return conn.connection.dbapi_connection.thrift_backend._transport._headers.get(
             "User-Agent"
         )
+    
+    def test_user_agent_adjustment(self, db_engine):
+        # If .connect() is called multiple times on an engine, don't keep pre-pending the user agent
+        # https://github.com/databricks/databricks-sql-python/issues/192
+        c1 = db_engine.connect()
+        c2 = db_engine.connect()
 
-    ua1 = get_conn_user_agent(c1)
-    ua2 = get_conn_user_agent(c2)
-    same_ua = ua1 == ua2
 
-    c1.close()
-    c2.close()
+        ua1 = self.get_conn_user_agent(c1)
+        ua2 = self.get_conn_user_agent(c2)
+        same_ua = ua1 == ua2
 
-    assert same_ua, f"User agents didn't match \n {ua1} \n {ua2}"
+        c1.close()
+        c2.close()
 
+        assert same_ua, f"User agents didn't match \n {ua1} \n {ua2}"
+
+    def test_sqlalchemy_user_agent_includes_version(self, db_engine):
+        """So that we know when we can safely deprecate support for sqlalchemy 1.x
+        """
+
+        import sqlalchemy
+        version_str = sqlalchemy.__version__
+        c = db_engine.connect()
+        ua = self.get_conn_user_agent(c)
+
+        assert version_str in ua
 
 @pytest.fixture
 def sample_table(metadata_obj: MetaData, db_engine: Engine):


### PR DESCRIPTION
## Description

This pr updates our user-agent setting logic for the sqlalchemy dialect so that we include the sqlalchemy package version. 

I used this as an opportunity to reorganise the two (now three) user agent tests into their own test class.