### PR TITLE
Add a default for retry after

### DIFF
--- a/src/databricks/sql/thrift_backend.py
+++ b/src/databricks/sql/thrift_backend.py
@@ -151,13 +151,9 @@ class ThriftBackend:
 
         self.staging_allowed_local_path = staging_allowed_local_path
         self._initialize_retry_args(kwargs)
-        self._use_arrow_native_complex_types = kwargs.get(
-            "_use_arrow_native_complex_types", True
-        )
+        self._use_arrow_native_complex_types = kwargs.get("_use_arrow_native_complex_types", True)
         self._use_arrow_native_decimals = kwargs.get("_use_arrow_native_decimals", True)
-        self._use_arrow_native_timestamps = kwargs.get(
-            "_use_arrow_native_timestamps", True
-        )
+        self._use_arrow_native_timestamps = kwargs.get("_use_arrow_native_timestamps", True)
 
         # Cloud fetch
         self.max_download_threads = kwargs.get("max_download_threads", 10)
@@ -251,15 +247,11 @@ class ThriftBackend:
             given_or_default = type_(kwargs.get(key, default))
             bound = _bound(min, max, given_or_default)
             setattr(self, key, bound)
-            logger.debug(
-                "retry parameter: {} given_or_default {}".format(key, given_or_default)
-            )
+            logger.debug("retry parameter: {} given_or_default {}".format(key, given_or_default))
             if bound != given_or_default:
                 logger.warning(
                     "Override out of policy retry parameter: "
-                    + "{} given {}, restricted to {}".format(
-                        key, given_or_default, bound
-                    )
+                    + "{} given {}, restricted to {}".format(key, given_or_default, bound)
                 )
 
         # Fail on retry delay min > max; consider later adding fail on min > duration?
@@ -287,9 +279,7 @@ class ThriftBackend:
         if THRIFT_ERROR_MESSAGE_HEADER in headers:
             err_msg = headers[THRIFT_ERROR_MESSAGE_HEADER]
         if DATABRICKS_ERROR_OR_REDIRECT_HEADER in headers:
-            if (
-                err_msg
-            ):  # We don't expect both to be set, but log both here just in case
+            if err_msg:  # We don't expect both to be set, but log both here just in case
                 err_msg = "Thriftserver error: {}, Databricks error: {}".format(
                     err_msg, headers[DATABRICKS_ERROR_OR_REDIRECT_HEADER]
                 )
@@ -309,10 +299,7 @@ class ThriftBackend:
         max_attempts = self._retry_stop_after_attempts_count
         max_duration_s = self._retry_stop_after_attempts_duration
 
-        if (
-            error_info.retry_delay is not None
-            and elapsed + error_info.retry_delay > max_duration_s
-        ):
+        if error_info.retry_delay is not None and elapsed + error_info.retry_delay > max_duration_s:
             no_retry_reason = NoRetryReason.OUT_OF_TIME
         elif error_info.retry_delay is not None and attempt >= max_attempts:
             no_retry_reason = NoRetryReason.OUT_OF_ATTEMPTS
@@ -376,8 +363,8 @@ class ThriftBackend:
             # encapsulate retry checks, returns None || delay-in-secs
             # Retry IFF 429/503 code + Retry-After header set
             http_code = getattr(self._transport, "code", None)
-            retry_after = getattr(self._transport, "headers", {}).get("Retry-After")
-            if http_code in [429, 503] and retry_after:
+            retry_after = getattr(self._transport, "headers", {}).get("Retry-After", 1)
+            if http_code in [429, 503]:
                 # bound delay (seconds) by [min_delay*1.5^(attempt-1), max_delay]
                 return bound_retry_delay(attempt, int(retry_after))
             return None
@@ -405,9 +392,7 @@ class ThriftBackend:
                 response = method(request)
 
                 # We need to call type(response) here because thrift doesn't implement __name__ attributes for thrift responses
-                logger.debug(
-                    "Received response: {}(<REDACTED>)".format(type(response).__name__)
-                )
+                logger.debug("Received response: {}(<REDACTED>)".format(type(response).__name__))
                 unsafe_logger.debug("Received response: {}".format(response))
                 return response
 
@@ -520,10 +505,7 @@ class ThriftBackend:
         if not (catalog or schema):
             return
 
-        if (
-            response.serverProtocolVersion
-            < ttypes.TProtocolVersion.SPARK_CLI_SERVICE_PROTOCOL_V4
-        ):
+        if response.serverProtocolVersion < ttypes.TProtocolVersion.SPARK_CLI_SERVICE_PROTOCOL_V4:
             raise InvalidServerResponseError(
                 "Setting initial namespace not supported by the DBR version, "
                 "Please use a Databricks SQL endpoint or a cluster with DBR >= 9.0."
@@ -538,10 +520,7 @@ class ThriftBackend:
 
     def _check_session_configuration(self, session_configuration):
         # This client expects timetampsAsString to be false, so we do not allow users to modify that
-        if (
-            session_configuration.get(TIMESTAMP_AS_STRING_CONFIG, "false").lower()
-            != "false"
-        ):
+        if session_configuration.get(TIMESTAMP_AS_STRING_CONFIG, "false").lower() != "false":
             raise Error(
                 "Invalid session configuration: {} cannot be changed "
                 "while using the Databricks SQL connector, it must be false not {}".format(
@@ -553,18 +532,14 @@ class ThriftBackend:
     def open_session(self, session_configuration, catalog, schema):
         try:
             self._transport.open()
-            session_configuration = {
-                k: str(v) for (k, v) in (session_configuration or {}).items()
-            }
+            session_configuration = {k: str(v) for (k, v) in (session_configuration or {}).items()}
             self._check_session_configuration(session_configuration)
             # We want to receive proper Timestamp arrow types.
             # We set it also in confOverlay in TExecuteStatementReq on a per query basic,
             # but it doesn't hurt to also set for the whole session.
             session_configuration[TIMESTAMP_AS_STRING_CONFIG] = "false"
             if catalog or schema:
-                initial_namespace = ttypes.TNamespace(
-                    catalogName=catalog, schemaName=schema
-                )
+                initial_namespace = ttypes.TNamespace(catalogName=catalog, schemaName=schema)
             else:
                 initial_namespace = None
 
@@ -590,9 +565,7 @@ class ThriftBackend:
         finally:
             self._transport.close()
 
-    def _check_command_not_in_error_or_closed_state(
-        self, op_handle, get_operations_resp
-    ):
+    def _check_command_not_in_error_or_closed_state(self, op_handle, get_operations_resp):
         if get_operations_resp.operationState == ttypes.TOperationState.ERROR_STATE:
             if get_operations_resp.displayMessage:
                 raise ServerOperationError(
@@ -617,10 +590,7 @@ class ThriftBackend:
                 "Command {} unexpectedly closed server side".format(
                     op_handle and self.guid_to_hex_id(op_handle.operationId.guid)
                 ),
-                {
-                    "operation-id": op_handle
-                    and self.guid_to_hex_id(op_handle.operationId.guid)
-                },
+                {"operation-id": op_handle and self.guid_to_hex_id(op_handle.operationId.guid)},
             )
 
     def _poll_for_status(self, op_handle):
@@ -637,7 +607,10 @@ class ThriftBackend:
                 num_rows,
             ) = convert_column_based_set_to_arrow_table(t_row_set.columns, description)
         elif t_row_set.arrowBatches is not None:
-            (arrow_table, num_rows,) = convert_arrow_based_set_to_arrow_table(
+            (
+                arrow_table,
+                num_rows,
+            ) = convert_arrow_based_set_to_arrow_table(
                 t_row_set.arrowBatches, lz4_compressed, schema_bytes
             )
         else:
@@ -679,9 +652,7 @@ class ThriftBackend:
             else:
                 # Current thriftserver implementation should always return a primitiveEntry,
                 # even for complex types
-                raise OperationalError(
-                    "Thrift protocol error: t_type_entry not a primitiveEntry"
-                )
+                raise OperationalError("Thrift protocol error: t_type_entry not a primitiveEntry")
 
         def convert_col(t_column_desc):
             return pyarrow.field(
@@ -699,9 +670,7 @@ class ThriftBackend:
             # Drop _TYPE suffix
             cleaned_type = (name[:-5] if name.endswith("_TYPE") else name).lower()
         else:
-            raise OperationalError(
-                "Thrift protocol error: t_type_entry not a primitiveEntry"
-            )
+            raise OperationalError("Thrift protocol error: t_type_entry not a primitiveEntry")
 
         if type_entry.primitiveEntry.type == ttypes.TTypeId.DECIMAL_TYPE:
             qualifiers = type_entry.primitiveEntry.typeQualifiers.qualifiers
@@ -722,9 +691,7 @@ class ThriftBackend:
 
     @staticmethod
     def _hive_schema_to_description(t_table_schema):
-        return [
-            ThriftBackend._col_to_description(col) for col in t_table_schema.columns
-        ]
+        return [ThriftBackend._col_to_description(col) for col in t_table_schema.columns]
 
     def _results_message_to_execute_response(self, resp, operation_state):
         if resp.directResults and resp.directResults.resultSetMetadata:
@@ -752,9 +719,7 @@ class ThriftBackend:
             or (not direct_results.resultSet)
             or direct_results.resultSet.hasMoreRows
         )
-        description = self._hive_schema_to_description(
-            t_result_set_metadata_resp.schema
-        )
+        description = self._hive_schema_to_description(t_result_set_metadata_resp.schema)
         schema_bytes = (
             t_result_set_metadata_resp.arrowSchema
             or self._hive_schema_to_arrow_schema(t_result_set_metadata_resp.schema)
@@ -795,8 +760,7 @@ class ThriftBackend:
                 op_handle, initial_operation_status_resp
             )
         operation_state = (
-            initial_operation_status_resp
-            and initial_operation_status_resp.operationState
+            initial_operation_status_resp and initial_operation_status_resp.operationState
         )
         while not operation_state or operation_state in [
             ttypes.TOperationState.RUNNING_STATE,
@@ -811,21 +775,13 @@ class ThriftBackend:
     def _check_direct_results_for_error(t_spark_direct_results):
         if t_spark_direct_results:
             if t_spark_direct_results.operationStatus:
-                ThriftBackend._check_response_for_error(
-                    t_spark_direct_results.operationStatus
-                )
+                ThriftBackend._check_response_for_error(t_spark_direct_results.operationStatus)
             if t_spark_direct_results.resultSetMetadata:
-                ThriftBackend._check_response_for_error(
-                    t_spark_direct_results.resultSetMetadata
-                )
+                ThriftBackend._check_response_for_error(t_spark_direct_results.resultSetMetadata)
             if t_spark_direct_results.resultSet:
-                ThriftBackend._check_response_for_error(
-                    t_spark_direct_results.resultSet
-                )
+                ThriftBackend._check_response_for_error(t_spark_direct_results.resultSet)
             if t_spark_direct_results.closeOperation:
-                ThriftBackend._check_response_for_error(
-                    t_spark_direct_results.closeOperation
-                )
+                ThriftBackend._check_response_for_error(t_spark_direct_results.closeOperation)
 
     def execute_command(
         self,
@@ -852,9 +808,7 @@ class ThriftBackend:
             sessionHandle=session_handle,
             statement=operation,
             runAsync=True,
-            getDirectResults=ttypes.TSparkGetDirectResults(
-                maxRows=max_rows, maxBytes=max_bytes
-            ),
+            getDirectResults=ttypes.TSparkGetDirectResults(maxRows=max_rows, maxBytes=max_bytes),
             canReadArrowResult=True,
             canDecompressLZ4Result=lz4_compression,
             canDownloadResult=use_cloud_fetch,
@@ -873,9 +827,7 @@ class ThriftBackend:
 
         req = ttypes.TGetCatalogsReq(
             sessionHandle=session_handle,
-            getDirectResults=ttypes.TSparkGetDirectResults(
-                maxRows=max_rows, maxBytes=max_bytes
-            ),
+            getDirectResults=ttypes.TSparkGetDirectResults(maxRows=max_rows, maxBytes=max_bytes),
         )
         resp = self.make_request(self._client.GetCatalogs, req)
         return self._handle_execute_response(resp, cursor)
@@ -893,9 +845,7 @@ class ThriftBackend:
 
         req = ttypes.TGetSchemasReq(
             sessionHandle=session_handle,
-            getDirectResults=ttypes.TSparkGetDirectResults(
-                maxRows=max_rows, maxBytes=max_bytes
-            ),
+            getDirectResults=ttypes.TSparkGetDirectResults(maxRows=max_rows, maxBytes=max_bytes),
             catalogName=catalog_name,
             schemaName=schema_name,
         )
@@ -917,9 +867,7 @@ class ThriftBackend:
 
         req = ttypes.TGetTablesReq(
             sessionHandle=session_handle,
-            getDirectResults=ttypes.TSparkGetDirectResults(
-                maxRows=max_rows, maxBytes=max_bytes
-            ),
+            getDirectResults=ttypes.TSparkGetDirectResults(maxRows=max_rows, maxBytes=max_bytes),
             catalogName=catalog_name,
             schemaName=schema_name,
             tableName=table_name,
@@ -943,9 +891,7 @@ class ThriftBackend:
 
         req = ttypes.TGetColumnsReq(
             sessionHandle=session_handle,
-            getDirectResults=ttypes.TSparkGetDirectResults(
-                maxRows=max_rows, maxBytes=max_bytes
-            ),
+            getDirectResults=ttypes.TSparkGetDirectResults(maxRows=max_rows, maxBytes=max_bytes),
             catalogName=catalog_name,
             schemaName=schema_name,
             tableName=table_name,
@@ -1016,9 +962,7 @@ class ThriftBackend:
 
     def cancel_command(self, active_op_handle):
         logger.debug(
-            "Cancelling command {}".format(
-                self.guid_to_hex_id(active_op_handle.operationId.guid)
-            )
+            "Cancelling command {}".format(self.guid_to_hex_id(active_op_handle.operationId.guid))
         )
         req = ttypes.TCancelOperationReq(active_op_handle)
         self.make_request(self._client.CancelOperation, req)


### PR DESCRIPTION
If we get a 503 without a Retry-After, it can indicate that nginx was responding while app was starting up / shutting down, and may not have a Retry-After set.  This causes the connector to bail, which is problematic for dependent projects such as dbt-databricks.  Apologies for the autoformat, the only real change is on lines 366-367.