### PR TITLE
Fix boolean literals

### DIFF
--- a/src/databricks/sqlalchemy/base.py
+++ b/src/databricks/sqlalchemy/base.py
@@ -64,6 +64,7 @@ class DatabricksDialect(default.DefaultDialect):
     supports_default_values: bool = False
     supports_server_side_cursors: bool = False
     supports_sequences: bool = False
+    supports_native_boolean: bool = True
 
     colspecs = {
         sqlalchemy.types.DateTime: dialect_type_impl.TIMESTAMP_NTZ,


### PR DESCRIPTION
Reproducing the issue:
``` python
import sqlalchemy
from sqlalchemy import select

engine = sqlalchemy.create_engine(
    f"databricks://token:{os.environ['DATABRICKS_TOKEN']}@{os.environ['DATABRICKS_SERVER_HOSTNAME']}:443/default",
    connect_args={
        "http_path": os.environ["DATABRICKS_HTTP_PATH"],
    },
)
connection = engine.connect()
result = connection.execute(select(True, False))
```

Go to Query History in the workspace. See that it executes: `SELECT 1 AS anon_1, 0 AS anon_2`

This becomes a problem when trying to compare to a boolean column:
``` python
In [11]: from sqlalchemy import MetaData, Column, Table, Boolean
    ...: metadata_obj = MetaData()
    ...: table = Table("table_with_bool", metadata_obj, Column("value", Boolean()))
    ...: expression = select(1).select_from(table).where(table.c.value == True)
    ...: print(str(expression.compile(dialect=engine.dialect)))
SELECT 1
FROM table_with_bool
WHERE table_with_bool.value = 1
```

In Databricks this produces the error:
`[DATATYPE_MISMATCH.BINARY_OP_DIFF_TYPES] Cannot resolve "(value = 1)" due to data type mismatch: the left and right operands of the binary operator have incompatible types ("BOOLEAN" and "INT").; line 3 pos 6`

SQLAlchemy has a flag called supports_native_boolean that controls this behaviour and is set to false by default. Setting this flag to true starts rendering booleans correctly:
``` python
In [12]: class FixedDialect(DatabricksDialect):
    ...:     supports_native_boolean: bool = True
    ...:
    ...:
    ...: metadata_obj = MetaData()
    ...: table = Table("table_with_bool", metadata_obj, Column("value", Boolean()))
    ...: expression = select(1).select_from(table).where(table.c.value == True)
    ...: print(str(expression.compile(dialect=FixedDialect())))
SELECT 1
FROM table_with_bool
WHERE table_with_bool.value = true
```
At growthloop.com we've been using this fix in production for about a month and haven't had any issues.

I'm confused as to why some of the tests are failing on main when the description of _regression.py in README.tests.md implies tests in this file should be passing, maybe I'm running them incorrectly? Nevertheless, this change seems to be fixing a couple of the reusable dialect tests.
Before:
```
test/_regression.py::BooleanTest_databricks+databricks::test_null PASSED                 [ 25%]
test/_regression.py::BooleanTest_databricks+databricks::test_render_literal_bool FAILED  [ 50%]
test/_regression.py::BooleanTest_databricks+databricks::test_round_trip PASSED           [ 75%]
test/_regression.py::BooleanTest_databricks+databricks::test_whereclause FAILED          [100%]
```

After:
```
test/_regression.py::BooleanTest_databricks+databricks::test_null PASSED                 [ 25%]
test/_regression.py::BooleanTest_databricks+databricks::test_render_literal_bool PASSED  [ 50%]
test/_regression.py::BooleanTest_databricks+databricks::test_round_trip PASSED           [ 75%]
test/_regression.py::BooleanTest_databricks+databricks::test_whereclause PASSED          [100%]
```
