### PR TITLE
Remove upper caps on dependencies

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1202,4 +1202,4 @@ sqlalchemy = ["sqlalchemy"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8.0"
-content-hash = "caa1c9e9001579a6f3ad2ca2ef0c6481ba6a860de8b72c137a7f4e9f44ea16ad"
+content-hash = "9d8a91369fc79f9ca9f7502e2ed284b66531c954ae59a723e465a76073966998"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1202,4 +1202,4 @@ sqlalchemy = ["sqlalchemy"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8.0"
-content-hash = "31066a85f646d0009d6fe9ffc833a64fcb4b6923c2e7f2652e7aa8540acba298"
+content-hash = "caa1c9e9001579a6f3ad2ca2ef0c6481ba6a860de8b72c137a7f4e9f44ea16ad"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,16 +16,16 @@ pandas = [
 ]
 pyarrow = ">=14.0.1"
 
-lz4 = ">=4.0.2"
-requests = ">=2.18.1"
-oauthlib = ">=3.1.0"
+lz4 = "^4.0.2"
+requests = "^2.18.1"
+oauthlib = "^3.1.0"
 numpy = [
     { version = ">=1.16.6", python = ">=3.8,<3.11" },
     { version = ">=1.23.4", python = ">=3.11" },
 ]
 sqlalchemy = { version = ">=2.0.21", optional = true }
-openpyxl = ">=3.0.10"
-alembic = { version = ">=1.0.11", optional = true }
+openpyxl = "^3.0.10"
+alembic = { version = "^1.0.11", optional = true }
 urllib3 = ">=1.26"
 
 [tool.poetry.extras]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,18 +14,18 @@ thrift = ">=0.16.0,<0.21.0"
 pandas = [
     { version = ">=1.2.5,<2.3.0", python = ">=3.8" }
 ]
-pyarrow = ">=14.0.1,<17"
+pyarrow = ">=14.0.1"
 
-lz4 = "^4.0.2"
-requests = "^2.18.1"
-oauthlib = "^3.1.0"
+lz4 = ">=4.0.2"
+requests = ">=2.18.1"
+oauthlib = ">=3.1.0"
 numpy = [
-    { version = "^1.16.6", python = ">=3.8,<3.11" },
-    { version = "^1.23.4", python = ">=3.11" },
+    { version = ">=1.16.6", python = ">=3.8,<3.11" },
+    { version = ">=1.23.4", python = ">=3.11" },
 ]
 sqlalchemy = { version = ">=2.0.21", optional = true }
-openpyxl = "^3.0.10"
-alembic = { version = "^1.0.11", optional = true }
+openpyxl = ">=3.0.10"
+alembic = { version = ">=1.0.11", optional = true }
 urllib3 = ">=1.26"
 
 [tool.poetry.extras]


### PR DESCRIPTION
## What

Like many Poetry-managed projects, this package sets upper caps on dependencies both via caret (`^`) and lesser-than signs (`<=`). This PR relaxes these requirements to just establishing lower bounds, not upper ones.

## Why

Poetry heavily believes in SemVer but many projects do not strictly follow it. For instance, [pyarrow](https://pypi.org/project/pyarrow/#history) has bumped major versions **eight** times in the last 2 years without really making breaking changes for the vast majority of users.

Many well-regarded devs in the Python ecosystem are calling against upper-bounds in projects due to the complications it generates for end users ([here's](https://iscinumpy.dev/post/bound-version-constraints/) an excellent discussion on the topic from a PyPa member).

Personally, I find myself in "dependency hell" in a project where we use SQLAlchemy to interface with many kinds of databases (the area where SQLAlchemy excels, for sure). The latest dialects we're trying to support require SQLAlchemy >= 2.0, but our current `databricks-sql-connector`version of `2.9.3` doesn't allow it. We also can't upgrade to the latest `3.4.0` because an upper limit on `pyarrow` has been set (which didn't exist before). A similar experience happens with Numpy >= 2.0.

## Related issues / PRs

Many versions of this issue have popped up before for this package (especially for `pyarrow` and `numpy`):
#427 
#55 
#428 
#74 
#88
#432

## Note

If this PR seems too ambitious, I'm happy to provide another one that only removes or, at least, bumps the upper cap for `pyarrow` and `numpy`. However, I believe removing upper caps in a general sense is the way to go. Major version bumps in Python are very frequently backwards compatible, and it's a much better experience for users to fix problems when they occur than to prevent them from upgrading (and eventually ditching your package altogether).

Here's a quote in the linked article from Brett Cannon, Python Steering Council Member and packaging expert:

> Libraries/packages should be setting a floor, and if necessary excluding known buggy versions, but otherwise don’t cap the maximum version as you can’t predict future compatibility

Or another quote from the author of the article himself:

> If you absolutely must set upper limits, you should release a new version as soon as possible with a higher cap when a dependency updates (ideally before the dependency releases the update). If you are committing to this, why not just quickly release a patch release with caps only after an actual conflict happens? It will be less common, and will help you quickly sort out and fix incompatibilities, rather than hiding your true compatibilities and delaying updates. **You want users to use the latest versions of your libraries if there’s a problem, so why can’t you offer the same consideration to the libraries you depend on and use?**
