### PR TITLE
Don't retry network requests that fail with code 403

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+# x.x.x (TBD)
+
+- Don't retry requests that fail with code 403
+
 # 3.1.0 (2024-02-16)
 
 - Revert retry-after behavior to be exponential backoff (#349)

--- a/src/databricks/sql/auth/retry.py
+++ b/src/databricks/sql/auth/retry.py
@@ -338,9 +338,11 @@ class DatabricksRetryPolicy(Retry):
         # Request succeeded. Don't retry.
         if status_code == 200:
             return False, "200 codes are not retried"
-        
+
         if status_code == 403:
-            raise NonRecoverableNetworkError("Received 403 - FORBIDDEN. Confirm your authentication credentials.") 
+            raise NonRecoverableNetworkError(
+                "Received 403 - FORBIDDEN. Confirm your authentication credentials."
+            )
 
         # Request failed and server said NotImplemented. This isn't recoverable. Don't retry.
         if status_code == 501:

--- a/src/databricks/sql/auth/retry.py
+++ b/src/databricks/sql/auth/retry.py
@@ -325,6 +325,7 @@ class DatabricksRetryPolicy(Retry):
                default, this means ExecuteStatement is only retried for codes 429 and 503.
                This limit prevents automatically retrying non-idempotent commands that could
                be destructive.
+            5. The request received a 403 response, because this can never succeed.
 
 
         Q: What about OSErrors and Redirects?
@@ -337,6 +338,9 @@ class DatabricksRetryPolicy(Retry):
         # Request succeeded. Don't retry.
         if status_code == 200:
             return False, "200 codes are not retried"
+        
+        if status_code == 403:
+            raise NonRecoverableNetworkError("Received 403 - FORBIDDEN. Confirm your authentication credentials.") 
 
         # Request failed and server said NotImplemented. This isn't recoverable. Don't retry.
         if status_code == 501:

--- a/tests/e2e/common/retry_test_mixins.py
+++ b/tests/e2e/common/retry_test_mixins.py
@@ -407,3 +407,17 @@ class PySQLRetryTestsMixin:
     def test_retry_legacy_behavior_warns_user(self, caplog):
         with self.connection(extra_params={**self._retry_policy, "_enable_v3_retries": False}):
             assert "Legacy retry behavior is enabled for this connection." in caplog.text
+
+
+    def test_403_not_retried(self):
+        """GIVEN the server returns a code 403
+        WHEN the connector receives this response
+        THEN nothing is retried and an exception is raised
+        """
+
+        # Code 403 is a Forbidden error
+        with mocked_server_response(status=403):
+            with pytest.raises(RequestError) as cm:
+                with self.connection(extra_params=self._retry_policy) as conn:
+                    pass
+                assert isinstance(cm.value.args[1], NonRecoverableNetworkError)


### PR DESCRIPTION
## Description

This adds a check to `should_retry()` which immediately raises an exception if a 403 code is received from Databricks and an associated test. Prior to this change, the connector would continue retrying until the retry counter was exceeded.

I think this has existed for some time but wasn't obvious to users until exponential backoff was implemented in #349. Because prior to #349, it would retry over and over again until it ran out of retries and then raise an exception. But now that backoff is in-force, it takes longer for it to exhaust the retry counter.

## Related Tickets & Documents
Fixes these:
- https://github.com/databricks/databricks-sql-python/issues/372
- https://github.com/databricks/databricks-sql-python/issues/346