### PR TITLE
Adds python package `packaging` to requirements

### DIFF
--- a/.github/workflows/dco-check.yml
+++ b/.github/workflows/dco-check.yml
@@ -4,7 +4,9 @@ on: [pull_request]
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    runs-on:
+        group: databricks-protected-runner-group
+        labels: linux-ubuntu-latest
     steps:
       - name: Check for DCO
         id: dco-check

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -167,4 +167,4 @@ Modify the dependency specification (syntax can be found [here](https://python-p
 Sometimes `poetry update` can freeze or run forever. Deleting the `poetry.lock` file and calling `poetry install` is guaranteed to update everything but is usually _slower_ than `poetry update` **if `poetry update` works at all**.
 
 
-Sample change: Add commit signoffs.
+Sample change: Add commit signoffs. Then the check will pass

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -165,3 +165,6 @@ Modify the dependency specification (syntax can be found [here](https://python-p
 - `rm poetry.lock && poetry install`
 
 Sometimes `poetry update` can freeze or run forever. Deleting the `poetry.lock` file and calling `poetry install` is guaranteed to update everything but is usually _slower_ than `poetry update` **if `poetry update` works at all**.
+
+
+Sample change: Add commit signoffs.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -165,6 +165,3 @@ Modify the dependency specification (syntax can be found [here](https://python-p
 - `rm poetry.lock && poetry install`
 
 Sometimes `poetry update` can freeze or run forever. Deleting the `poetry.lock` file and calling `poetry install` is guaranteed to update everything but is usually _slower_ than `poetry update` **if `poetry update` works at all**.
-
-
-Sample change: Add commit signoffs. Then the check will pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ requests = "^2.18.1"
 oauthlib = "^3.1.0"
 openpyxl = "^3.0.10"
 urllib3 = ">=1.26"
+packaging = ">=20.0"
 pyarrow = [
     { version = ">=14.0.1", python = ">=3.8,<3.13", optional=true },
     { version = ">=18.0.0", python = ">=3.13", optional=true }


### PR DESCRIPTION
<!-- We welcome contributions. All patches must include a sign-off. Please see CONTRIBUTING.md for details -->

## What type of PR is this?
<!-- Check all that apply, delete what doesn't apply. -->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Other

## Description
We use the `packaging` module in the retry logic in `retry.py`. This PR adds the `packaging` module as a requirement for this usecase.

## How is this tested?

- [ ] Unit tests
- [ ] E2E Tests
- [x] Manually
- [ ] N/A

<!-- If Manually, please describe. -->
Manual poetry installation and venv installation
## Related Tickets & Documents
https://github.com/databricks/databricks-sql-python/issues/540