### PR TITLE
fix deprecated logger.warn usage

### DIFF
--- a/src/databricks/sql/thrift_backend.py
+++ b/src/databricks/sql/thrift_backend.py
@@ -175,7 +175,7 @@ class ThriftBackend:
 
         if _max_redirects:
             if _max_redirects > self._retry_stop_after_attempts_count:
-                logger.warn(
+                logger.warning(
                     "_retry_max_redirects > _retry_stop_after_attempts_count so it will have no affect!"
                 )
             urllib3_kwargs = {"redirect": _max_redirects}


### PR DESCRIPTION
<!-- We welcome contributions. All patches must include a sign-off. Please see CONTRIBUTING.md for details -->


## What type of PR is this?
<!-- Check all that apply, delete what doesn't apply. -->

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Other

## Description
- Modify the usage of the deprecated logger method.
    - `src/databricks/sql/thrift_backend.py`:
        - Use `logger.warning` instead of `logger.warn`.

## How is this tested?

- [x] Unit tests
- [ ] E2E Tests
- [ ] Manually
- [ ] N/A

<!-- If Manually, please describe. -->
