### PR TITLE
[ES-1372353] make user_agent_header part of public API

### DIFF
--- a/examples/set_user_agent.py
+++ b/examples/set_user_agent.py
@@ -5,7 +5,7 @@ with sql.connect(
     server_hostname=os.getenv("DATABRICKS_SERVER_HOSTNAME"),
     http_path=os.getenv("DATABRICKS_HTTP_PATH"),
     access_token=os.getenv("DATABRICKS_TOKEN"),
-    _user_agent_entry="ExamplePartnerTag",
+    user_agent_entry="ExamplePartnerTag",
 ) as connection:
 
     with connection.cursor() as cursor:

--- a/src/databricks/sql/client.py
+++ b/src/databricks/sql/client.py
@@ -234,7 +234,7 @@ class Connection:
             if user_agent_entry is not None:
                 logger.warning(
                     "[WARN] Parameter '_user_agent_entry' is deprecated; use 'user_agent_entry' instead. "
-                    "This parameter will be removed in the next release."
+                    "This parameter will be removed in the upcoming releases."
                 )
 
         if user_agent_entry:

--- a/src/databricks/sql/client.py
+++ b/src/databricks/sql/client.py
@@ -122,6 +122,9 @@ class Connection:
                 port of the oauth redirect uri (localhost). This is required when custom oauth client_id
                 `oauth_client_id` is set
 
+            user_agent_entry: `str`, optional
+                Tag to add to User-Agent header. For use by partners. If not specified, it will use the default user agent PyDatabricksSqlConnector
+
             experimental_oauth_persistence: configures preferred storage for persisting oauth tokens.
                 This has to be a class implementing `OAuthPersistence`.
                 When `auth_type` is set to `databricks-oauth` or `azure-oauth` without persisting the oauth token in a
@@ -176,7 +179,7 @@ class Connection:
         """
 
         # Internal arguments in **kwargs:
-        # _user_agent_entry
+        # user_agent_entry
         #   Tag to add to User-Agent header. For use by partners.
         # _use_cert_as_auth
         #  Use a TLS cert instead of a token
@@ -227,11 +230,11 @@ class Connection:
             server_hostname, **kwargs
         )
 
-        if not kwargs.get("_user_agent_entry"):
+        if not kwargs.get("user_agent_entry"):
             useragent_header = "{}/{}".format(USER_AGENT_NAME, __version__)
         else:
             useragent_header = "{}/{} ({})".format(
-                USER_AGENT_NAME, __version__, kwargs.get("_user_agent_entry")
+                USER_AGENT_NAME, __version__, kwargs.get("user_agent_entry")
             )
 
         base_headers = [("User-Agent", useragent_header)]

--- a/src/databricks/sql/client.py
+++ b/src/databricks/sql/client.py
@@ -123,7 +123,7 @@ class Connection:
                 `oauth_client_id` is set
 
             user_agent_entry: `str`, optional
-                Tag to add to User-Agent header. For use by partners. If not specified, it will use the default user agent PyDatabricksSqlConnector
+                A custom tag to append to the User-Agent header. This is typically used by partners to identify their applications.. If not specified, it will use the default user agent PyDatabricksSqlConnector
 
             experimental_oauth_persistence: configures preferred storage for persisting oauth tokens.
                 This has to be a class implementing `OAuthPersistence`.
@@ -228,12 +228,21 @@ class Connection:
             server_hostname, **kwargs
         )
 
-        if not kwargs.get("user_agent_entry"):
-            useragent_header = "{}/{}".format(USER_AGENT_NAME, __version__)
-        else:
+        user_agent_entry = kwargs.get("user_agent_entry")
+        if user_agent_entry is None:
+            user_agent_entry = kwargs.get("_user_agent_entry")
+            if user_agent_entry is not None:
+                logger.warning(
+                    "[WARN] Parameter '_user_agent_entry' is deprecated; use 'user_agent_entry' instead. "
+                    "This parameter will be removed in the next release."
+                )
+
+        if user_agent_entry:
             useragent_header = "{}/{} ({})".format(
-                USER_AGENT_NAME, __version__, kwargs.get("user_agent_entry")
+                USER_AGENT_NAME, __version__, user_agent_entry
             )
+        else:
+            useragent_header = "{}/{}".format(USER_AGENT_NAME, __version__)
 
         base_headers = [("User-Agent", useragent_header)]
 

--- a/src/databricks/sql/client.py
+++ b/src/databricks/sql/client.py
@@ -179,8 +179,6 @@ class Connection:
         """
 
         # Internal arguments in **kwargs:
-        # user_agent_entry
-        #   Tag to add to User-Agent header. For use by partners.
         # _use_cert_as_auth
         #  Use a TLS cert instead of a token
         # _enable_ssl

--- a/src/databricks/sql/thrift_backend.py
+++ b/src/databricks/sql/thrift_backend.py
@@ -95,8 +95,6 @@ class ThriftBackend:
         **kwargs,
     ):
         # Internal arguments in **kwargs:
-        # _user_agent_entry
-        #   Tag to add to User-Agent header. For use by partners.
         # _username, _password
         #   Username and password Basic authentication (no official support)
         # _connection_uri

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -157,7 +157,7 @@ class ClientTestSuite(unittest.TestCase):
         )
         self.assertIn(user_agent_header, http_headers)
 
-        databricks.sql.connect(**self.DUMMY_CONNECTION_ARGS, _user_agent_entry="foobar")
+        databricks.sql.connect(**self.DUMMY_CONNECTION_ARGS, user_agent_entry="foobar")
         user_agent_header_with_entry = (
             "User-Agent",
             "{}/{} ({})".format(


### PR DESCRIPTION
## Description

- Renamed `_user_agent_entry` in connect call args to `user_agent_entry`.
- removed this from list of internal arguments in docstring.

## How is this tested?
Verified agent population in query history when using `user_agent_entry`

## Related Tickets & Documents
ES-1372353