### PR TITLE
Add version check for urllib3 in backoff calculation

### DIFF
--- a/src/databricks/sql/auth/retry.py
+++ b/src/databricks/sql/auth/retry.py
@@ -5,6 +5,8 @@ import typing
 from enum import Enum
 from typing import List, Optional, Tuple, Union
 
+import urllib3
+
 # We only use this import for type hinting
 try:
     # If urllib3~=2.0 is installed
@@ -14,6 +16,8 @@ except ImportError:
     from urllib3 import HTTPResponse as BaseHTTPResponse
 from urllib3 import Retry
 from urllib3.util.retry import RequestHistory
+from packaging import version
+
 
 from databricks.sql.exc import (
     CursorAlreadyClosedError,
@@ -307,8 +311,9 @@ class DatabricksRetryPolicy(Retry):
 
         current_attempt = self.stop_after_attempts_count - int(self.total or 0)
         proposed_backoff = (2**current_attempt) * self.delay_min
-        if self.backoff_jitter != 0.0:
-            proposed_backoff += random.random() * self.backoff_jitter
+        if version.parse(urllib3.__version__) >= version.parse("2.0.0"):
+            if self.backoff_jitter != 0.0:
+                proposed_backoff += random.random() * self.backoff_jitter
 
         proposed_backoff = min(proposed_backoff, self.delay_max)
         self.check_proposed_wait(proposed_backoff)


### PR DESCRIPTION
## Description
Addresses #525 
Added version check for `urllib3` to apply additional backoff jitter if version is `>=2.0.0`.
## How is this tested?
Tested manually using the connector to trigger retry flow.