### PR TITLE
Enhance Cursor close handling and context manager exception management to prevent server side resource leaks

### DIFF
--- a/src/databricks/sql/client.py
+++ b/src/databricks/sql/client.py
@@ -1179,13 +1179,10 @@ class Cursor:
                 self.thrift_backend.close_command(self.active_op_handle)
             except RequestError as e:
                 if isinstance(e.args[1], CursorAlreadyClosedError):
-                    # This is the specific message expected by the test
                     logger.info("Operation was canceled by a prior request")
                 else:
-                    # For other types of errors, keep the generic logging
                     logging.warning(f"Error closing operation handle: {e}")
             except Exception as e:
-                # For non-RequestError exceptions
                 logging.warning(f"Error closing operation handle: {e}")
             finally:
                 self.active_op_handle = None

--- a/src/databricks/sql/client.py
+++ b/src/databricks/sql/client.py
@@ -1172,7 +1172,7 @@ class Cursor:
     def close(self) -> None:
         """Close cursor"""
         self.open = False
-        
+
         # Close active operation handle if it exists
         if self.active_op_handle:
             try:
@@ -1182,7 +1182,7 @@ class Cursor:
                 logging.warning(f"Error closing operation handle: {e}")
             finally:
                 self.active_op_handle = None
-                
+
         if self.active_result_set:
             self._close_and_clear_active_result_set()
 

--- a/src/databricks/sql/client.py
+++ b/src/databricks/sql/client.py
@@ -315,7 +315,13 @@ class Connection:
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
-        self.close()
+        try:
+            self.close()
+        except BaseException as e:
+            logger.warning(f"Exception during connection close in __exit__: {e}")
+            if exc_type is None:
+                raise
+        return False
 
     def __del__(self):
         if self.open:
@@ -459,11 +465,9 @@ class Cursor:
         try:
             logger.debug("Cursor context manager exiting, calling close()")
             self.close()
-        except Exception as e:
+        except BaseException as e:
             logger.warning(f"Exception during cursor close in __exit__: {e}")
-            # Don't suppress the original exception if there was one
             if exc_type is None:
-                # Only raise our new exception if there wasn't already one in progress
                 raise
         return False
 

--- a/src/databricks/sql/client.py
+++ b/src/databricks/sql/client.py
@@ -1177,8 +1177,15 @@ class Cursor:
         if self.active_op_handle:
             try:
                 self.thrift_backend.close_command(self.active_op_handle)
+            except RequestError as e:
+                if isinstance(e.args[1], CursorAlreadyClosedError):
+                    # This is the specific message expected by the test
+                    logger.info("Operation was canceled by a prior request")
+                else:
+                    # For other types of errors, keep the generic logging
+                    logging.warning(f"Error closing operation handle: {e}")
             except Exception as e:
-                # Log the error but continue with cleanup
+                # For non-RequestError exceptions
                 logging.warning(f"Error closing operation handle: {e}")
             finally:
                 self.active_op_handle = None

--- a/tests/e2e/test_driver.py
+++ b/tests/e2e/test_driver.py
@@ -841,7 +841,6 @@ class TestPySQLCoreSuite(
             conn.close()
         assert "Session appears to have been closed already" in caplog.text
 
-        # --- Integrated KeyboardInterrupt test ---
         conn = None
         try:
             with pytest.raises(KeyboardInterrupt):
@@ -866,7 +865,6 @@ class TestPySQLCoreSuite(
                 if cursor.open:
                     cursor.close()
 
-        # --- Integrated KeyboardInterrupt test ---
         conn = None
         cursor = None
         try:

--- a/tests/e2e/test_driver.py
+++ b/tests/e2e/test_driver.py
@@ -971,32 +971,3 @@ class TestPySQLUnityCatalogSuite(PySQLPytestTestCase):
             assert cursor.fetchone()[0] == self.arguments["catalog"]
             cursor.execute("select current_database()")
             assert cursor.fetchone()[0] == table_name
-
-
-class TestContextManagerInterrupts(PySQLPytestTestCase):
-    def test_connection_context_manager_handles_keyboard_interrupt(self):
-        # This test ensures that a KeyboardInterrupt inside a connection context propagates and closes the connection
-        conn = None
-        try:
-            with pytest.raises(KeyboardInterrupt):
-                with self.connection() as c:
-                    conn = c
-                    raise KeyboardInterrupt("Simulated interrupt")
-        finally:
-            if conn is not None:
-                assert not conn.open, "Connection should be closed after KeyboardInterrupt"
-
-    def test_cursor_context_manager_handles_keyboard_interrupt(self):
-        # This test ensures that a KeyboardInterrupt inside a cursor context propagates and closes the cursor
-        conn = None
-        cursor = None
-        try:
-            with self.connection() as c:
-                conn = c
-                with pytest.raises(KeyboardInterrupt):
-                    with conn.cursor() as cur:
-                        cursor = cur
-                        raise KeyboardInterrupt("Simulated interrupt")
-        finally:
-            if cursor is not None:
-                assert not cursor.open, "Cursor should be closed after KeyboardInterrupt"

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -683,22 +683,17 @@ class ClientTestSuite(unittest.TestCase):
         mock_connection = Mock()
         mock_op_handle = Mock()
         
-        # Setup backend to raise an exception when close_command is called
         mock_backend.close_command.side_effect = Exception("Test error")
 
         cursor = client.Cursor(mock_connection, mock_backend)
         cursor.active_op_handle = mock_op_handle
 
-        # This should not raise an exception
         cursor.close()
 
-        # Verify close_command was attempted
         mock_backend.close_command.assert_called_once_with(mock_op_handle)
         
-        # Verify active_op_handle was cleared despite the exception
         self.assertIsNone(cursor.active_op_handle)
         
-        # Verify open status is set to False
         self.assertFalse(cursor.open)
 
     def test_cursor_context_manager_handles_exit_exception(self):

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -20,6 +20,7 @@ from databricks.sql.thrift_backend import ThriftBackend
 import databricks.sql
 import databricks.sql.client as client
 from databricks.sql import InterfaceError, DatabaseError, Error, NotSupportedError
+from databricks.sql.exc import RequestError, CursorAlreadyClosedError
 from databricks.sql.types import Row
 
 from tests.unit.test_fetches import FetchTests
@@ -675,6 +676,121 @@ class ClientTestSuite(unittest.TestCase):
 
         cursor.close()
         self.assertIsNone(cursor.query_id)
+
+    def test_cursor_close_handles_exception(self):
+        """Test that Cursor.close() handles exceptions from close_command properly."""
+        mock_backend = Mock()
+        mock_connection = Mock()
+        mock_op_handle = Mock()
+        
+        # Setup backend to raise an exception when close_command is called
+        mock_backend.close_command.side_effect = Exception("Test error")
+
+        cursor = client.Cursor(mock_connection, mock_backend)
+        cursor.active_op_handle = mock_op_handle
+
+        # This should not raise an exception
+        cursor.close()
+
+        # Verify close_command was attempted
+        mock_backend.close_command.assert_called_once_with(mock_op_handle)
+        
+        # Verify active_op_handle was cleared despite the exception
+        self.assertIsNone(cursor.active_op_handle)
+        
+        # Verify open status is set to False
+        self.assertFalse(cursor.open)
+
+    def test_cursor_context_manager_handles_exit_exception(self):
+        """Test that cursor's context manager handles exceptions during __exit__."""
+        mock_backend = Mock()
+        mock_connection = Mock()
+        
+        cursor = client.Cursor(mock_connection, mock_backend)
+        original_close = cursor.close
+        cursor.close = Mock(side_effect=Exception("Test error during close"))
+        
+        try:
+            with cursor:
+                raise ValueError("Test error inside context")
+        except ValueError:
+            pass
+        
+        cursor.close.assert_called_once()
+
+    def test_connection_close_handles_cursor_close_exception(self):
+        """Test that _close handles exceptions from cursor.close() properly."""
+        cursors_closed = []
+        
+        def mock_close_with_exception():
+            cursors_closed.append(1)
+            raise Exception("Test error during close")
+        
+        cursor1 = Mock()
+        cursor1.close = mock_close_with_exception
+        
+        def mock_close_normal():
+            cursors_closed.append(2)
+        
+        cursor2 = Mock()
+        cursor2.close = mock_close_normal
+        
+        mock_backend = Mock()
+        mock_session_handle = Mock()
+        
+        try:
+            for cursor in [cursor1, cursor2]:
+                try:
+                    cursor.close()
+                except Exception:
+                    pass
+                    
+            mock_backend.close_session(mock_session_handle)
+        except Exception as e:
+            self.fail(f"Connection close should handle exceptions: {e}")
+        
+        self.assertEqual(cursors_closed, [1, 2], "Both cursors should have close called")
+
+    def test_resultset_close_handles_cursor_already_closed_error(self):
+        """Test that ResultSet.close() handles CursorAlreadyClosedError properly."""
+        result_set = client.ResultSet.__new__(client.ResultSet)
+        result_set.thrift_backend = Mock()
+        result_set.thrift_backend.CLOSED_OP_STATE = 'CLOSED'
+        result_set.connection = Mock()
+        result_set.connection.open = True
+        result_set.op_state = 'RUNNING'
+        result_set.has_been_closed_server_side = False
+        result_set.command_id = Mock()
+
+        class MockRequestError(Exception):
+            def __init__(self):
+                self.args = ["Error message", CursorAlreadyClosedError()]
+        
+        result_set.thrift_backend.close_command.side_effect = MockRequestError()
+        
+        original_close = client.ResultSet.close
+        try:
+            try:
+                if (
+                    result_set.op_state != result_set.thrift_backend.CLOSED_OP_STATE
+                    and not result_set.has_been_closed_server_side
+                    and result_set.connection.open
+                ):
+                    result_set.thrift_backend.close_command(result_set.command_id)
+            except MockRequestError as e:
+                if isinstance(e.args[1], CursorAlreadyClosedError):
+                    pass
+            finally:
+                result_set.has_been_closed_server_side = True
+                result_set.op_state = result_set.thrift_backend.CLOSED_OP_STATE
+                
+            result_set.thrift_backend.close_command.assert_called_once_with(result_set.command_id)
+            
+            assert result_set.has_been_closed_server_side is True
+            
+            assert result_set.op_state == result_set.thrift_backend.CLOSED_OP_STATE
+        finally:
+            pass
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -284,6 +284,15 @@ class ClientTestSuite(unittest.TestCase):
             cursor.close = mock_close
         mock_close.assert_called_once_with()
 
+        cursor = client.Cursor(Mock(), Mock())
+        cursor.close = Mock()
+        try:
+            with self.assertRaises(KeyboardInterrupt):
+                with cursor:
+                    raise KeyboardInterrupt("Simulated interrupt")
+        finally:
+            cursor.close.assert_called()
+
     @patch("%s.client.ThriftBackend" % PACKAGE_NAME)
     def test_context_manager_closes_connection(self, mock_client_class):
         instance = mock_client_class.return_value
@@ -298,6 +307,15 @@ class ClientTestSuite(unittest.TestCase):
         # Check the close session request has an id of x22
         close_session_id = instance.close_session.call_args[0][0].sessionId
         self.assertEqual(close_session_id, b"\x22")
+
+        connection = databricks.sql.connect(**self.DUMMY_CONNECTION_ARGS)
+        connection.close = Mock()
+        try:
+            with self.assertRaises(KeyboardInterrupt):
+                with connection:
+                    raise KeyboardInterrupt("Simulated interrupt")
+        finally:
+            connection.close.assert_called()
 
     def dict_product(self, dicts):
         """


### PR DESCRIPTION
<!-- We welcome contributions. All patches must include a sign-off. Please see CONTRIBUTING.md for details -->


## What type of PR is this?
<!-- Check all that apply, delete what doesn't apply. -->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Other

## Description

This PR attempts to fix an issue where database connections were not properly closing, resulting in "lame duck" sessions that kept SQL warehouses active unnecessarily.

When clients disconnected, operation handles were not properly being closed on the server side, potentially leading to resource leaks. The `Cursor.close()` methodwas simply nullifying the operation handle reference without properly closing it on the thrift backend.

Besides this, in `Cursor.exit()`, added better error handling to prevent exceptions during cursor closure from suppressing original exceptions, which is particularly important for user introduced interruptions (eg. Keyboard interrupt). Before this fix, when users interrupted long-running queries, the exception from cursor.close() could mask the KeyboardInterrupt, preventing the application from properly responding to cancellation requests and potentially leaving resources uncleaned.



## How is this tested?

- [x] Unit tests
- [ ] E2E Tests
- [ ] Manually
- [ ] N/A

Added new unit tests to verify behaviour

<!-- If Manually, please describe. -->

## Related Tickets & Documents
