### PR TITLE
Update the proxy authentication

### DIFF
--- a/src/databricks/sql/auth/thrift_http_client.py
+++ b/src/databricks/sql/auth/thrift_http_client.py
@@ -14,7 +14,7 @@ from http.client import HTTPResponse
 from io import BytesIO
 
 from urllib3 import HTTPConnectionPool, HTTPSConnectionPool, ProxyManager
-
+from urllib3.util import make_headers
 from databricks.sql.auth.retry import CommandType, DatabricksRetryPolicy
 
 
@@ -120,7 +120,7 @@ class THttpClient(thrift.transport.THttpClient.THttpClient):
             proxy_manager = ProxyManager(
                 self.proxy_uri,
                 num_pools=1,
-                headers={"Proxy-Authorization": self.proxy_auth},
+                proxy_headers=self.proxy_auth,
             )
             self.__pool = proxy_manager.connection_from_host(
                 host=self.realhost,
@@ -201,8 +201,7 @@ class THttpClient(thrift.transport.THttpClient.THttpClient):
             urllib.parse.unquote(proxy.username),
             urllib.parse.unquote(proxy.password),
         )
-        cr = base64.b64encode(ap.encode()).strip()
-        return "Basic " + six.ensure_str(cr)
+        return make_headers(proxy_basic_auth=ap)
 
     def set_retry_command_type(self, value: CommandType):
         """Pass the provided CommandType to the retry policy"""


### PR DESCRIPTION
This PR solves the proxy auth issue reported in #353.
The idea is to use the *proxy_headers* argument of the *ProxyManager* instead of the *Proxy-Authorization* http header according to the [API docs](https://urllib3.readthedocs.io/en/stable/reference/urllib3.poolmanager.html#urllib3.ProxyManager)