### PR TITLE
[issue-458] Log if the user passes a NoneType access token

### DIFF
--- a/src/databricks/sql/__init__.py
+++ b/src/databricks/sql/__init__.py
@@ -10,7 +10,7 @@ paramstyle = "named"
 
 import re
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional, Union
 
 if TYPE_CHECKING:
     # Use this import purely for type annotations, a la https://mypy.readthedocs.io/en/latest/runtime_troubles.html#import-cycles
@@ -83,8 +83,23 @@ def DateFromTicks(ticks):
 def TimestampFromTicks(ticks):
     return Timestamp(*time.localtime(ticks)[:6])
 
+def singleton(class_):
+    instances = {}
+    def getinstance(*args, **kwargs):
+        if class_ not in instances:
+            instances[class_] = class_(*args, **kwargs)
+        return instances[class_]
+    return getinstance
 
-def connect(server_hostname, http_path, access_token=None, **kwargs) -> "Connection":
+@singleton
+class DefaultNone(object):
+    """Used to represent a default value of None so that this code can distinguish between
+    the user passing None versus a default value of None being used.
+    """
+    pass
+
+
+def connect(server_hostname, http_path, access_token: Optional[Union[str, DefaultNone]]=DefaultNone, **kwargs) -> "Connection":
     from .client import Connection
 
     return Connection(server_hostname, http_path, access_token, **kwargs)

--- a/src/databricks/sql/client.py
+++ b/src/databricks/sql/client.py
@@ -12,7 +12,7 @@ import os
 import decimal
 from uuid import UUID
 
-from databricks.sql import __version__
+from databricks.sql import __version__, DefaultNone
 from databricks.sql import *
 from databricks.sql.exc import (
     OperationalError,
@@ -63,7 +63,7 @@ class Connection:
         self,
         server_hostname: str,
         http_path: str,
-        access_token: Optional[str] = None,
+        access_token: Optional[Union[str, DefaultNone]] = None,
         http_headers: Optional[List[Tuple[str, str]]] = None,
         session_configuration: Optional[Dict[str, Any]] = None,
         catalog: Optional[str] = None,
@@ -204,7 +204,13 @@ class Connection:
         # use_cloud_fetch
         # Enable use of cloud fetch to extract large query results in parallel via cloud storage
 
-        if access_token:
+        if access_token is DefaultNone:
+            access_token = None
+        elif access_token is None:
+            logger.info(
+                "Connection access_token was passed a None value. U2M OAuth will be attempted"
+                )
+        else:
             access_token_kv = {"access_token": access_token}
             kwargs = {**kwargs, **access_token_kv}
 


### PR DESCRIPTION
## Description

This PR implements the pattern described [here](https://github.com/databricks/databricks-sql-python/issues/458#issuecomment-2442887279) to emit a log message if the user _passes_ a None value for their `access_token`, since this is likely not intentional.

This doesn't change the behavior of the connector. In the case of the linked issue, it will not prevent the browser from hanging. But it _will_ notify the user about what's happening behind the scenes.

## Related Tickets & Documents

Relates #458 