### PR TITLE
[PECOBLR-361] convert column table to arrow if arrow present

### DIFF
--- a/src/databricks/sql/client.py
+++ b/src/databricks/sql/client.py
@@ -1423,8 +1423,8 @@ class ResultSet:
                 results = pyarrow.concat_tables([results, partial_results])
             self._next_row_index += partial_results.num_rows
 
-        # If PyArrow is installed and we have a ColumnTable result,
-        # convert it to a PyArrow Table for consistency with pre-3.5.0 behavior
+        # If PyArrow is installed and we have a ColumnTable result, convert it to PyArrow Table
+        # Valid only for metadata commands result set
         if isinstance(results, ColumnTable) and pyarrow:
             data = {
                 name: col

--- a/src/databricks/sql/client.py
+++ b/src/databricks/sql/client.py
@@ -1415,9 +1415,22 @@ class ResultSet:
         while not self.has_been_closed_server_side and self.has_more_rows:
             self._fill_results_buffer()
             partial_results = self.results.remaining_rows()
-            results = pyarrow.concat_tables([results, partial_results])
+            if isinstance(results, ColumnTable) and isinstance(
+                partial_results, ColumnTable
+            ):
+                results = self.merge_columnar(results, partial_results)
+            else:
+                results = pyarrow.concat_tables([results, partial_results])
             self._next_row_index += partial_results.num_rows
 
+        # If PyArrow is installed and we have a ColumnTable result,
+        # convert it to a PyArrow Table for consistency with pre-3.5.0 behavior
+        if isinstance(results, ColumnTable) and pyarrow:
+            data = {
+                name: col
+                for name, col in zip(results.column_names, results.column_table)
+            }
+            return pyarrow.Table.from_pydict(data)
         return results
 
     def fetchall_columnar(self):

--- a/tests/e2e/test_driver.py
+++ b/tests/e2e/test_driver.py
@@ -801,6 +801,13 @@ class TestPySQLCoreSuite(
                 decimal_type = arrow_df.field(0).type
                 assert pyarrow.types.is_decimal(decimal_type)
 
+    @skipUnless(pysql_supports_arrow(), "arrow test needs arrow support")
+    def test_catalogs_returns_arrow_table(self):
+        with self.cursor() as cursor:
+            cursor.catalogs()
+            results = cursor.fetchall_arrow()
+            assert isinstance(results, pyarrow.Table)
+
     def test_close_connection_closes_cursors(self):
 
         from databricks.sql.thrift_api.TCLIService import ttypes


### PR DESCRIPTION
<!-- We welcome contributions. All patches must include a sign-off. Please see CONTRIBUTING.md for details -->

## What type of PR is this?
<!-- Check all that apply, delete what doesn't apply. -->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Oth

## Description
Added logic in `fetchall_arrow()` to convert `ColumnTable` results to a `pyarrow.Table` if `pyarrow` is installed, maintaining consistency with behavior prior to version 3.5.0. This behavior makes result set aligned with the docstring of `fetchall_pyarrow` method

## How is this tested?

- [ ] Unit tests
- [X] E2E Tests
- [X] Manually
- [ ] N/A

Introduced a new test case, `test_catalogs_returns_arrow_table`, in `tests/e2e/test_driver.py` to validate that the `fetchall_arrow` method returns a `pyarrow.Table` when used with `cursor.catalogs()`. This test is conditionally executed if Arrow support is available.

<!-- If Manually, please describe. -->

## Related Tickets & Documents
Resolves #550 
