### PR TITLE
Refactor decimal conversion in PyArrow tables to use direct casting

### DIFF
--- a/src/databricks/sql/utils.py
+++ b/src/databricks/sql/utils.py
@@ -624,7 +624,6 @@ def convert_decimals_in_arrow_table(table, description) -> "pyarrow.Table":
             # create the target decimal type
             dtype = pyarrow.decimal128(precision, scale)
 
-            # convert the column directly using PyArrow's cast operation
             new_col = col.cast(dtype)
             new_field = field.with_type(dtype)
 


### PR DESCRIPTION
<!-- We welcome contributions. All patches must include a sign-off. Please see CONTRIBUTING.md for details -->


## What type of PR is this?
<!-- Check all that apply, delete what doesn't apply. -->

- [X] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Other

## Description
This PR replaces the previous implementation of convert_decimals_in_arrow_table() with a more efficient approach that uses PyArrow's native casting operation instead of going through pandas conversion and array creation.

- Remove conversion to pandas DataFrame via to_pandas() and apply() methods
- Remove intermediate steps of creating array from decimal column and setting it back
- Replace with direct type casting using PyArrow's cast() method
- Build a new table with transformed columns rather than modifying the original table
- Create a new schema based on the modified fields

The new approach is more performant by avoiding pandas conversion overhead. The table below highlights substantial performance improvements when retrieving all rows from a table containing decimal columns, particularly when compression is disabled. Even greater gains were observed with compression enabled—showing approximately an 84% improvement (6 seconds compared to 39 seconds). Benchmarking was performed against e2-dogfood, with the client located in the us-west-2 region.
![image](https://github.com/user-attachments/assets/5407b651-8ab6-4c13-b525-cf912f503ba0)

## How is this tested?

- [X] Unit tests
- [X] E2E Tests
- [X] Manually
- [ ] N/A

<!-- If Manually, please describe. -->
Benchmarking was performed against e2-dogfood, with the client located in the us-west-2 region.

## Related Tickets & Documents
