### PR TITLE
Fix pandas 2.2.2 support

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1202,4 +1202,4 @@ sqlalchemy = ["sqlalchemy"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8.0"
-content-hash = "f99292898ce01a04566c5deaea9b46646881bf816d8d755e89446c2e8b8a616e"
+content-hash = "31066a85f646d0009d6fe9ffc833a64fcb4b6923c2e7f2652e7aa8540acba298"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ include = ["CHANGELOG.md"]
 python = "^3.8.0"
 thrift = ">=0.16.0,<0.21.0"
 pandas = [
-    { version = ">=1.2.5,<2.2.0", python = ">=3.8" }
+    { version = ">=1.2.5,<2.3.0", python = ">=3.8" }
 ]
 pyarrow = ">=14.0.1,<17"
 

--- a/src/databricks/sql/client.py
+++ b/src/databricks/sql/client.py
@@ -1164,7 +1164,7 @@ class ResultSet:
             timestamp_as_object=True,
         )
 
-        res = df.to_numpy(na_value=None)
+        res = df.to_numpy(na_value=None, dtype='object')
         return [ResultRow(*v) for v in res]
 
     @property

--- a/src/databricks/sql/client.py
+++ b/src/databricks/sql/client.py
@@ -1164,7 +1164,7 @@ class ResultSet:
             timestamp_as_object=True,
         )
 
-        res = df.to_numpy(na_value=None, dtype='object')
+        res = df.to_numpy(na_value=None, dtype="object")
         return [ResultRow(*v) for v in res]
 
     @property


### PR DESCRIPTION
Fix pandas 2.2.2 support

https://pandas.pydata.org/docs/dev/whatsnew/v2.2.0.html#to-numpy-for-numpy-nullable-and-arrow-types-converts-to-suitable-numpy-dtype

Closes #342 