### PR TITLE
Removed CI CD for python3.8

### DIFF
--- a/.github/workflows/code-quality-checks.yml
+++ b/.github/workflows/code-quality-checks.yml
@@ -62,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ 3.8, 3.9, "3.10", "3.11" ]
+        python-version: [3.9, "3.10", "3.11" ]
     steps:
       #----------------------------------------------
       #       check-out repo and set-up python
@@ -113,7 +113,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9, "3.10"]
+        python-version: [3.9, "3.10"]
     steps:
       #----------------------------------------------
       #       check-out repo and set-up python
@@ -165,7 +165,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9, "3.10"]
+        python-version: [3.9, "3.10"]
     steps:
       #----------------------------------------------
       #       check-out repo and set-up python

--- a/.github/workflows/code-quality-checks.yml
+++ b/.github/workflows/code-quality-checks.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9, "3.10", "3.11"]
+        python-version: [3.9, "3.10", "3.11"]
     steps:
       #----------------------------------------------
       #       check-out repo and set-up python


### PR DESCRIPTION
## Description
- Latest version of poetry 2.x has removed support for Python3.8 [Poetry Github](https://github.com/python-poetry/poetry/blob/81f2935a17c6a084ccc54987cfbbeaab1f555cd4/pyproject.toml#L5)
- Python3.8 has been officially deprecated from 2024-10-14