### PR TITLE
Fixed the Issue of TCP not closing

### DIFF
--- a/src/databricks/sql/auth/thrift_http_client.py
+++ b/src/databricks/sql/auth/thrift_http_client.py
@@ -144,6 +144,7 @@ class THttpClient(thrift.transport.THttpClient.THttpClient):
         self.__resp and self.__resp.drain_conn()
         self.__resp and self.__resp.release_conn()
         self.__resp = None
+        self.__pool = None
 
     def read(self, sz):
         return self.__resp.read(sz)

--- a/src/databricks/sql/thrift_backend.py
+++ b/src/databricks/sql/thrift_backend.py
@@ -365,6 +365,7 @@ class ThriftBackend:
             # - non-None retry_delay -> sleep delay before retry
             # - error, error_message always set when available
 
+            exception_occurred = False
             error, error_message, retry_delay = None, None, None
             try:
                 this_method_name = getattr(method, "__name__")
@@ -388,6 +389,7 @@ class ThriftBackend:
                 return response
 
             except urllib3.exceptions.HTTPError as err:
+                exception_occurred = True
                 # retry on timeout. Happens a lot in Azure and it is safe as data has not been sent to server yet
 
                 # TODO: don't use exception handling for GOS polling...
@@ -406,6 +408,7 @@ class ThriftBackend:
                 else:
                     raise err
             except OSError as err:
+                exception_occurred = True
                 error = err
                 error_message = str(err)
                 # fmt: off
@@ -436,12 +439,14 @@ class ThriftBackend:
                     else:
                         logger.warning(log_string)
             except Exception as err:
+                exception_occurred = True
                 error = err
                 retry_delay = extract_retry_delay(attempt)
                 error_message = ThriftBackend._extract_error_message_from_headers(
                     getattr(self._transport, "headers", {})
                 )
-            finally:
+
+            if exception_occurred:
                 # Calling `close()` here releases the active HTTP connection back to the pool
                 self._transport.close()
 


### PR DESCRIPTION
## Description

Currently while closing a Connection the HTTPConnectionPool is not explicitly closed and just the buffer is emptied upon closing the connection. This creates the issue of the TCP connection being in ESTABLISHED phased indefinetly and not moving to the CLOSED phase.

## Fix
- Modified the code to only close the connection in case en error occurs while making a request
- Setting the pool as None to ensure that the Python Garbage cleanup takes care of the final closure and releasing of the port

## Testing 

Tested by monitoring the connection port through the lifecycle of the query to verify its working