### PR TITLE
Separate Session related functionality from Connection class 

### DIFF
--- a/src/databricks/sql/client.py
+++ b/src/databricks/sql/client.py
@@ -313,6 +313,11 @@ class Connection:
         """Delegate to Session class static method"""
         return Session.get_protocol_version(openSessionResp)
 
+    @property
+    def open(self) -> bool:
+        """Return whether the connection is open by checking if the session is open."""
+        return self.session.open
+
     def cursor(
         self,
         arraysize: int = DEFAULT_ARRAY_SIZE,

--- a/src/databricks/sql/client.py
+++ b/src/databricks/sql/client.py
@@ -235,10 +235,13 @@ class Connection:
             catalog,
             schema,
             _use_arrow_native_complex_types,
-            **kwargs
+            **kwargs,
         )
-        
-        logger.info("Successfully opened connection with session " + str(self.get_session_id_hex()))
+
+        logger.info(
+            "Successfully opened connection with session "
+            + str(self.get_session_id_hex())
+        )
 
         self.use_inline_params = self._set_use_inline_params_with_warning(
             kwargs.get("use_inline_params", False)

--- a/src/databricks/sql/client.py
+++ b/src/databricks/sql/client.py
@@ -282,7 +282,7 @@ class Connection:
         self.close()
 
     def __del__(self):
-        if self.session.open:
+        if self.open:
             logger.debug(
                 "Closing unclosed connection for session "
                 "{}".format(self.get_session_id_hex())
@@ -331,7 +331,7 @@ class Connection:
 
         Will throw an Error if the connection has been closed.
         """
-        if not self.session.open:
+        if not self.open:
             raise Error("Cannot create cursor from closed connection")
 
         cursor = Cursor(
@@ -1437,7 +1437,7 @@ class ResultSet:
             if (
                 self.op_state != self.thrift_backend.CLOSED_OP_STATE
                 and not self.has_been_closed_server_side
-                and self.connection.session.open
+                and self.connection.open
             ):
                 self.thrift_backend.close_command(self.command_id)
         except RequestError as e:

--- a/src/databricks/sql/session.py
+++ b/src/databricks/sql/session.py
@@ -26,13 +26,13 @@ class Session:
     ) -> None:
         """
         Create a session to a Databricks SQL endpoint or a Databricks cluster.
-        
+
         This class handles all session-related behavior and communication with the backend.
         """
         self.open = False
         self.host = server_hostname
         self.port = kwargs.get("_port", 443)
-        
+
         auth_provider = get_python_sql_connector_auth_provider(
             server_hostname, **kwargs
         )
@@ -143,4 +143,4 @@ class Session:
         except Exception as e:
             logger.error(f"Attempt to close session raised a local exception: {e}")
 
-        self.open = False 
+        self.open = False

--- a/src/databricks/sql/session.py
+++ b/src/databricks/sql/session.py
@@ -1,0 +1,146 @@
+import logging
+from typing import Dict, Tuple, List, Optional, Any
+
+from databricks.sql.thrift_api.TCLIService import ttypes
+from databricks.sql.types import SSLOptions
+from databricks.sql.auth.auth import get_python_sql_connector_auth_provider
+from databricks.sql.exc import SessionAlreadyClosedError, DatabaseError, RequestError
+from databricks.sql import __version__
+from databricks.sql import USER_AGENT_NAME
+from databricks.sql.thrift_backend import ThriftBackend
+
+logger = logging.getLogger(__name__)
+
+
+class Session:
+    def __init__(
+        self,
+        server_hostname: str,
+        http_path: str,
+        http_headers: Optional[List[Tuple[str, str]]] = None,
+        session_configuration: Optional[Dict[str, Any]] = None,
+        catalog: Optional[str] = None,
+        schema: Optional[str] = None,
+        _use_arrow_native_complex_types: Optional[bool] = True,
+        **kwargs,
+    ) -> None:
+        """
+        Create a session to a Databricks SQL endpoint or a Databricks cluster.
+        
+        This class handles all session-related behavior and communication with the backend.
+        """
+        self.open = False
+        self.host = server_hostname
+        self.port = kwargs.get("_port", 443)
+        
+        auth_provider = get_python_sql_connector_auth_provider(
+            server_hostname, **kwargs
+        )
+
+        user_agent_entry = kwargs.get("user_agent_entry")
+        if user_agent_entry is None:
+            user_agent_entry = kwargs.get("_user_agent_entry")
+            if user_agent_entry is not None:
+                logger.warning(
+                    "[WARN] Parameter '_user_agent_entry' is deprecated; use 'user_agent_entry' instead. "
+                    "This parameter will be removed in the upcoming releases."
+                )
+
+        if user_agent_entry:
+            useragent_header = "{}/{} ({})".format(
+                USER_AGENT_NAME, __version__, user_agent_entry
+            )
+        else:
+            useragent_header = "{}/{}".format(USER_AGENT_NAME, __version__)
+
+        base_headers = [("User-Agent", useragent_header)]
+
+        self._ssl_options = SSLOptions(
+            # Double negation is generally a bad thing, but we have to keep backward compatibility
+            tls_verify=not kwargs.get(
+                "_tls_no_verify", False
+            ),  # by default - verify cert and host
+            tls_verify_hostname=kwargs.get("_tls_verify_hostname", True),
+            tls_trusted_ca_file=kwargs.get("_tls_trusted_ca_file"),
+            tls_client_cert_file=kwargs.get("_tls_client_cert_file"),
+            tls_client_cert_key_file=kwargs.get("_tls_client_cert_key_file"),
+            tls_client_cert_key_password=kwargs.get("_tls_client_cert_key_password"),
+        )
+
+        self.thrift_backend = ThriftBackend(
+            self.host,
+            self.port,
+            http_path,
+            (http_headers or []) + base_headers,
+            auth_provider,
+            ssl_options=self._ssl_options,
+            _use_arrow_native_complex_types=_use_arrow_native_complex_types,
+            **kwargs,
+        )
+
+        self._open_session_resp = self.thrift_backend.open_session(
+            session_configuration, catalog, schema
+        )
+        self._session_handle = self._open_session_resp.sessionHandle
+        self.protocol_version = self.get_protocol_version(self._open_session_resp)
+        self.open = True
+        logger.info("Successfully opened session " + str(self.get_session_id_hex()))
+
+    @staticmethod
+    def get_protocol_version(openSessionResp):
+        """
+        Since the sessionHandle will sometimes have a serverProtocolVersion, it takes
+        precedence over the serverProtocolVersion defined in the OpenSessionResponse.
+        """
+        if (
+            openSessionResp.sessionHandle
+            and hasattr(openSessionResp.sessionHandle, "serverProtocolVersion")
+            and openSessionResp.sessionHandle.serverProtocolVersion
+        ):
+            return openSessionResp.sessionHandle.serverProtocolVersion
+        return openSessionResp.serverProtocolVersion
+
+    @staticmethod
+    def server_parameterized_queries_enabled(protocolVersion):
+        if (
+            protocolVersion
+            and protocolVersion >= ttypes.TProtocolVersion.SPARK_CLI_SERVICE_PROTOCOL_V8
+        ):
+            return True
+        else:
+            return False
+
+    def get_session_handle(self):
+        return self._session_handle
+
+    def get_session_id(self):
+        return self.thrift_backend.handle_to_id(self._session_handle)
+
+    def get_session_id_hex(self):
+        return self.thrift_backend.handle_to_hex_id(self._session_handle)
+
+    def close(self) -> None:
+        """Close the underlying session."""
+        logger.info(f"Closing session {self.get_session_id_hex()}")
+        if not self.open:
+            logger.debug("Session appears to have been closed already")
+            return
+
+        try:
+            self.thrift_backend.close_session(self._session_handle)
+        except RequestError as e:
+            if isinstance(e.args[1], SessionAlreadyClosedError):
+                logger.info("Session was closed by a prior request")
+        except DatabaseError as e:
+            if "Invalid SessionHandle" in str(e):
+                logger.warning(
+                    f"Attempted to close session that was already closed: {e}"
+                )
+            else:
+                logger.warning(
+                    f"Attempt to close session raised an exception at the server: {e}"
+                )
+        except Exception as e:
+            logger.error(f"Attempt to close session raised a local exception: {e}")
+
+        self.open = False 

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -146,7 +146,7 @@ class ClientTestSuite(unittest.TestCase):
         mock_session = Mock()
         mock_session.open = True
         type(mock_connection).session = PropertyMock(return_value=mock_session)
-        
+
         result_set = client.ResultSet(
             mock_connection, mock_results_response, mock_thrift_backend
         )

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -1,0 +1,187 @@
+import unittest
+from unittest.mock import patch, MagicMock, Mock, PropertyMock
+import gc
+
+from databricks.sql.thrift_api.TCLIService.ttypes import (
+    TOpenSessionResp,
+)
+
+import databricks.sql
+
+
+class SessionTestSuite(unittest.TestCase):
+    """
+    Unit tests for Session functionality 
+    """
+
+    PACKAGE_NAME = "databricks.sql"
+    DUMMY_CONNECTION_ARGS = {
+        "server_hostname": "foo",
+        "http_path": "dummy_path",
+        "access_token": "tok",
+    }
+
+    @patch("%s.session.ThriftBackend" % PACKAGE_NAME)
+    def test_close_uses_the_correct_session_id(self, mock_client_class):
+        instance = mock_client_class.return_value
+
+        mock_open_session_resp = MagicMock(spec=TOpenSessionResp)()
+        mock_open_session_resp.sessionHandle.sessionId = b"\x22"
+        instance.open_session.return_value = mock_open_session_resp
+
+        connection = databricks.sql.connect(**self.DUMMY_CONNECTION_ARGS)
+        connection.close()
+
+        # Check the close session request has an id of x22
+        close_session_id = instance.close_session.call_args[0][0].sessionId
+        self.assertEqual(close_session_id, b"\x22")
+
+    @patch("%s.session.ThriftBackend" % PACKAGE_NAME)
+    def test_auth_args(self, mock_client_class):
+        # Test that the following auth args work:
+        # token = foo,
+        # token = None, _tls_client_cert_file = something, _use_cert_as_auth = True
+        connection_args = [
+            {
+                "server_hostname": "foo",
+                "http_path": None,
+                "access_token": "tok",
+            },
+            {
+                "server_hostname": "foo",
+                "http_path": None,
+                "_tls_client_cert_file": "something",
+                "_use_cert_as_auth": True,
+                "access_token": None,
+            },
+        ]
+
+        for args in connection_args:
+            connection = databricks.sql.connect(**args)
+            host, port, http_path, *_ = mock_client_class.call_args[0]
+            self.assertEqual(args["server_hostname"], host)
+            self.assertEqual(args["http_path"], http_path)
+            connection.close()
+
+    @patch("%s.session.ThriftBackend" % PACKAGE_NAME)
+    def test_http_header_passthrough(self, mock_client_class):
+        http_headers = [("foo", "bar")]
+        databricks.sql.connect(**self.DUMMY_CONNECTION_ARGS, http_headers=http_headers)
+
+        call_args = mock_client_class.call_args[0][3]
+        self.assertIn(("foo", "bar"), call_args)
+
+    @patch("%s.session.ThriftBackend" % PACKAGE_NAME)
+    def test_tls_arg_passthrough(self, mock_client_class):
+        databricks.sql.connect(
+            **self.DUMMY_CONNECTION_ARGS,
+            _tls_verify_hostname="hostname",
+            _tls_trusted_ca_file="trusted ca file",
+            _tls_client_cert_key_file="trusted client cert",
+            _tls_client_cert_key_password="key password",
+        )
+
+        kwargs = mock_client_class.call_args[1]
+        self.assertEqual(kwargs["_tls_verify_hostname"], "hostname")
+        self.assertEqual(kwargs["_tls_trusted_ca_file"], "trusted ca file")
+        self.assertEqual(kwargs["_tls_client_cert_key_file"], "trusted client cert")
+        self.assertEqual(kwargs["_tls_client_cert_key_password"], "key password")
+
+    @patch("%s.session.ThriftBackend" % PACKAGE_NAME)
+    def test_useragent_header(self, mock_client_class):
+        databricks.sql.connect(**self.DUMMY_CONNECTION_ARGS)
+
+        http_headers = mock_client_class.call_args[0][3]
+        user_agent_header = (
+            "User-Agent",
+            "{}/{}".format(databricks.sql.USER_AGENT_NAME, databricks.sql.__version__),
+        )
+        self.assertIn(user_agent_header, http_headers)
+
+        databricks.sql.connect(**self.DUMMY_CONNECTION_ARGS, user_agent_entry="foobar")
+        user_agent_header_with_entry = (
+            "User-Agent",
+            "{}/{} ({})".format(
+                databricks.sql.USER_AGENT_NAME, databricks.sql.__version__, "foobar"
+            ),
+        )
+        http_headers = mock_client_class.call_args[0][3]
+        self.assertIn(user_agent_header_with_entry, http_headers)
+
+    @patch("%s.session.ThriftBackend" % PACKAGE_NAME)
+    def test_context_manager_closes_connection(self, mock_client_class):
+        instance = mock_client_class.return_value
+
+        mock_open_session_resp = MagicMock(spec=TOpenSessionResp)()
+        mock_open_session_resp.sessionHandle.sessionId = b"\x22"
+        instance.open_session.return_value = mock_open_session_resp
+
+        with databricks.sql.connect(**self.DUMMY_CONNECTION_ARGS) as connection:
+            pass
+
+        # Check the close session request has an id of x22
+        close_session_id = instance.close_session.call_args[0][0].sessionId
+        self.assertEqual(close_session_id, b"\x22")
+
+    @patch("%s.session.ThriftBackend" % PACKAGE_NAME)
+    def test_max_number_of_retries_passthrough(self, mock_client_class):
+        databricks.sql.connect(
+            _retry_stop_after_attempts_count=54, **self.DUMMY_CONNECTION_ARGS
+        )
+
+        self.assertEqual(
+            mock_client_class.call_args[1]["_retry_stop_after_attempts_count"], 54
+        )
+
+    @patch("%s.session.ThriftBackend" % PACKAGE_NAME)
+    def test_socket_timeout_passthrough(self, mock_client_class):
+        databricks.sql.connect(_socket_timeout=234, **self.DUMMY_CONNECTION_ARGS)
+        self.assertEqual(mock_client_class.call_args[1]["_socket_timeout"], 234)
+
+    @patch("%s.session.ThriftBackend" % PACKAGE_NAME)
+    def test_configuration_passthrough(self, mock_client_class):
+        mock_session_config = Mock()
+        databricks.sql.connect(
+            session_configuration=mock_session_config, **self.DUMMY_CONNECTION_ARGS
+        )
+
+        self.assertEqual(
+            mock_client_class.return_value.open_session.call_args[0][0],
+            mock_session_config,
+        )
+
+    @patch("%s.session.ThriftBackend" % PACKAGE_NAME)
+    def test_initial_namespace_passthrough(self, mock_client_class):
+        mock_cat = Mock()
+        mock_schem = Mock()
+
+        databricks.sql.connect(
+            **self.DUMMY_CONNECTION_ARGS, catalog=mock_cat, schema=mock_schem
+        )
+        self.assertEqual(
+            mock_client_class.return_value.open_session.call_args[0][1], mock_cat
+        )
+        self.assertEqual(
+            mock_client_class.return_value.open_session.call_args[0][2], mock_schem
+        )
+
+    @patch("%s.session.ThriftBackend" % PACKAGE_NAME)
+    def test_finalizer_closes_abandoned_connection(self, mock_client_class):
+        instance = mock_client_class.return_value
+
+        mock_open_session_resp = MagicMock(spec=TOpenSessionResp)()
+        mock_open_session_resp.sessionHandle.sessionId = b"\x22"
+        instance.open_session.return_value = mock_open_session_resp
+
+        databricks.sql.connect(**self.DUMMY_CONNECTION_ARGS)
+
+        # not strictly necessary as the refcount is 0, but just to be sure
+        gc.collect()
+
+        # Check the close session request has an id of x22
+        close_session_id = instance.close_session.call_args[0][0].sessionId
+        self.assertEqual(close_session_id, b"\x22")
+
+
+if __name__ == "__main__":
+    unittest.main() 

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -11,7 +11,7 @@ import databricks.sql
 
 class SessionTestSuite(unittest.TestCase):
     """
-    Unit tests for Session functionality 
+    Unit tests for Session functionality
     """
 
     PACKAGE_NAME = "databricks.sql"
@@ -184,4 +184,4 @@ class SessionTestSuite(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    unittest.main() 
+    unittest.main()

--- a/tests/unit/test_thrift_backend.py
+++ b/tests/unit/test_thrift_backend.py
@@ -86,7 +86,9 @@ class ThriftBackendTestSuite(unittest.TestCase):
 
     def _make_type_desc(self, type):
         return ttypes.TTypeDesc(
-            types=[ttypes.TTypeEntry(primitiveEntry=ttypes.TPrimitiveTypeEntry(type=type))]
+            types=[
+                ttypes.TTypeEntry(primitiveEntry=ttypes.TPrimitiveTypeEntry(type=type))
+            ]
         )
 
     def _make_fake_thrift_backend(self):


### PR DESCRIPTION
## What type of PR is this?
- [x] Refactor

## Description
Separate the Session related functionality from the Connection class, in order to: 
- Better align the object structure with that of the JDBC driver 
- Further abstract the backend implementation details from the connection, to eventually give way to the introduction of SEA. 

## How is this tested?
- [x] Unit tests
    - some of the existing unit tests were slightly altered to account for the introduction of the Session class. No unit tests were removed or introduced. 
- [ ] E2E Tests
- [ ] Manually
- [ ] N/A

## Related Tickets & Documents
https://docs.google.com/document/d/1Y-eXLhNqqhrMVGnOlG8sdFrCxBTN1GdQvuKG4IfHmo0/edit?usp=sharing