### PR TITLE
[ES-1020566] Fix: thrift connections fail when urllib3 is below 1.26.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+# 3.0.3 (TBD)
+
+- Fix: Thrift connections would fail if installed `urllib3` was below version `1.26.0`
+
 # 3.0.2 (2024-01-25)
 
 - SQLAlchemy dialect now supports table and column comments (thanks @cbornet!)


### PR DESCRIPTION
## Description

Starting in [urllib3==1.26.0](https://urllib3.readthedocs.io/en/stable/changelog.html#id31), the `method_whitelist` configuration for retries was deprecated and renamed to `allowed_methods`. databricks-sql-connector passes this argument to `Retry()` for every connection, which caused failures for even basic connection tests.

This pull request implements a dynamic lookup for this property name that uses `method_whitelist` if the installed version of `urllib3` is below `1.26.0`.


## Tests

This PR passes all of the non-retry related e2e tests. It fails all of the retry tests (sad face) because those tests depend on a specific mock patch that doesn't work on urllib3 below 1.26.0. I'll follow-up with a separate PR that fixes these tests. Given that the nature of this failure is that `Retry()` can't even initialise, however, this is a good first step.

For testing, I locally installed `urllib3==1.25.11` and ran all of the e2e tests. Then did the same with `urllib3==2.1.0`.
