### PR TITLE
"Export" `DatabricksDialect` from `databricks.sqlalchemy`

### DIFF
--- a/src/databricks/sqlalchemy/__init__.py
+++ b/src/databricks/sqlalchemy/__init__.py
@@ -1,4 +1,4 @@
 from databricks.sqlalchemy.base import DatabricksDialect
 from databricks.sqlalchemy._types import TINYINT, TIMESTAMP, TIMESTAMP_NTZ
 
-__all__ = ["TINYINT", "TIMESTAMP", "TIMESTAMP_NTZ"]
+__all__ = ["DatabricksDialect", "TINYINT", "TIMESTAMP", "TIMESTAMP_NTZ"]


### PR DESCRIPTION
Although python doesn't really have an "Export" command, type checkers like mypy will warn if an imported object isn't part of module's `__all__` list.

https://mypy.readthedocs.io/en/stable/command_line.html#cmdoption-mypy-no-implicit-reexport