### PR TITLE
Support for enforcing embedded schema

### DIFF
--- a/src/databricks/sql/client.py
+++ b/src/databricks/sql/client.py
@@ -737,6 +737,7 @@ class Cursor:
         self,
         operation: str,
         parameters: Optional[TParameterCollection] = None,
+        enforceEmbeddedSchema=False,
     ) -> "Cursor":
         """
         Execute a query and wait for execution to complete.
@@ -801,6 +802,7 @@ class Cursor:
             use_cloud_fetch=self.connection.use_cloud_fetch,
             parameters=prepared_params,
             async_op=False,
+            enforceEmbeddedSchema=enforceEmbeddedSchema,
         )
         self.active_result_set = ResultSet(
             self.connection,
@@ -822,6 +824,7 @@ class Cursor:
         self,
         operation: str,
         parameters: Optional[TParameterCollection] = None,
+        enforceEmbeddedSchema=False,
     ) -> "Cursor":
         """
 
@@ -862,6 +865,7 @@ class Cursor:
             use_cloud_fetch=self.connection.use_cloud_fetch,
             parameters=prepared_params,
             async_op=True,
+            enforceEmbeddedSchema=enforceEmbeddedSchema,
         )
 
         return self

--- a/src/databricks/sql/thrift_backend.py
+++ b/src/databricks/sql/thrift_backend.py
@@ -883,6 +883,7 @@ class ThriftBackend:
         use_cloud_fetch=True,
         parameters=[],
         async_op=False,
+        enforceEmbeddedSchema=False,
     ):
         assert session_handle is not None
 
@@ -910,6 +911,7 @@ class ThriftBackend:
             },
             useArrowNativeTypes=spark_arrow_types,
             parameters=parameters,
+            enforceEmbeddedSchemaCorrectness=enforceEmbeddedSchema,
         )
         resp = self.make_request(self._client.ExecuteStatement, req)
 


### PR DESCRIPTION
## Description

As a part of query optimization Databricks returns cached results when the underlying query is the same. This creates issue when the same query is used but with a different alias, in this case the result is the same but the metadata is different. But Databricks returns the same metadata as a part of query optimisation

## Added 
Added option to enforce schema to make sure the metadata is in updated state