### PR TITLE
Fix : Unable to poll results in async API

### DIFF
--- a/src/databricks/sql/thrift_backend.py
+++ b/src/databricks/sql/thrift_backend.py
@@ -899,9 +899,11 @@ class ThriftBackend:
             statement=operation,
             runAsync=True,
             # For async operation we don't want the direct results
-            getDirectResults=ttypes.TSparkGetDirectResults(
-                maxRows=0 if async_op else max_rows,
-                maxBytes=0 if async_op else max_bytes,
+            getDirectResults=None
+            if async_op
+            else ttypes.TSparkGetDirectResults(
+                maxRows=max_rows,
+                maxBytes=max_bytes,
             ),
             canReadArrowResult=True if pyarrow else False,
             canDecompressLZ4Result=lz4_compression,

--- a/src/databricks/sql/thrift_backend.py
+++ b/src/databricks/sql/thrift_backend.py
@@ -898,8 +898,10 @@ class ThriftBackend:
             sessionHandle=session_handle,
             statement=operation,
             runAsync=True,
+            # For async operation we don't want the direct results
             getDirectResults=ttypes.TSparkGetDirectResults(
-                maxRows=max_rows, maxBytes=max_bytes
+                maxRows=0 if async_op else max_rows,
+                maxBytes=0 if async_op else max_bytes,
             ),
             canReadArrowResult=True if pyarrow else False,
             canDecompressLZ4Result=lz4_compression,

--- a/tests/e2e/common/large_queries_mixin.py
+++ b/tests/e2e/common/large_queries_mixin.py
@@ -83,11 +83,11 @@ class LargeQueriesMixin:
                 assert row[0] == row_id
 
     def test_long_running_query(self):
-        """Incrementally increase query size until it takes at least 4 minutes,
+        """Incrementally increase query size until it takes at least 5 minutes,
         and asserts that the query completes successfully.
         """
         minutes = 60
-        min_duration = 4 * minutes
+        min_duration = 5 * minutes
 
         duration = -1
         scale0 = 10000
@@ -113,5 +113,5 @@ class LargeQueriesMixin:
                 duration = time.time() - start
                 current_fraction = duration / min_duration
                 print("Took {} s with scale factor={}".format(duration, scale_factor))
-                # Extrapolate linearly to reach 4 min and add 50% padding to push over the limit
+                # Extrapolate linearly to reach 5 min and add 50% padding to push over the limit
                 scale_factor = math.ceil(1.5 * scale_factor / current_fraction)

--- a/tests/e2e/common/large_queries_mixin.py
+++ b/tests/e2e/common/large_queries_mixin.py
@@ -94,7 +94,7 @@ class LargeQueriesMixin:
         scale_factor = 1
         with self.cursor() as cursor:
             while duration < min_duration:
-                assert scale_factor < 512, "Detected infinite loop"
+                assert scale_factor < 1024, "Detected infinite loop"
                 start = time.time()
 
                 cursor.execute(

--- a/tests/e2e/common/large_queries_mixin.py
+++ b/tests/e2e/common/large_queries_mixin.py
@@ -83,11 +83,11 @@ class LargeQueriesMixin:
                 assert row[0] == row_id
 
     def test_long_running_query(self):
-        """Incrementally increase query size until it takes at least 5 minutes,
+        """Incrementally increase query size until it takes at least 4 minutes,
         and asserts that the query completes successfully.
         """
         minutes = 60
-        min_duration = 5 * minutes
+        min_duration = 4 * minutes
 
         duration = -1
         scale0 = 10000
@@ -113,5 +113,5 @@ class LargeQueriesMixin:
                 duration = time.time() - start
                 current_fraction = duration / min_duration
                 print("Took {} s with scale factor={}".format(duration, scale_factor))
-                # Extrapolate linearly to reach 5 min and add 50% padding to push over the limit
+                # Extrapolate linearly to reach 4 min and add 50% padding to push over the limit
                 scale_factor = math.ceil(1.5 * scale_factor / current_fraction)


### PR DESCRIPTION
## Description
Polling using the async API returned the `RESOURCE_NOT_FOUND` error for async executed queries

## Fix
Force retention of data on the server side by not returning the results in the `direct results` within the `execute_query` response

## Testing
Added e2e tests 
