### PR TITLE
[PECO-1961] On non-retryable error, ensure PySQL includes useful information in error

### DIFF
--- a/src/databricks/sql/utils.py
+++ b/src/databricks/sql/utils.py
@@ -357,7 +357,12 @@ class RequestErrorInfo(
             user_friendly_error_message = "{}: {}".format(
                 user_friendly_error_message, self.error_message
             )
-        return user_friendly_error_message
+        try:
+            error_context = str(self.error)
+        except:
+            error_context = ""
+
+        return user_friendly_error_message + ". " + error_context
 
 
 # Taken from PyHive

--- a/src/databricks/sql/utils.py
+++ b/src/databricks/sql/utils.py
@@ -27,6 +27,7 @@ from databricks.sql.parameters.native import ParameterStructure, TDbsqlParameter
 import logging
 
 BIT_MASKS = [1, 2, 4, 8, 16, 32, 64, 128]
+DEFAULT_ERROR_CONTEXT = "Unknown error"
 
 logger = logging.getLogger(__name__)
 
@@ -360,7 +361,7 @@ class RequestErrorInfo(
         try:
             error_context = str(self.error)
         except:
-            error_context = ""
+            error_context = DEFAULT_ERROR_CONTEXT
 
         return user_friendly_error_message + ". " + error_context
 


### PR DESCRIPTION
## Description
This PR addresses an issue where the original exception context was not included in the error message. 

### Changes made
Appended original exception context `self.error` in the user-friendly error message

### Testing
Simulated authentication error (Non-retry) and verified exception was being raised with error message.