### PR TITLE
[PECO-1751] Refactor CloudFetch downloader: handle files sequentially

### DIFF
--- a/src/databricks/sql/cloudfetch/download_manager.py
+++ b/src/databricks/sql/cloudfetch/download_manager.py
@@ -25,14 +25,14 @@ class ResultFileDownloadManager:
             if link.rowCount <= 0:
                 continue
             logger.debug(
-                "ResultFileDownloadManager.add_file_links: start offset {}, row count: {}".format(
+                "ResultFileDownloadManager: adding file link, start offset {}, row count: {}".format(
                     link.startRowOffset, link.rowCount
                 )
             )
             self._pending_links.append(link)
 
         self._download_tasks: List[Future[DownloadedFile]] = []
-        self._max_download_threads: int = max_download_threads + 1
+        self._max_download_threads: int = max_download_threads
         self._thread_pool = ThreadPoolExecutor(max_workers=self._max_download_threads)
 
         self._downloadable_result_settings = DownloadableResultSettings(lz4_compressed)

--- a/src/databricks/sql/cloudfetch/downloader.py
+++ b/src/databricks/sql/cloudfetch/downloader.py
@@ -3,12 +3,29 @@ from dataclasses import dataclass
 
 import requests
 import lz4.frame
-import threading
 import time
 
 from databricks.sql.thrift_api.TCLIService.ttypes import TSparkArrowResultLink
 
+from databricks.sql.exc import Error
+
 logger = logging.getLogger(__name__)
+
+
+@dataclass
+class DownloadedFile:
+    """
+    Class for the result file and metadata.
+
+    Attributes:
+        file_bytes (bytes): Downloaded file in bytes.
+        start_row_offset (int): The offset of the starting row in relation to the full result.
+        row_count (int): Number of rows the file represents in the result.
+    """
+
+    file_bytes: bytes
+    start_row_offset: int
+    row_count: int
 
 
 @dataclass
@@ -29,111 +46,74 @@ class DownloadableResultSettings:
     max_consecutive_file_download_retries: int = 0
 
 
-class ResultSetDownloadHandler(threading.Thread):
+class ResultSetDownloadHandler:
     def __init__(
         self,
-        downloadable_result_settings: DownloadableResultSettings,
-        t_spark_arrow_result_link: TSparkArrowResultLink,
+        settings: DownloadableResultSettings,
+        link: TSparkArrowResultLink,
     ):
-        super().__init__()
-        self.settings = downloadable_result_settings
-        self.result_link = t_spark_arrow_result_link
-        self.is_download_scheduled = False
-        self.is_download_finished = threading.Event()
-        self.is_file_downloaded_successfully = False
-        self.is_link_expired = False
-        self.is_download_timedout = False
-        self.result_file = None
+        self.settings = settings
+        self.link = link
 
-    def is_file_download_successful(self) -> bool:
-        """
-        Check and report if cloud fetch file downloaded successfully.
-
-        This function will block until a file download finishes or until a timeout.
-        """
-        timeout = (
-            self.settings.download_timeout
-            if self.settings.download_timeout > 0
-            else None
-        )
-        try:
-            if not self.is_download_finished.wait(timeout=timeout):
-                self.is_download_timedout = True
-                logger.debug(
-                    "Cloud fetch download timed out after {} seconds for link representing rows {} to {}".format(
-                        self.settings.download_timeout,
-                        self.result_link.startRowOffset,
-                        self.result_link.startRowOffset + self.result_link.rowCount,
-                    )
-                )
-                return False
-        except Exception as e:
-            logger.error(e)
-            return False
-        return self.is_file_downloaded_successfully
-
-    def run(self):
+    def run(self) -> DownloadedFile:
         """
         Download the file described in the cloud fetch link.
 
         This function checks if the link has or is expiring, gets the file via a requests session, decompresses the
         file, and signals to waiting threads that the download is finished and whether it was successful.
         """
-        self._reset()
 
         # Check if link is already expired or is expiring
-        if ResultSetDownloadHandler.check_link_expired(
-            self.result_link, self.settings.link_expiry_buffer_secs
-        ):
-            self.is_link_expired = True
-            return
+        ResultSetDownloadHandler._validate_link(
+            self.link, self.settings.link_expiry_buffer_secs
+        )
 
         session = requests.Session()
         session.timeout = self.settings.download_timeout
+        # TODO: Retry:
+        # from requests.adapters import HTTPAdapter, Retry
+        # retries = Retry(total=5,
+        #         backoff_factor=0.1,
+        #         status_forcelist=[ 500, 502, 503, 504 ])
+        # session.mount('http://', HTTPAdapter(max_retries=retries))
 
         try:
             # Get the file via HTTP request
-            response = session.get(self.result_link.fileLink)
-
-            if not response.ok:
-                self.is_file_downloaded_successfully = False
-                return
+            response = session.get(self.link.fileLink)
+            response.raise_for_status()
 
             # Save (and decompress if needed) the downloaded file
             compressed_data = response.content
             decompressed_data = (
-                ResultSetDownloadHandler.decompress_data(compressed_data)
+                ResultSetDownloadHandler._decompress_data(compressed_data)
                 if self.settings.is_lz4_compressed
                 else compressed_data
             )
-            self.result_file = decompressed_data
 
             # The size of the downloaded file should match the size specified from TSparkArrowResultLink
-            self.is_file_downloaded_successfully = (
-                len(self.result_file) == self.result_link.bytesNum
-            )
-        except Exception as e:
-            logger.error(e)
-            self.is_file_downloaded_successfully = False
+            if len(decompressed_data) != self.link.bytesNum:
+                logger.debug(
+                    "ResultSetDownloadHandler: downloaded file size {} does not match the expected value {}".format(
+                        len(decompressed_data), self.link.bytesNum
+                    )
+                )
 
+            logger.debug(
+                "ResultSetDownloadHandler: successfully downloaded file, offset {}, row count {}".format(
+                    self.link.startRowOffset, self.link.rowCount
+                )
+            )
+
+            return DownloadedFile(
+                decompressed_data,
+                self.link.startRowOffset,
+                self.link.rowCount,
+            )
         finally:
             session and session.close()
-            # Awaken threads waiting for this to be true which signals the run is complete
-            self.is_download_finished.set()
-
-    def _reset(self):
-        """
-        Reset download-related flags for every retry of run()
-        """
-        self.is_file_downloaded_successfully = False
-        self.is_link_expired = False
-        self.is_download_timedout = False
-        self.is_download_finished = threading.Event()
 
     @staticmethod
-    def check_link_expired(
-        link: TSparkArrowResultLink, expiry_buffer_secs: int
-    ) -> bool:
+    def _validate_link(link: TSparkArrowResultLink, expiry_buffer_secs: int):
         """
         Check if a link has expired or will expire.
 
@@ -142,14 +122,13 @@ class ResultSetDownloadHandler(threading.Thread):
         """
         current_time = int(time.time())
         if (
-            link.expiryTime < current_time
-            or link.expiryTime - current_time < expiry_buffer_secs
+            link.expiryTime <= current_time
+            or link.expiryTime - current_time <= expiry_buffer_secs
         ):
-            return True
-        return False
+            raise Error("CloudFetch link has expired")
 
     @staticmethod
-    def decompress_data(compressed_data: bytes) -> bytes:
+    def _decompress_data(compressed_data: bytes) -> bytes:
         """
         Decompress lz4 frame compressed data.
 

--- a/src/databricks/sql/utils.py
+++ b/src/databricks/sql/utils.py
@@ -170,9 +170,8 @@ class CloudFetchQueue(ResultSetQueue):
                 )
 
         self.download_manager = ResultFileDownloadManager(
-            self.max_download_threads, self.lz4_compressed
+            result_links or [], self.max_download_threads, self.lz4_compressed
         )
-        self.download_manager.add_file_links(result_links)
 
         self.table = self._create_next_table()
         self.table_row_index = 0

--- a/tests/unit/test_download_manager.py
+++ b/tests/unit/test_download_manager.py
@@ -2,7 +2,6 @@ import unittest
 from unittest.mock import patch, MagicMock
 
 import databricks.sql.cloudfetch.download_manager as download_manager
-import databricks.sql.cloudfetch.downloader as downloader
 from databricks.sql.thrift_api.TCLIService.ttypes import TSparkArrowResultLink
 
 
@@ -11,10 +10,8 @@ class DownloadManagerTests(unittest.TestCase):
     Unit tests for checking download manager logic.
     """
 
-    def create_download_manager(self):
-        max_download_threads = 10
-        lz4_compressed = True
-        return download_manager.ResultFileDownloadManager(max_download_threads, lz4_compressed)
+    def create_download_manager(self, links, max_download_threads=10, lz4_compressed=True):
+        return download_manager.ResultFileDownloadManager(links, max_download_threads, lz4_compressed)
 
     def create_result_link(
             self,
@@ -36,172 +33,25 @@ class DownloadManagerTests(unittest.TestCase):
 
     def test_add_file_links_zero_row_count(self):
         links = [self.create_result_link(row_count=0, bytes_num=0)]
-        manager = self.create_download_manager()
-        manager.add_file_links(links)
+        manager = self.create_download_manager(links)
 
-        assert not manager.download_handlers
+        assert len(manager._pending_links) == 0  # the only link supplied contains no data, so should be skipped
+        assert len(manager._download_tasks) == 0
 
     def test_add_file_links_success(self):
         links = self.create_result_links(num_files=10)
-        manager = self.create_download_manager()
-        manager.add_file_links(links)
+        manager = self.create_download_manager(links)
 
-        assert len(manager.download_handlers) == 10
-
-    def test_remove_past_handlers_one(self):
-        links = self.create_result_links(num_files=10)
-        manager = self.create_download_manager()
-        manager.add_file_links(links)
-
-        manager._remove_past_handlers(8000)
-        assert len(manager.download_handlers) == 9
-
-    def test_remove_past_handlers_all(self):
-        links = self.create_result_links(num_files=10)
-        manager = self.create_download_manager()
-        manager.add_file_links(links)
-
-        manager._remove_past_handlers(8000*10)
-        assert len(manager.download_handlers) == 0
+        assert len(manager._pending_links) == len(links)
+        assert len(manager._download_tasks) == 0
 
     @patch("concurrent.futures.ThreadPoolExecutor.submit")
-    def test_schedule_downloads_partial_already_scheduled(self, mock_submit):
+    def test_schedule_downloads(self, mock_submit):
+        max_download_threads = 4
         links = self.create_result_links(num_files=10)
-        manager = self.create_download_manager()
-        manager.add_file_links(links)
-
-        for i in range(5):
-            manager.download_handlers[i].is_download_scheduled = True
+        manager = self.create_download_manager(links, max_download_threads=max_download_threads)
 
         manager._schedule_downloads()
-        assert mock_submit.call_count == 5
-        assert sum([1 if handler.is_download_scheduled else 0 for handler in manager.download_handlers]) == 10
-
-    @patch("concurrent.futures.ThreadPoolExecutor.submit")
-    def test_schedule_downloads_will_not_schedule_twice(self, mock_submit):
-        links = self.create_result_links(num_files=10)
-        manager = self.create_download_manager()
-        manager.add_file_links(links)
-
-        for i in range(5):
-            manager.download_handlers[i].is_download_scheduled = True
-
-        manager._schedule_downloads()
-        assert mock_submit.call_count == 5
-        assert sum([1 if handler.is_download_scheduled else 0 for handler in manager.download_handlers]) == 10
-
-        manager._schedule_downloads()
-        assert mock_submit.call_count == 5
-
-    @patch("concurrent.futures.ThreadPoolExecutor.submit", side_effect=[True, KeyError("foo")])
-    def test_schedule_downloads_submit_fails(self, mock_submit):
-        links = self.create_result_links(num_files=10)
-        manager = self.create_download_manager()
-        manager.add_file_links(links)
-
-        manager._schedule_downloads()
-        assert mock_submit.call_count == 2
-        assert sum([1 if handler.is_download_scheduled else 0 for handler in manager.download_handlers]) == 1
-
-    @patch("concurrent.futures.ThreadPoolExecutor.submit")
-    def test_find_next_file_index_all_scheduled_next_row_0(self, mock_submit):
-        links = self.create_result_links(num_files=10)
-        manager = self.create_download_manager()
-        manager.add_file_links(links)
-        manager._schedule_downloads()
-
-        assert manager._find_next_file_index(0) == 0
-
-    @patch("concurrent.futures.ThreadPoolExecutor.submit")
-    def test_find_next_file_index_all_scheduled_next_row_7999(self, mock_submit):
-        links = self.create_result_links(num_files=10)
-        manager = self.create_download_manager()
-        manager.add_file_links(links)
-        manager._schedule_downloads()
-
-        assert manager._find_next_file_index(7999) is None
-
-    @patch("concurrent.futures.ThreadPoolExecutor.submit")
-    def test_find_next_file_index_all_scheduled_next_row_8000(self, mock_submit):
-        links = self.create_result_links(num_files=10)
-        manager = self.create_download_manager()
-        manager.add_file_links(links)
-        manager._schedule_downloads()
-
-        assert manager._find_next_file_index(8000) == 1
-
-    @patch("concurrent.futures.ThreadPoolExecutor.submit", side_effect=[True, KeyError("foo")])
-    def test_find_next_file_index_one_scheduled_next_row_8000(self, mock_submit):
-        links = self.create_result_links(num_files=10)
-        manager = self.create_download_manager()
-        manager.add_file_links(links)
-        manager._schedule_downloads()
-
-        assert manager._find_next_file_index(8000) is None
-
-    @patch("databricks.sql.cloudfetch.downloader.ResultSetDownloadHandler.is_file_download_successful",
-           return_value=True)
-    @patch("concurrent.futures.ThreadPoolExecutor.submit")
-    def test_check_if_download_successful_happy(self, mock_submit, mock_is_file_download_successful):
-        links = self.create_result_links(num_files=10)
-        manager = self.create_download_manager()
-        manager.add_file_links(links)
-        manager._schedule_downloads()
-
-        status = manager._check_if_download_successful(manager.download_handlers[0])
-        assert status
-        assert manager.num_consecutive_result_file_download_retries == 0
-
-    @patch("databricks.sql.cloudfetch.downloader.ResultSetDownloadHandler.is_file_download_successful",
-           return_value=False)
-    def test_check_if_download_successful_link_expired(self, mock_is_file_download_successful):
-        manager = self.create_download_manager()
-        handler = downloader.ResultSetDownloadHandler(manager.downloadable_result_settings, self.create_result_link())
-        handler.is_link_expired = True
-
-        status = manager._check_if_download_successful(handler)
-        mock_is_file_download_successful.assert_called()
-        assert not status
-        assert manager.fetch_need_retry
-
-    @patch("databricks.sql.cloudfetch.downloader.ResultSetDownloadHandler.is_file_download_successful",
-           return_value=False)
-    def test_check_if_download_successful_download_timed_out_no_retries(self, mock_is_file_download_successful):
-        manager = self.create_download_manager()
-        handler = downloader.ResultSetDownloadHandler(manager.downloadable_result_settings, self.create_result_link())
-        handler.is_download_timedout = True
-
-        status = manager._check_if_download_successful(handler)
-        mock_is_file_download_successful.assert_called()
-        assert not status
-        assert manager.fetch_need_retry
-
-    @patch("concurrent.futures.ThreadPoolExecutor.submit")
-    @patch("databricks.sql.cloudfetch.downloader.ResultSetDownloadHandler.is_file_download_successful",
-           return_value=False)
-    def test_check_if_download_successful_download_timed_out_1_retry(self, mock_is_file_download_successful, mock_submit):
-        manager = self.create_download_manager()
-        manager.downloadable_result_settings = download_manager.DownloadableResultSettings(
-            is_lz4_compressed=True,
-            download_timeout=0,
-            max_consecutive_file_download_retries=1,
-        )
-        handler = downloader.ResultSetDownloadHandler(manager.downloadable_result_settings, self.create_result_link())
-        handler.is_download_timedout = True
-
-        status = manager._check_if_download_successful(handler)
-        assert mock_is_file_download_successful.call_count == 2
-        assert mock_submit.call_count == 1
-        assert not status
-        assert manager.fetch_need_retry
-
-    @patch("databricks.sql.cloudfetch.downloader.ResultSetDownloadHandler.is_file_download_successful",
-           return_value=False)
-    def test_check_if_download_successful_other_reason(self, mock_is_file_download_successful):
-        manager = self.create_download_manager()
-        handler = downloader.ResultSetDownloadHandler(manager.downloadable_result_settings, self.create_result_link())
-
-        status = manager._check_if_download_successful(handler)
-        mock_is_file_download_successful.assert_called()
-        assert not status
-        assert manager.fetch_need_retry
+        assert mock_submit.call_count == max_download_threads
+        assert len(manager._pending_links) == len(links) - max_download_threads
+        assert len(manager._download_tasks) == max_download_threads

--- a/tests/unit/test_downloader.py
+++ b/tests/unit/test_downloader.py
@@ -1,7 +1,17 @@
 import unittest
 from unittest.mock import Mock, patch, MagicMock
 
+import requests
+
 import databricks.sql.cloudfetch.downloader as downloader
+from databricks.sql.exc import Error
+
+
+def create_response(**kwargs) -> requests.Response:
+    result = requests.Response()
+    for k, v in kwargs.items():
+        setattr(result, k, v)
+    return result
 
 
 class DownloaderTests(unittest.TestCase):
@@ -16,9 +26,11 @@ class DownloaderTests(unittest.TestCase):
         # Already expired
         result_link.expiryTime = 999
         d = downloader.ResultSetDownloadHandler(settings, result_link)
-        assert not d.is_link_expired
-        d.run()
-        assert d.is_link_expired
+
+        with self.assertRaises(Error) as context:
+            d.run()
+        self.assertTrue('link has expired' in context.exception.message)
+
         mock_time.assert_called_once()
 
     @patch('time.time', return_value=1000)
@@ -28,83 +40,58 @@ class DownloaderTests(unittest.TestCase):
         # Within the expiry buffer time
         result_link.expiryTime = 1004
         d = downloader.ResultSetDownloadHandler(settings, result_link)
-        assert not d.is_link_expired
-        d.run()
-        assert d.is_link_expired
+
+        with self.assertRaises(Error) as context:
+            d.run()
+        self.assertTrue('link has expired' in context.exception.message)
+
         mock_time.assert_called_once()
 
-    @patch('requests.Session', return_value=MagicMock(get=MagicMock(return_value=MagicMock(ok=False))))
+    @patch('requests.Session', return_value=MagicMock(get=MagicMock(return_value=None)))
     @patch('time.time', return_value=1000)
     def test_run_get_response_not_ok(self, mock_time, mock_session):
+        mock_session.return_value.get.return_value = create_response(status_code=404)
+
         settings = Mock(link_expiry_buffer_secs=0, download_timeout=0)
         settings.download_timeout = 0
         settings.use_proxy = False
         result_link = Mock(expiryTime=1001)
 
         d = downloader.ResultSetDownloadHandler(settings, result_link)
-        d.run()
+        with self.assertRaises(requests.exceptions.HTTPError) as context:
+            d.run()
+        self.assertTrue('404' in str(context.exception))
 
-        assert not d.is_file_downloaded_successfully
-        assert d.is_download_finished.is_set()
-
-    @patch('requests.Session',
-           return_value=MagicMock(get=MagicMock(return_value=MagicMock(ok=True, content=b"1234567890" * 9))))
-    @patch('time.time', return_value=1000)
-    def test_run_uncompressed_data_length_incorrect(self, mock_time, mock_session):
-        settings = Mock(link_expiry_buffer_secs=0, download_timeout=0, use_proxy=False, is_lz4_compressed=False)
-        result_link = Mock(bytesNum=100, expiryTime=1001)
-
-        d = downloader.ResultSetDownloadHandler(settings, result_link)
-        d.run()
-
-        assert not d.is_file_downloaded_successfully
-        assert d.is_download_finished.is_set()
-
-    @patch('requests.Session', return_value=MagicMock(get=MagicMock(return_value=MagicMock(ok=True))))
-    @patch('time.time', return_value=1000)
-    def test_run_compressed_data_length_incorrect(self, mock_time, mock_session):
-        settings = Mock(link_expiry_buffer_secs=0, download_timeout=0, use_proxy=False)
-        settings.is_lz4_compressed = True
-        result_link = Mock(bytesNum=100, expiryTime=1001)
-        mock_session.return_value.get.return_value.content = \
-            b'\x04"M\x18h@Z\x00\x00\x00\x00\x00\x00\x00\xec\x14\x00\x00\x00\xaf1234567890\n\x008P67890\x00\x00\x00\x00'
-
-        d = downloader.ResultSetDownloadHandler(settings, result_link)
-        d.run()
-
-        assert not d.is_file_downloaded_successfully
-        assert d.is_download_finished.is_set()
-
-    @patch('requests.Session',
-           return_value=MagicMock(get=MagicMock(return_value=MagicMock(ok=True, content=b"1234567890" * 10))))
+    @patch('requests.Session', return_value=MagicMock(get=MagicMock(return_value=None)))
     @patch('time.time', return_value=1000)
     def test_run_uncompressed_successful(self, mock_time, mock_session):
+        file_bytes = b"1234567890" * 10
+        mock_session.return_value.get.return_value = create_response(status_code=200, _content=file_bytes)
+
         settings = Mock(link_expiry_buffer_secs=0, download_timeout=0, use_proxy=False)
         settings.is_lz4_compressed = False
         result_link = Mock(bytesNum=100, expiryTime=1001)
 
         d = downloader.ResultSetDownloadHandler(settings, result_link)
-        d.run()
+        file = d.run()
 
-        assert d.result_file == b"1234567890" * 10
-        assert d.is_file_downloaded_successfully
-        assert d.is_download_finished.is_set()
+        assert file.file_bytes == b"1234567890" * 10
 
     @patch('requests.Session', return_value=MagicMock(get=MagicMock(return_value=MagicMock(ok=True))))
     @patch('time.time', return_value=1000)
     def test_run_compressed_successful(self, mock_time, mock_session):
+        file_bytes = b"1234567890" * 10
+        compressed_bytes = b'\x04"M\x18h@d\x00\x00\x00\x00\x00\x00\x00#\x14\x00\x00\x00\xaf1234567890\n\x00BP67890\x00\x00\x00\x00'
+        mock_session.return_value.get.return_value = create_response(status_code=200, _content=compressed_bytes)
+
         settings = Mock(link_expiry_buffer_secs=0, download_timeout=0, use_proxy=False)
         settings.is_lz4_compressed = True
         result_link = Mock(bytesNum=100, expiryTime=1001)
-        mock_session.return_value.get.return_value.content = \
-            b'\x04"M\x18h@d\x00\x00\x00\x00\x00\x00\x00#\x14\x00\x00\x00\xaf1234567890\n\x00BP67890\x00\x00\x00\x00'
 
         d = downloader.ResultSetDownloadHandler(settings, result_link)
-        d.run()
+        file = d.run()
 
-        assert d.result_file == b"1234567890" * 10
-        assert d.is_file_downloaded_successfully
-        assert d.is_download_finished.is_set()
+        assert file.file_bytes == b"1234567890" * 10
 
     @patch('requests.Session.get', side_effect=ConnectionError('foo'))
     @patch('time.time', return_value=1000)
@@ -115,10 +102,8 @@ class DownloaderTests(unittest.TestCase):
             b'\x04"M\x18h@d\x00\x00\x00\x00\x00\x00\x00#\x14\x00\x00\x00\xaf1234567890\n\x00BP67890\x00\x00\x00\x00'
 
         d = downloader.ResultSetDownloadHandler(settings, result_link)
-        d.run()
-
-        assert not d.is_file_downloaded_successfully
-        assert d.is_download_finished.is_set()
+        with self.assertRaises(ConnectionError):
+            d.run()
 
     @patch('requests.Session.get', side_effect=TimeoutError('foo'))
     @patch('time.time', return_value=1000)
@@ -129,27 +114,5 @@ class DownloaderTests(unittest.TestCase):
             b'\x04"M\x18h@d\x00\x00\x00\x00\x00\x00\x00#\x14\x00\x00\x00\xaf1234567890\n\x00BP67890\x00\x00\x00\x00'
 
         d = downloader.ResultSetDownloadHandler(settings, result_link)
-        d.run()
-
-        assert not d.is_file_downloaded_successfully
-        assert d.is_download_finished.is_set()
-
-    @patch("threading.Event.wait", return_value=True)
-    def test_is_file_download_successful_has_finished(self, mock_wait):
-        for timeout in [0, 1]:
-            with self.subTest(timeout=timeout):
-                settings = Mock(download_timeout=timeout)
-                result_link = Mock()
-                handler = downloader.ResultSetDownloadHandler(settings, result_link)
-
-                status = handler.is_file_download_successful()
-                assert status == handler.is_file_downloaded_successfully
-
-    def test_is_file_download_successful_times_outs(self):
-        settings = Mock(download_timeout=1)
-        result_link = Mock()
-        handler = downloader.ResultSetDownloadHandler(settings, result_link)
-
-        status = handler.is_file_download_successful()
-        assert not status
-        assert handler.is_download_timedout
+        with self.assertRaises(TimeoutError):
+            d.run()


### PR DESCRIPTION
[PECO-1751]

This PR is an attempt to fix various CloudFetch-related issues (no data returned, duplicated rows returned, also maybe some performance and memory issues).

Replaces databricks/databricks-sql-python#362

#### The problem

In current implementation, all the links from a single TRowSet are added to a concurrent thrrad pool. The pool downloads them in a random order (all the tasks have the same priority and as a result - same chance to be executed first). To maintain the order of results, `startRowOffset`/`rowCount` fields from each CloudFetch link are used: library keeps track of the current row number, and use it to pick the right CloudFetch link (looking for the file where the current row is within [startRowOffset; startRowOffset + rowCount]).

This solution has several caveats. First of all, data can be fetched only from beginning to the end. With a concurrent thread pool, you never know which file will be downloaded first. In the worst case, while the user is waiting for the very first file, the library may download all the other ones and keep them in memory because the user may need them in future. This increases the latency (on average it will be okay, but we have no control over it), and also memory consumption.
Another problem with this approach is that if any of the files cannot be downloaded (even after retries) - there is no need to download the remaining files, the user won’t be able to process them anyway. But because files are downloaded in arbitrary order - nobody knows how many files will be downloaded before the user reaches the failed one.

Also, instead of utilizing the power of Futures, a custom synchronization and error handling is implemented - which may be a cause of synchronization issues. Additionally, retries are implemented outside of the download task, so when the task fails - outer code has to reschedule it, which is also a great source of sporadic errors.

#### The solution

This PR changes CloudFetch downloader to use a queue. Downloader keeps a list of pending links (not scheduled), and current tasks. Number of tasks is limited, so new files are scheduled only when previous task is completed and extracted from queue. As user requests next files, downloader will pick the first task from the queue, and schedule the new one to run in background - to keep the queue full. Then, downloader will wait for the task it picked from the queue, and then return it to user. Tasks are still running in in parallel in background. Also, each task itself is reponsible for handling errors (e.g. retry failed downloads), so when task completes - it is either eventually successfull, or failed after all possible retries. 

With this approach, the proper order of files is automatically assured. All errors are either handled in downloader or propagated to user. If some file cannot be downloaded due to error - library will not download the remaining ones (like it did previously). Utilizing Futures solves all possible issues with threads synchronization. Because new files are downloaded only when user consumes previous ones - library will not keep the whole dataset in memory.


[PECO-1751]: https://databricks.atlassian.net/browse/PECO-1751?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ