### PR TITLE
[PECO-1926] Create a non pyarrow flow to handle small results for the column set

### DIFF
--- a/src/databricks/sql/client.py
+++ b/src/databricks/sql/client.py
@@ -1227,13 +1227,17 @@ class ResultSet:
 
         return results
 
-        def merge_columnar(self, result1, result2):
-            """
-            Function to merge / combining the columnar results into a single result
-            :param result1:
-            :param result2:
-            :return:
-            """
+    def merge_columnar(self, result1, result2):
+        """
+        Function to merge / combining the columnar results into a single result
+        :param result1:
+        :param result2:
+        :return:
+        """
+
+        if len(result1) != len(result2):
+            raise ValueError("The number of columns in both results must be the same")
+
         merged_result = [result1[i] + result2[i] for i in range(len(result1))]
         return merged_result
 

--- a/src/databricks/sql/client.py
+++ b/src/databricks/sql/client.py
@@ -1,7 +1,10 @@
 from typing import Dict, Tuple, List, Optional, Any, Union, Sequence
 
 import pandas
-import pyarrow
+try:
+    import pyarrow
+except ImportError:
+    pyarrow = None
 import requests
 import json
 import os
@@ -22,6 +25,8 @@ from databricks.sql.utils import (
     ParamEscaper,
     inject_parameters,
     transform_paramstyle,
+    ArrowQueue,
+    ColumnQueue
 )
 from databricks.sql.parameters.native import (
     DbsqlParameterBase,
@@ -991,14 +996,14 @@ class Cursor:
         else:
             raise Error("There is no active result set")
 
-    def fetchall_arrow(self) -> pyarrow.Table:
+    def fetchall_arrow(self) -> "pyarrow.Table":
         self._check_not_closed()
         if self.active_result_set:
             return self.active_result_set.fetchall_arrow()
         else:
             raise Error("There is no active result set")
 
-    def fetchmany_arrow(self, size) -> pyarrow.Table:
+    def fetchmany_arrow(self, size) -> "pyarrow.Table":
         self._check_not_closed()
         if self.active_result_set:
             return self.active_result_set.fetchmany_arrow(size)
@@ -1143,6 +1148,18 @@ class ResultSet:
         self.results = results
         self.has_more_rows = has_more_rows
 
+    def _convert_columnar_table(self, table):
+        column_names = [c[0] for c in self.description]
+        ResultRow = Row(*column_names)
+        result = []
+        for row_index in range(len(table[0])):
+            curr_row = []
+            for col_index in range(len(table)):
+                curr_row.append(table[col_index][row_index])
+            result.append(ResultRow(*curr_row))
+
+        return result
+
     def _convert_arrow_table(self, table):
         column_names = [c[0] for c in self.description]
         ResultRow = Row(*column_names)
@@ -1185,7 +1202,7 @@ class ResultSet:
     def rownumber(self):
         return self._next_row_index
 
-    def fetchmany_arrow(self, size: int) -> pyarrow.Table:
+    def fetchmany_arrow(self, size: int) -> "pyarrow.Table":
         """
         Fetch the next set of rows of a query result, returning a PyArrow table.
 
@@ -1210,7 +1227,42 @@ class ResultSet:
 
         return results
 
-    def fetchall_arrow(self) -> pyarrow.Table:
+        def merge_columnar(self, result1, result2):
+            """
+            Function to merge / combining the columnar results into a single result
+            :param result1:
+            :param result2:
+            :return:
+            """
+        merged_result = [result1[i] + result2[i] for i in range(len(result1))]
+        return merged_result
+
+    def fetchmany_columnar(self, size: int):
+        """
+        Fetch the next set of rows of a query result, returning a Columnar Table.
+        An empty sequence is returned when no more rows are available.
+        """
+        if size < 0:
+            raise ValueError("size argument for fetchmany is %s but must be >= 0", size)
+
+        results = self.results.next_n_rows(size)
+        n_remaining_rows = size - len(results[0])
+        self._next_row_index += len(results[0])
+
+        while (
+                n_remaining_rows > 0
+                and not self.has_been_closed_server_side
+                and self.has_more_rows
+        ):
+            self._fill_results_buffer()
+            partial_results = self.results.next_n_rows(n_remaining_rows)
+            results = self.merge_columnar(results, partial_results)
+            n_remaining_rows -= len(partial_results[0])
+            self._next_row_index += len(partial_results[0])
+
+        return results
+
+    def fetchall_arrow(self) -> "pyarrow.Table":
         """Fetch all (remaining) rows of a query result, returning them as a PyArrow table."""
         results = self.results.remaining_rows()
         self._next_row_index += results.num_rows
@@ -1223,12 +1275,30 @@ class ResultSet:
 
         return results
 
+    def fetchall_columnar(self):
+        """Fetch all (remaining) rows of a query result, returning them as a Columnar table."""
+        results = self.results.remaining_rows()
+        self._next_row_index += len(results[0])
+
+        while not self.has_been_closed_server_side and self.has_more_rows:
+            self._fill_results_buffer()
+            partial_results = self.results.remaining_rows()
+            results = self.merge_columnar(results, partial_results)
+            self._next_row_index += len(partial_results[0])
+
+        return results
+
     def fetchone(self) -> Optional[Row]:
         """
         Fetch the next row of a query result set, returning a single sequence,
         or None when no more data is available.
         """
-        res = self._convert_arrow_table(self.fetchmany_arrow(1))
+
+        if isinstance(self.results, ColumnQueue):
+            res = self._convert_columnar_table(self.fetchmany_columnar(1))
+        else:
+            res = self._convert_arrow_table(self.fetchmany_arrow(1))
+
         if len(res) > 0:
             return res[0]
         else:
@@ -1238,7 +1308,10 @@ class ResultSet:
         """
         Fetch all (remaining) rows of a query result, returning them as a list of rows.
         """
-        return self._convert_arrow_table(self.fetchall_arrow())
+        if isinstance(self.results, ColumnQueue):
+            return self._convert_columnar_table(self.fetchall_columnar())
+        else:
+            return self._convert_arrow_table(self.fetchall_arrow())
 
     def fetchmany(self, size: int) -> List[Row]:
         """
@@ -1246,7 +1319,10 @@ class ResultSet:
 
         An empty sequence is returned when no more rows are available.
         """
-        return self._convert_arrow_table(self.fetchmany_arrow(size))
+        if isinstance(self.results, ColumnQueue):
+            return self._convert_columnar_table(self.fetchmany_columnar(size))
+        else:
+            return self._convert_arrow_table(self.fetchmany_arrow(size))
 
     def close(self) -> None:
         """

--- a/src/databricks/sql/thrift_backend.py
+++ b/src/databricks/sql/thrift_backend.py
@@ -625,11 +625,6 @@ class ThriftBackend:
     @staticmethod
     def _hive_schema_to_arrow_schema(t_table_schema):
 
-        if pyarrow is None:
-            raise ImportError(
-                "pyarrow is required to convert Hive schema to Arrow schema"
-            )
-
         def map_type(t_type_entry):
             if t_type_entry.primitiveEntry:
                 return {

--- a/src/databricks/sql/thrift_backend.py
+++ b/src/databricks/sql/thrift_backend.py
@@ -7,7 +7,10 @@ import uuid
 import threading
 from typing import List, Union
 
-import pyarrow
+try:
+    import pyarrow
+except ImportError:
+    pyarrow = None
 import thrift.transport.THttpClient
 import thrift.protocol.TBinaryProtocol
 import thrift.transport.TSocket
@@ -621,6 +624,12 @@ class ThriftBackend:
 
     @staticmethod
     def _hive_schema_to_arrow_schema(t_table_schema):
+
+        if pyarrow is None:
+            raise ImportError(
+                "pyarrow is required to convert Hive schema to Arrow schema"
+            )
+
         def map_type(t_type_entry):
             if t_type_entry.primitiveEntry:
                 return {
@@ -726,12 +735,17 @@ class ThriftBackend:
         description = self._hive_schema_to_description(
             t_result_set_metadata_resp.schema
         )
-        schema_bytes = (
-            t_result_set_metadata_resp.arrowSchema
-            or self._hive_schema_to_arrow_schema(t_result_set_metadata_resp.schema)
-            .serialize()
-            .to_pybytes()
-        )
+
+        if pyarrow:
+            schema_bytes = (
+                    t_result_set_metadata_resp.arrowSchema
+                    or self._hive_schema_to_arrow_schema(t_result_set_metadata_resp.schema)
+                    .serialize()
+                    .to_pybytes()
+            )
+        else:
+            schema_bytes = None
+
         lz4_compressed = t_result_set_metadata_resp.lz4Compressed
         is_staging_operation = t_result_set_metadata_resp.isStagingOperation
         if direct_results and direct_results.resultSet:
@@ -827,7 +841,7 @@ class ThriftBackend:
             getDirectResults=ttypes.TSparkGetDirectResults(
                 maxRows=max_rows, maxBytes=max_bytes
             ),
-            canReadArrowResult=True,
+            canReadArrowResult=True if pyarrow else False,
             canDecompressLZ4Result=lz4_compression,
             canDownloadResult=use_cloud_fetch,
             confOverlay={

--- a/src/databricks/sql/utils.py
+++ b/src/databricks/sql/utils.py
@@ -589,15 +589,17 @@ def convert_decimals_in_arrow_table(table, description) -> "pyarrow.Table":
 
 
 def convert_to_assigned_datatypes_in_column_table(column_table, description):
+
+    converted_column_table = []
     for i, col in enumerate(column_table):
         if description[i][1] == "decimal":
-            column_table[i] = tuple(v if v is None else Decimal(v) for v in col)
+            converted_column_table.append(tuple(v if v is None else Decimal(v) for v in col))
         elif description[i][1] == "date":
-            column_table[i] = tuple(
+            converted_column_table[i].append(tuple(
                 v if v is None else datetime.date.fromisoformat(v) for v in col
-            )
+            ))
         elif description[i][1] == "timestamp":
-            column_table[i] = tuple(
+            converted_column_table[i].append(tuple(
                 (
                     v
                     if v is None
@@ -606,9 +608,11 @@ def convert_to_assigned_datatypes_in_column_table(column_table, description):
                     )
                 )
                 for v in col
-            )
+            ))
+        else:
+            converted_column_table.append(col)
 
-    return column_table
+    return converted_column_table
 
 
 def convert_column_based_set_to_arrow_table(columns, description):
@@ -624,7 +628,7 @@ def convert_column_based_set_to_arrow_table(columns, description):
 
 def convert_column_based_set_to_column_table(columns, description):
     column_names = [c[0] for c in description]
-    column_table = [_covert_column_to_list(c) for c in columns]
+    column_table = [_convert_column_to_list(c) for c in columns]
 
     return column_table, column_names
 
@@ -653,8 +657,8 @@ def _convert_column_to_arrow_array(t_col):
     raise OperationalError("Empty TColumn instance {}".format(t_col))
 
 
-def _covert_column_to_list(t_col):
-    supported_field_types = (
+def _convert_column_to_list(t_col):
+    SUPPORTED_FIELD_TYPES = (
         "boolVal",
         "byteVal",
         "i16Val",
@@ -665,7 +669,7 @@ def _covert_column_to_list(t_col):
         "binaryVal",
     )
 
-    for field in supported_field_types:
+    for field in SUPPORTED_FIELD_TYPES:
         wrapper = getattr(t_col, field)
         if wrapper:
             return _create_python_tuple(wrapper)

--- a/src/databricks/sql/utils.py
+++ b/src/databricks/sql/utils.py
@@ -125,6 +125,8 @@ class ColumnTable:
         sliced_column_table = [column[curr_index : curr_index + length] for column in self.column_table]
         return ColumnTable(sliced_column_table, self.column_names)
 
+    def __eq__(self, other):
+        return self.column_table == other.column_table and self.column_names == other.column_names
 
 class ColumnQueue(ResultSetQueue):
     def __init__(self, column_table: ColumnTable):

--- a/src/databricks/sql/utils.py
+++ b/src/databricks/sql/utils.py
@@ -617,11 +617,11 @@ def convert_to_assigned_datatypes_in_column_table(column_table, description):
         if description[i][1] == "decimal":
             converted_column_table.append(tuple(v if v is None else Decimal(v) for v in col))
         elif description[i][1] == "date":
-            converted_column_table[i].append(tuple(
+            converted_column_table.append(tuple(
                 v if v is None else datetime.date.fromisoformat(v) for v in col
             ))
         elif description[i][1] == "timestamp":
-            converted_column_table[i].append(tuple(
+            converted_column_table.append(tuple(
                 (
                     v
                     if v is None

--- a/src/databricks/sqlalchemy/pytest.ini
+++ b/src/databricks/sqlalchemy/pytest.ini
@@ -1,0 +1,4 @@
+
+[sqla_testing]
+requirement_cls=databricks.sqlalchemy.requirements:Requirements
+profile_file=profiles.txt

--- a/src/databricks/sqlalchemy/pytest.ini
+++ b/src/databricks/sqlalchemy/pytest.ini
@@ -1,4 +1,0 @@
-
-[sqla_testing]
-requirement_cls=databricks.sqlalchemy.requirements:Requirements
-profile_file=profiles.txt

--- a/tests/unit/test_column_queue.py
+++ b/tests/unit/test_column_queue.py
@@ -1,0 +1,20 @@
+import pytest
+from databricks.sql.utils import ColumnQueue
+
+
+class TestColumnQueueSuite:
+    @pytest.fixture(scope="function")
+    def setup(self):
+        columnar_table = [[0, 3, 6, 9], [1, 4, 7, 10], [2, 5, 8, 11]]
+        column_names = [f"col_{i}" for i in range(len(columnar_table))]
+        return ColumnQueue(columnar_table, column_names)
+
+    def test_fetchmany_respects_n_rows(self, setup):
+        column_queue = setup
+        assert column_queue.next_n_rows(2) == [[0, 3], [1, 4], [2, 5]]
+        assert column_queue.next_n_rows(2) == [[6, 9], [7, 10], [8, 11]]
+
+    def test_fetch_remaining_rows_respects_n_rows(self, setup):
+        column_queue = setup
+        assert column_queue.next_n_rows(2) == [[0, 3], [1, 4], [2, 5]]
+        assert column_queue.remaining_rows() == [[6, 9], [7, 10], [8, 11]]

--- a/tests/unit/test_column_queue.py
+++ b/tests/unit/test_column_queue.py
@@ -1,20 +1,22 @@
-import pytest
-from databricks.sql.utils import ColumnQueue
+from databricks.sql.utils import ColumnQueue, ColumnTable
 
 
 class TestColumnQueueSuite:
-    @pytest.fixture(scope="function")
-    def setup(self):
-        columnar_table = [[0, 3, 6, 9], [1, 4, 7, 10], [2, 5, 8, 11]]
-        column_names = [f"col_{i}" for i in range(len(columnar_table))]
-        return ColumnQueue(columnar_table, column_names)
+    @staticmethod
+    def make_column_table(table):
+        n_cols = len(table) if table else 0
+        return ColumnTable(table, [f"col_{i}" for i in range(n_cols)])
 
-    def test_fetchmany_respects_n_rows(self, setup):
-        column_queue = setup
-        assert column_queue.next_n_rows(2) == [[0, 3], [1, 4], [2, 5]]
-        assert column_queue.next_n_rows(2) == [[6, 9], [7, 10], [8, 11]]
+    def test_fetchmany_respects_n_rows(self):
+        column_table = self.make_column_table([[0, 3, 6, 9], [1, 4, 7, 10], [2, 5, 8, 11]])
+        column_queue = ColumnQueue(column_table)
 
-    def test_fetch_remaining_rows_respects_n_rows(self, setup):
-        column_queue = setup
-        assert column_queue.next_n_rows(2) == [[0, 3], [1, 4], [2, 5]]
-        assert column_queue.remaining_rows() == [[6, 9], [7, 10], [8, 11]]
+        assert column_queue.next_n_rows(2) == column_table.slice(0, 2)
+        assert column_queue.next_n_rows(2) == column_table.slice(2, 2)
+
+    def test_fetch_remaining_rows_respects_n_rows(self):
+        column_table = self.make_column_table([[0, 3, 6, 9], [1, 4, 7, 10], [2, 5, 8, 11]])
+        column_queue = ColumnQueue(column_table)
+
+        assert column_queue.next_n_rows(2) == column_table.slice(0, 2)
+        assert column_queue.remaining_rows() == column_table.slice(2, 2)


### PR DESCRIPTION
[PECO-1926]

## Description

To handle the flow of result when pyarrow is not present. This setup is particularly used for users who want to handle small quantities of data 

## Task Completed

- [x] Introduced the new non arrow flow for data to be handled by the users not having pyarrow
- [x] ColumnQueue is the new ResultSetQueue that I have added to handle the column set data 
- [x] Entire pipeline of handling the column set data to finally converting it to the TRow type for the user has been implemented
- [x] Added tests for the ColumnQueue to ensure that it is working as intended

[PECO-1926]: https://databricks.atlassian.net/browse/PECO-1926?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ