### PR TITLE
[PECO-1857] Use SSL options with HTTPS connection pool

### DIFF
--- a/src/databricks/sql/auth/thrift_http_client.py
+++ b/src/databricks/sql/auth/thrift_http_client.py
@@ -26,9 +26,6 @@ class THttpClient(thrift.transport.THttpClient.THttpClient):
         uri_or_host,
         port=None,
         path=None,
-        cafile=None,
-        cert_file=None,
-        key_file=None,
         ssl_options: SSLOptions = None,
         max_connections: int = 1,
         retry_policy: Union[DatabricksRetryPolicy, int] = 0,
@@ -51,14 +48,10 @@ class THttpClient(thrift.transport.THttpClient.THttpClient):
             self.scheme = parsed.scheme
             assert self.scheme in ("http", "https")
             if self.scheme == "https":
-                self.certfile = cert_file
-                self.keyfile = key_file
-                # TODO: Seems this context is never used anywhere - need to double-check
-                self.context = (
-                    ssl.create_default_context(cafile=cafile)
-                    if (cafile and not ssl_options)
-                    else ssl_options.create_ssl_context()
-                )
+                # TODO: Not sure if those options are used anywhere - need to double-check
+                self.certfile = self._ssl_options.tls_client_cert_file
+                self.keyfile = self._ssl_options.tls_client_cert_key_file
+                self.context = self._ssl_options.create_ssl_context()
             self.port = parsed.port
             self.host = parsed.hostname
             self.path = parsed.path

--- a/src/databricks/sql/auth/thrift_http_client.py
+++ b/src/databricks/sql/auth/thrift_http_client.py
@@ -115,9 +115,9 @@ class THttpClient(thrift.transport.THttpClient.THttpClient):
             pool_class = HTTPSConnectionPool
             _pool_kwargs.update(
                 {
-                    "cert_reqs": ssl.CERT_NONE
+                    "cert_reqs": ssl.CERT_REQUIRED
                     if self._ssl_options.tls_verify
-                    else ssl.CERT_REQUIRED,
+                    else ssl.CERT_NONE,
                     "ca_certs": self._ssl_options.tls_trusted_ca_file,
                     "cert_file": self._ssl_options.tls_client_cert_file,
                     "key_file": self._ssl_options.tls_client_cert_key_file,

--- a/src/databricks/sql/auth/thrift_http_client.py
+++ b/src/databricks/sql/auth/thrift_http_client.py
@@ -1,7 +1,7 @@
 import base64
 import logging
 import urllib.parse
-from typing import Dict, Union
+from typing import Dict, Union, Optional
 
 import six
 import thrift
@@ -26,7 +26,7 @@ class THttpClient(thrift.transport.THttpClient.THttpClient):
         uri_or_host,
         port=None,
         path=None,
-        ssl_options: SSLOptions = None,
+        ssl_options: Optional[SSLOptions] = None,
         max_connections: int = 1,
         retry_policy: Union[DatabricksRetryPolicy, int] = 0,
     ):
@@ -48,10 +48,11 @@ class THttpClient(thrift.transport.THttpClient.THttpClient):
             self.scheme = parsed.scheme
             assert self.scheme in ("http", "https")
             if self.scheme == "https":
-                # TODO: Not sure if those options are used anywhere - need to double-check
-                self.certfile = self._ssl_options.tls_client_cert_file
-                self.keyfile = self._ssl_options.tls_client_cert_key_file
-                self.context = self._ssl_options.create_ssl_context()
+                if self._ssl_options is not None:
+                    # TODO: Not sure if those options are used anywhere - need to double-check
+                    self.certfile = self._ssl_options.tls_client_cert_file
+                    self.keyfile = self._ssl_options.tls_client_cert_key_file
+                    self.context = self._ssl_options.create_ssl_context()
             self.port = parsed.port
             self.host = parsed.hostname
             self.path = parsed.path

--- a/src/databricks/sql/auth/thrift_http_client.py
+++ b/src/databricks/sql/auth/thrift_http_client.py
@@ -14,7 +14,7 @@ from io import BytesIO
 from urllib3 import HTTPConnectionPool, HTTPSConnectionPool, ProxyManager
 from urllib3.util import make_headers
 from databricks.sql.auth.retry import CommandType, DatabricksRetryPolicy
-from databricks.sql.utils import SSLOptions
+from databricks.sql.types import SSLOptions
 
 logger = logging.getLogger(__name__)
 

--- a/src/databricks/sql/client.py
+++ b/src/databricks/sql/client.py
@@ -22,6 +22,7 @@ from databricks.sql.utils import (
     ParamEscaper,
     inject_parameters,
     transform_paramstyle,
+    SSLOptions,
 )
 from databricks.sql.parameters.native import (
     DbsqlParameterBase,
@@ -178,8 +179,9 @@ class Connection:
         # _tls_trusted_ca_file
         #   Set to the path of the file containing trusted CA certificates for server certificate
         #   verification. If not provide, uses system truststore.
-        # _tls_client_cert_file, _tls_client_cert_key_file
+        # _tls_client_cert_file, _tls_client_cert_key_file, _tls_client_cert_key_password
         #   Set client SSL certificate.
+        #   See https://docs.python.org/3/library/ssl.html#ssl.SSLContext.load_cert_chain
         # _retry_stop_after_attempts_count
         #  The maximum number of attempts during a request retry sequence (defaults to 24)
         # _socket_timeout
@@ -220,12 +222,25 @@ class Connection:
 
         base_headers = [("User-Agent", useragent_header)]
 
+        self._ssl_options = SSLOptions(
+            # Double negation is generally a bad thing, but we have to keep backward compatibility
+            tls_verify=not kwargs.get(
+                "_tls_no_verify", False
+            ),  # by default - verify cert and host
+            tls_verify_hostname=kwargs.get("_tls_verify_hostname", True),
+            tls_trusted_ca_file=kwargs.get("_tls_trusted_ca_file"),
+            tls_client_cert_file=kwargs.get("_tls_client_cert_file"),
+            tls_client_cert_key_file=kwargs.get("_tls_client_cert_key_file"),
+            tls_client_cert_key_password=kwargs.get("_tls_client_cert_key_password"),
+        )
+
         self.thrift_backend = ThriftBackend(
             self.host,
             self.port,
             http_path,
             (http_headers or []) + base_headers,
             auth_provider,
+            ssl_options=self._ssl_options,
             _use_arrow_native_complex_types=_use_arrow_native_complex_types,
             **kwargs,
         )

--- a/src/databricks/sql/client.py
+++ b/src/databricks/sql/client.py
@@ -22,7 +22,6 @@ from databricks.sql.utils import (
     ParamEscaper,
     inject_parameters,
     transform_paramstyle,
-    SSLOptions,
 )
 from databricks.sql.parameters.native import (
     DbsqlParameterBase,
@@ -36,7 +35,7 @@ from databricks.sql.parameters.native import (
 )
 
 
-from databricks.sql.types import Row
+from databricks.sql.types import Row, SSLOptions
 from databricks.sql.auth.auth import get_python_sql_connector_auth_provider
 from databricks.sql.experimental.oauth_persistence import OAuthPersistence
 

--- a/src/databricks/sql/cloudfetch/download_manager.py
+++ b/src/databricks/sql/cloudfetch/download_manager.py
@@ -1,6 +1,5 @@
 import logging
 
-from ssl import SSLContext
 from concurrent.futures import ThreadPoolExecutor, Future
 from typing import List, Union
 
@@ -9,7 +8,7 @@ from databricks.sql.cloudfetch.downloader import (
     DownloadableResultSettings,
     DownloadedFile,
 )
-from databricks.sql.utils import SSLOptions
+from databricks.sql.types import SSLOptions
 
 from databricks.sql.thrift_api.TCLIService.ttypes import TSparkArrowResultLink
 

--- a/src/databricks/sql/cloudfetch/download_manager.py
+++ b/src/databricks/sql/cloudfetch/download_manager.py
@@ -9,6 +9,8 @@ from databricks.sql.cloudfetch.downloader import (
     DownloadableResultSettings,
     DownloadedFile,
 )
+from databricks.sql.utils import SSLOptions
+
 from databricks.sql.thrift_api.TCLIService.ttypes import TSparkArrowResultLink
 
 logger = logging.getLogger(__name__)
@@ -20,7 +22,7 @@ class ResultFileDownloadManager:
         links: List[TSparkArrowResultLink],
         max_download_threads: int,
         lz4_compressed: bool,
-        ssl_context: SSLContext,
+        ssl_options: SSLOptions,
     ):
         self._pending_links: List[TSparkArrowResultLink] = []
         for link in links:
@@ -38,7 +40,7 @@ class ResultFileDownloadManager:
         self._thread_pool = ThreadPoolExecutor(max_workers=self._max_download_threads)
 
         self._downloadable_result_settings = DownloadableResultSettings(lz4_compressed)
-        self._ssl_context = ssl_context
+        self._ssl_options = ssl_options
 
     def get_next_downloaded_file(
         self, next_row_offset: int
@@ -95,7 +97,7 @@ class ResultFileDownloadManager:
             handler = ResultSetDownloadHandler(
                 settings=self._downloadable_result_settings,
                 link=link,
-                ssl_context=self._ssl_context,
+                ssl_options=self._ssl_options,
             )
             task = self._thread_pool.submit(handler.run)
             self._download_tasks.append(task)

--- a/src/databricks/sql/cloudfetch/downloader.py
+++ b/src/databricks/sql/cloudfetch/downloader.py
@@ -3,13 +3,12 @@ from dataclasses import dataclass
 
 import requests
 from requests.adapters import HTTPAdapter, Retry
-from ssl import SSLContext, CERT_NONE
 import lz4.frame
 import time
 
 from databricks.sql.thrift_api.TCLIService.ttypes import TSparkArrowResultLink
-
 from databricks.sql.exc import Error
+from databricks.sql.utils import SSLOptions
 
 logger = logging.getLogger(__name__)
 
@@ -66,11 +65,11 @@ class ResultSetDownloadHandler:
         self,
         settings: DownloadableResultSettings,
         link: TSparkArrowResultLink,
-        ssl_context: SSLContext,
+        ssl_options: SSLOptions,
     ):
         self.settings = settings
         self.link = link
-        self._ssl_context = ssl_context
+        self._ssl_options = ssl_options
 
     def run(self) -> DownloadedFile:
         """
@@ -95,14 +94,13 @@ class ResultSetDownloadHandler:
         session.mount("http://", HTTPAdapter(max_retries=retryPolicy))
         session.mount("https://", HTTPAdapter(max_retries=retryPolicy))
 
-        ssl_verify = self._ssl_context.verify_mode != CERT_NONE
-
         try:
             # Get the file via HTTP request
             response = session.get(
                 self.link.fileLink,
                 timeout=self.settings.download_timeout,
-                verify=ssl_verify,
+                verify=self._ssl_options.tls_verify,
+                # TODO: Pass cert from `self._ssl_options`
             )
             response.raise_for_status()
 

--- a/src/databricks/sql/cloudfetch/downloader.py
+++ b/src/databricks/sql/cloudfetch/downloader.py
@@ -8,7 +8,7 @@ import time
 
 from databricks.sql.thrift_api.TCLIService.ttypes import TSparkArrowResultLink
 from databricks.sql.exc import Error
-from databricks.sql.utils import SSLOptions
+from databricks.sql.types import SSLOptions
 
 logger = logging.getLogger(__name__)
 

--- a/src/databricks/sql/thrift_backend.py
+++ b/src/databricks/sql/thrift_backend.py
@@ -5,7 +5,6 @@ import math
 import time
 import uuid
 import threading
-from ssl import CERT_NONE, CERT_REQUIRED, create_default_context
 from typing import List, Union
 
 import pyarrow
@@ -35,8 +34,8 @@ from databricks.sql.utils import (
     convert_arrow_based_set_to_arrow_table,
     convert_decimals_in_arrow_table,
     convert_column_based_set_to_arrow_table,
-    SSLOptions,
 )
+from databricks.sql.types import SSLOptions
 
 logger = logging.getLogger(__name__)
 

--- a/src/databricks/sql/types.py
+++ b/src/databricks/sql/types.py
@@ -19,6 +19,54 @@
 from typing import Any, Dict, List, Optional, Tuple, Union, TypeVar
 import datetime
 import decimal
+from ssl import SSLContext, CERT_NONE, CERT_REQUIRED, create_default_context
+
+
+class SSLOptions:
+    tls_verify: bool
+    tls_verify_hostname: bool
+    tls_trusted_ca_file: Optional[str]
+    tls_client_cert_file: Optional[str]
+    tls_client_cert_key_file: Optional[str]
+    tls_client_cert_key_password: Optional[str]
+
+    def __init__(
+        self,
+        tls_verify: Optional[bool] = True,
+        tls_verify_hostname: Optional[bool] = True,
+        tls_trusted_ca_file: Optional[str] = None,
+        tls_client_cert_file: Optional[str] = None,
+        tls_client_cert_key_file: Optional[str] = None,
+        tls_client_cert_key_password: Optional[str] = None,
+    ):
+        self.tls_verify = tls_verify
+        self.tls_verify_hostname = tls_verify_hostname
+        self.tls_trusted_ca_file = tls_trusted_ca_file
+        self.tls_client_cert_file = tls_client_cert_file
+        self.tls_client_cert_key_file = tls_client_cert_key_file
+        self.tls_client_cert_key_password = tls_client_cert_key_password
+
+    def create_ssl_context(self) -> SSLContext:
+        ssl_context = create_default_context(cafile=self.tls_trusted_ca_file)
+
+        if self.tls_verify is False:
+            ssl_context.check_hostname = False
+            ssl_context.verify_mode = CERT_NONE
+        elif self.tls_verify_hostname is False:
+            ssl_context.check_hostname = False
+            ssl_context.verify_mode = CERT_REQUIRED
+        else:
+            ssl_context.check_hostname = True
+            ssl_context.verify_mode = CERT_REQUIRED
+
+        if self.tls_client_cert_file:
+            ssl_context.load_cert_chain(
+                certfile=self.tls_client_cert_file,
+                keyfile=self.tls_client_cert_key_file,
+                password=self.tls_client_cert_key_password,
+            )
+
+        return ssl_context
 
 
 class Row(tuple):

--- a/src/databricks/sql/types.py
+++ b/src/databricks/sql/types.py
@@ -32,8 +32,8 @@ class SSLOptions:
 
     def __init__(
         self,
-        tls_verify: Optional[bool] = True,
-        tls_verify_hostname: Optional[bool] = True,
+        tls_verify: bool = True,
+        tls_verify_hostname: bool = True,
         tls_trusted_ca_file: Optional[str] = None,
         tls_client_cert_file: Optional[str] = None,
         tls_client_cert_key_file: Optional[str] = None,

--- a/src/databricks/sql/utils.py
+++ b/src/databricks/sql/utils.py
@@ -9,7 +9,6 @@ from decimal import Decimal
 from enum import Enum
 from typing import Any, Dict, List, Optional, Union
 import re
-from ssl import SSLContext, CERT_NONE, CERT_REQUIRED, create_default_context
 
 import lz4.frame
 import pyarrow
@@ -21,6 +20,7 @@ from databricks.sql.thrift_api.TCLIService.ttypes import (
     TSparkArrowResultLink,
     TSparkRowSetType,
 )
+from databricks.sql.types import SSLOptions
 
 from databricks.sql.parameters.native import ParameterStructure, TDbsqlParameter
 
@@ -29,53 +29,6 @@ import logging
 BIT_MASKS = [1, 2, 4, 8, 16, 32, 64, 128]
 
 logger = logging.getLogger(__name__)
-
-
-class SSLOptions:
-    tls_verify: bool
-    tls_verify_hostname: bool
-    tls_trusted_ca_file: Optional[str]
-    tls_client_cert_file: Optional[str]
-    tls_client_cert_key_file: Optional[str]
-    tls_client_cert_key_password: Optional[str]
-
-    def __init__(
-        self,
-        tls_verify: Optional[bool] = True,
-        tls_verify_hostname: Optional[bool] = True,
-        tls_trusted_ca_file: Optional[str] = None,
-        tls_client_cert_file: Optional[str] = None,
-        tls_client_cert_key_file: Optional[str] = None,
-        tls_client_cert_key_password: Optional[str] = None,
-    ):
-        self.tls_verify = tls_verify
-        self.tls_verify_hostname = tls_verify_hostname
-        self.tls_trusted_ca_file = tls_trusted_ca_file
-        self.tls_client_cert_file = tls_client_cert_file
-        self.tls_client_cert_key_file = tls_client_cert_key_file
-        self.tls_client_cert_key_password = tls_client_cert_key_password
-
-    def create_ssl_context(self) -> SSLContext:
-        ssl_context = create_default_context(cafile=self.tls_trusted_ca_file)
-
-        if self.tls_verify is False:
-            ssl_context.check_hostname = False
-            ssl_context.verify_mode = CERT_NONE
-        elif self.tls_verify_hostname is False:
-            ssl_context.check_hostname = False
-            ssl_context.verify_mode = CERT_REQUIRED
-        else:
-            ssl_context.check_hostname = True
-            ssl_context.verify_mode = CERT_REQUIRED
-
-        if self.tls_client_cert_file:
-            ssl_context.load_cert_chain(
-                certfile=self.tls_client_cert_file,
-                keyfile=self.tls_client_cert_key_file,
-                password=self.tls_client_cert_key_password,
-            )
-
-        return ssl_context
 
 
 class ResultSetQueue(ABC):

--- a/src/databricks/sql/utils.py
+++ b/src/databricks/sql/utils.py
@@ -9,7 +9,7 @@ from decimal import Decimal
 from enum import Enum
 from typing import Any, Dict, List, Optional, Union
 import re
-from ssl import SSLContext
+from ssl import SSLContext, CERT_NONE, CERT_REQUIRED, create_default_context
 
 import lz4.frame
 import pyarrow
@@ -24,11 +24,58 @@ from databricks.sql.thrift_api.TCLIService.ttypes import (
 
 from databricks.sql.parameters.native import ParameterStructure, TDbsqlParameter
 
-BIT_MASKS = [1, 2, 4, 8, 16, 32, 64, 128]
-
 import logging
 
+BIT_MASKS = [1, 2, 4, 8, 16, 32, 64, 128]
+
 logger = logging.getLogger(__name__)
+
+
+class SSLOptions:
+    tls_verify: bool
+    tls_verify_hostname: bool
+    tls_trusted_ca_file: Optional[str]
+    tls_client_cert_file: Optional[str]
+    tls_client_cert_key_file: Optional[str]
+    tls_client_cert_key_password: Optional[str]
+
+    def __init__(
+        self,
+        tls_verify: Optional[bool] = True,
+        tls_verify_hostname: Optional[bool] = True,
+        tls_trusted_ca_file: Optional[str] = None,
+        tls_client_cert_file: Optional[str] = None,
+        tls_client_cert_key_file: Optional[str] = None,
+        tls_client_cert_key_password: Optional[str] = None,
+    ):
+        self.tls_verify = tls_verify
+        self.tls_verify_hostname = tls_verify_hostname
+        self.tls_trusted_ca_file = tls_trusted_ca_file
+        self.tls_client_cert_file = tls_client_cert_file
+        self.tls_client_cert_key_file = tls_client_cert_key_file
+        self.tls_client_cert_key_password = tls_client_cert_key_password
+
+    def create_ssl_context(self) -> SSLContext:
+        ssl_context = create_default_context(cafile=self.tls_trusted_ca_file)
+
+        if self.tls_verify is False:
+            ssl_context.check_hostname = False
+            ssl_context.verify_mode = CERT_NONE
+        elif self.tls_verify_hostname is False:
+            ssl_context.check_hostname = False
+            ssl_context.verify_mode = CERT_REQUIRED
+        else:
+            ssl_context.check_hostname = True
+            ssl_context.verify_mode = CERT_REQUIRED
+
+        if self.tls_client_cert_file:
+            ssl_context.load_cert_chain(
+                certfile=self.tls_client_cert_file,
+                keyfile=self.tls_client_cert_key_file,
+                password=self.tls_client_cert_key_password,
+            )
+
+        return ssl_context
 
 
 class ResultSetQueue(ABC):
@@ -48,7 +95,7 @@ class ResultSetQueueFactory(ABC):
         t_row_set: TRowSet,
         arrow_schema_bytes: bytes,
         max_download_threads: int,
-        ssl_context: SSLContext,
+        ssl_options: SSLOptions,
         lz4_compressed: bool = True,
         description: Optional[List[List[Any]]] = None,
     ) -> ResultSetQueue:
@@ -62,7 +109,7 @@ class ResultSetQueueFactory(ABC):
             lz4_compressed (bool): Whether result data has been lz4 compressed.
             description (List[List[Any]]): Hive table schema description.
             max_download_threads (int): Maximum number of downloader thread pool threads.
-            ssl_context (SSLContext): SSLContext object for CloudFetchQueue
+            ssl_options (SSLOptions): SSLOptions object for CloudFetchQueue
 
         Returns:
             ResultSetQueue
@@ -91,7 +138,7 @@ class ResultSetQueueFactory(ABC):
                 lz4_compressed=lz4_compressed,
                 description=description,
                 max_download_threads=max_download_threads,
-                ssl_context=ssl_context,
+                ssl_options=ssl_options,
             )
         else:
             raise AssertionError("Row set type is not valid")
@@ -137,7 +184,7 @@ class CloudFetchQueue(ResultSetQueue):
         self,
         schema_bytes,
         max_download_threads: int,
-        ssl_context: SSLContext,
+        ssl_options: SSLOptions,
         start_row_offset: int = 0,
         result_links: Optional[List[TSparkArrowResultLink]] = None,
         lz4_compressed: bool = True,
@@ -160,7 +207,7 @@ class CloudFetchQueue(ResultSetQueue):
         self.result_links = result_links
         self.lz4_compressed = lz4_compressed
         self.description = description
-        self._ssl_context = ssl_context
+        self._ssl_options = ssl_options
 
         logger.debug(
             "Initialize CloudFetch loader, row set start offset: {}, file list:".format(
@@ -178,7 +225,7 @@ class CloudFetchQueue(ResultSetQueue):
             links=result_links or [],
             max_download_threads=self.max_download_threads,
             lz4_compressed=self.lz4_compressed,
-            ssl_context=self._ssl_context,
+            ssl_options=self._ssl_options,
         )
 
         self.table = self._create_next_table()

--- a/tests/unit/test_cloud_fetch_queue.py
+++ b/tests/unit/test_cloud_fetch_queue.py
@@ -1,10 +1,10 @@
 import pyarrow
 import unittest
 from unittest.mock import MagicMock, patch
-from ssl import create_default_context
 
 from databricks.sql.thrift_api.TCLIService.ttypes import TSparkArrowResultLink
 import databricks.sql.utils as utils
+from databricks.sql.types import SSLOptions
 
 class CloudFetchQueueSuite(unittest.TestCase):
 
@@ -51,7 +51,7 @@ class CloudFetchQueueSuite(unittest.TestCase):
             schema_bytes,
             result_links=result_links,
             max_download_threads=10,
-            ssl_context=create_default_context(),
+            ssl_options=SSLOptions(),
         )
 
         assert len(queue.download_manager._pending_links) == 10
@@ -65,7 +65,7 @@ class CloudFetchQueueSuite(unittest.TestCase):
             schema_bytes,
             result_links=result_links,
             max_download_threads=10,
-            ssl_context=create_default_context(),
+            ssl_options=SSLOptions(),
         )
 
         assert len(queue.download_manager._pending_links) == 0
@@ -78,7 +78,7 @@ class CloudFetchQueueSuite(unittest.TestCase):
             MagicMock(),
             result_links=[],
             max_download_threads=10,
-            ssl_context=create_default_context(),
+            ssl_options=SSLOptions(),
         )
 
         assert queue._create_next_table() is None
@@ -95,7 +95,7 @@ class CloudFetchQueueSuite(unittest.TestCase):
             result_links=[],
             description=description,
             max_download_threads=10,
-            ssl_context=create_default_context(),
+            ssl_options=SSLOptions(),
         )
         expected_result = self.make_arrow_table()
 
@@ -120,7 +120,7 @@ class CloudFetchQueueSuite(unittest.TestCase):
             result_links=[],
             description=description,
             max_download_threads=10,
-            ssl_context=create_default_context(),
+            ssl_options=SSLOptions(),
         )
         assert queue.table == self.make_arrow_table()
         assert queue.table.num_rows == 4
@@ -140,7 +140,7 @@ class CloudFetchQueueSuite(unittest.TestCase):
             result_links=[],
             description=description,
             max_download_threads=10,
-            ssl_context=create_default_context(),
+            ssl_options=SSLOptions(),
         )
         assert queue.table == self.make_arrow_table()
         assert queue.table.num_rows == 4
@@ -160,7 +160,7 @@ class CloudFetchQueueSuite(unittest.TestCase):
             result_links=[],
             description=description,
             max_download_threads=10,
-            ssl_context=create_default_context(),
+            ssl_options=SSLOptions(),
         )
         assert queue.table == self.make_arrow_table()
         assert queue.table.num_rows == 4
@@ -180,7 +180,7 @@ class CloudFetchQueueSuite(unittest.TestCase):
             result_links=[],
             description=description,
             max_download_threads=10,
-            ssl_context=create_default_context(),
+            ssl_options=SSLOptions(),
         )
         assert queue.table == self.make_arrow_table()
         assert queue.table.num_rows == 4
@@ -199,7 +199,7 @@ class CloudFetchQueueSuite(unittest.TestCase):
             result_links=[],
             description=description,
             max_download_threads=10,
-            ssl_context=create_default_context(),
+            ssl_options=SSLOptions(),
         )
         assert queue.table is None
 
@@ -216,7 +216,7 @@ class CloudFetchQueueSuite(unittest.TestCase):
             result_links=[],
             description=description,
             max_download_threads=10,
-            ssl_context=create_default_context(),
+            ssl_options=SSLOptions(),
         )
         assert queue.table == self.make_arrow_table()
         assert queue.table.num_rows == 4
@@ -235,7 +235,7 @@ class CloudFetchQueueSuite(unittest.TestCase):
             result_links=[],
             description=description,
             max_download_threads=10,
-            ssl_context=create_default_context(),
+            ssl_options=SSLOptions(),
         )
         assert queue.table == self.make_arrow_table()
         assert queue.table.num_rows == 4
@@ -254,7 +254,7 @@ class CloudFetchQueueSuite(unittest.TestCase):
             result_links=[],
             description=description,
             max_download_threads=10,
-            ssl_context=create_default_context(),
+            ssl_options=SSLOptions(),
         )
         assert queue.table == self.make_arrow_table()
         assert queue.table.num_rows == 4
@@ -273,7 +273,7 @@ class CloudFetchQueueSuite(unittest.TestCase):
             result_links=[],
             description=description,
             max_download_threads=10,
-            ssl_context=create_default_context(),
+            ssl_options=SSLOptions(),
         )
         assert queue.table == self.make_arrow_table()
         assert queue.table.num_rows == 4
@@ -293,7 +293,7 @@ class CloudFetchQueueSuite(unittest.TestCase):
             result_links=[],
             description=description,
             max_download_threads=10,
-            ssl_context=create_default_context(),
+            ssl_options=SSLOptions(),
         )
         assert queue.table is None
 

--- a/tests/unit/test_download_manager.py
+++ b/tests/unit/test_download_manager.py
@@ -1,9 +1,8 @@
 import unittest
 from unittest.mock import patch, MagicMock
 
-from ssl import create_default_context
-
 import databricks.sql.cloudfetch.download_manager as download_manager
+from databricks.sql.types import SSLOptions
 from databricks.sql.thrift_api.TCLIService.ttypes import TSparkArrowResultLink
 
 
@@ -17,7 +16,7 @@ class DownloadManagerTests(unittest.TestCase):
             links,
             max_download_threads,
             lz4_compressed,
-            ssl_context=create_default_context(),
+            ssl_options=SSLOptions(),
         )
 
     def create_result_link(

--- a/tests/unit/test_downloader.py
+++ b/tests/unit/test_downloader.py
@@ -2,10 +2,10 @@ import unittest
 from unittest.mock import Mock, patch, MagicMock
 
 import requests
-from ssl import create_default_context
 
 import databricks.sql.cloudfetch.downloader as downloader
 from databricks.sql.exc import Error
+from databricks.sql.types import SSLOptions
 
 
 def create_response(**kwargs) -> requests.Response:
@@ -26,7 +26,7 @@ class DownloaderTests(unittest.TestCase):
         result_link = Mock()
         # Already expired
         result_link.expiryTime = 999
-        d = downloader.ResultSetDownloadHandler(settings, result_link, ssl_context=create_default_context())
+        d = downloader.ResultSetDownloadHandler(settings, result_link, ssl_options=SSLOptions())
 
         with self.assertRaises(Error) as context:
             d.run()
@@ -40,7 +40,7 @@ class DownloaderTests(unittest.TestCase):
         result_link = Mock()
         # Within the expiry buffer time
         result_link.expiryTime = 1004
-        d = downloader.ResultSetDownloadHandler(settings, result_link, ssl_context=create_default_context())
+        d = downloader.ResultSetDownloadHandler(settings, result_link, ssl_options=SSLOptions())
 
         with self.assertRaises(Error) as context:
             d.run()
@@ -58,7 +58,7 @@ class DownloaderTests(unittest.TestCase):
         settings.use_proxy = False
         result_link = Mock(expiryTime=1001)
 
-        d = downloader.ResultSetDownloadHandler(settings, result_link, ssl_context=create_default_context())
+        d = downloader.ResultSetDownloadHandler(settings, result_link, ssl_options=SSLOptions())
         with self.assertRaises(requests.exceptions.HTTPError) as context:
             d.run()
         self.assertTrue('404' in str(context.exception))
@@ -73,7 +73,7 @@ class DownloaderTests(unittest.TestCase):
         settings.is_lz4_compressed = False
         result_link = Mock(bytesNum=100, expiryTime=1001)
 
-        d = downloader.ResultSetDownloadHandler(settings, result_link, ssl_context=create_default_context())
+        d = downloader.ResultSetDownloadHandler(settings, result_link, ssl_options=SSLOptions())
         file = d.run()
 
         assert file.file_bytes == b"1234567890" * 10
@@ -89,7 +89,7 @@ class DownloaderTests(unittest.TestCase):
         settings.is_lz4_compressed = True
         result_link = Mock(bytesNum=100, expiryTime=1001)
 
-        d = downloader.ResultSetDownloadHandler(settings, result_link, ssl_context=create_default_context())
+        d = downloader.ResultSetDownloadHandler(settings, result_link, ssl_options=SSLOptions())
         file = d.run()
 
         assert file.file_bytes == b"1234567890" * 10
@@ -102,7 +102,7 @@ class DownloaderTests(unittest.TestCase):
         mock_session.return_value.get.return_value.content = \
             b'\x04"M\x18h@d\x00\x00\x00\x00\x00\x00\x00#\x14\x00\x00\x00\xaf1234567890\n\x00BP67890\x00\x00\x00\x00'
 
-        d = downloader.ResultSetDownloadHandler(settings, result_link, ssl_context=create_default_context())
+        d = downloader.ResultSetDownloadHandler(settings, result_link, ssl_options=SSLOptions())
         with self.assertRaises(ConnectionError):
             d.run()
 
@@ -114,6 +114,6 @@ class DownloaderTests(unittest.TestCase):
         mock_session.return_value.get.return_value.content = \
             b'\x04"M\x18h@d\x00\x00\x00\x00\x00\x00\x00#\x14\x00\x00\x00\xaf1234567890\n\x00BP67890\x00\x00\x00\x00'
 
-        d = downloader.ResultSetDownloadHandler(settings, result_link, ssl_context=create_default_context())
+        d = downloader.ResultSetDownloadHandler(settings, result_link, ssl_options=SSLOptions())
         with self.assertRaises(TimeoutError):
             d.run()


### PR DESCRIPTION
This issue seems to be a regression after databricks/databricks-sql-python#131 

SSL options (`_tls_no_verify`, `_tls_trusted_ca_file`, `_tls_client_cert_file`, `_tls_client_cert_key_file`, `_tls_client_cert_key_password`) are not used for requests to Thrift backend: they are just not passed to connection pool