### PR TITLE
Redact the URL query parameters from the urllib3.connectionpool logs

### DIFF
--- a/src/databricks/sql/__init__.py
+++ b/src/databricks/sql/__init__.py
@@ -25,7 +25,11 @@ class RedactUrlQueryParamsFilter(logging.Filter):
         record.msg = self.redact(str(record.msg))
         if isinstance(record.args, dict):
             for k in record.args.keys():
-                record.args[k] = self.redact(record.args[k])
+                record.args[k] = (
+                    self.redact(record.args[k])
+                    if isinstance(record.arg[k], str)
+                    else record.args[k]
+                )
         else:
             record.args = tuple(
                 (self.redact(arg) if isinstance(arg, str) else arg)

--- a/src/databricks/sql/__init__.py
+++ b/src/databricks/sql/__init__.py
@@ -10,6 +10,7 @@ paramstyle = "named"
 
 import re
 
+
 class RedactUrlQueryParamsFilter(logging.Filter):
     pattern = re.compile(r"(\?|&)([\w-]+)=([^&]+)")
     mask = r"\1\2=<REDACTED>"
@@ -32,6 +33,7 @@ class RedactUrlQueryParamsFilter(logging.Filter):
             )
 
         return True
+
 
 logging.getLogger("urllib3.connectionpool").addFilter(RedactUrlQueryParamsFilter())
 


### PR DESCRIPTION
If LogLevel is set to DEBUG, urllib3 is logging all the request URLs. These URLs include pre-signed URLs which are sensitive and should not be logged. This implements a redacting filter for logging that will replace param values in the URL with <REDACTED>. The URLs will be logged with URL path and param names and without the original param values.