### PR TITLE
Remove a mypy error message workaround that should be unnecessary in mypy 1.15.0

### DIFF
--- a/.github/workflows/code-quality-checks.yml
+++ b/.github/workflows/code-quality-checks.yml
@@ -211,6 +211,4 @@ jobs:
       #              mypy the code
       #----------------------------------------------
       - name: Mypy
-        run: |
-          mkdir .mypy_cache # Workaround for bad error message "error: --install-types failed (no mypy cache directory)"; see https://github.com/python/mypy/issues/10768#issuecomment-2178450153
-          poetry run mypy --install-types --non-interactive src
+        run: poetry run mypy --install-types --non-interactive src

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ pyarrow = ["pyarrow"]
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.1.2"
-mypy = "^1.10.1"
+mypy = "^1.15.0"
 pylint = ">=2.12.0"
 black = "^22.3.0"
 pytest-dotenv = "^0.5.2"


### PR DESCRIPTION
This pr should be good to go next time there's another release of mypy. I'm just keeping it a draft til then.

See https://github.com/python/mypy/pull/17485 or https://github.com/python/mypy/issues/10768 for more information on the problem and workaround that used to be here.