### PR TITLE
fix `test_closing_connection_closes_commands`

### DIFF
--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -31,73 +31,6 @@ from tests.unit.test_thrift_backend import ThriftBackendTestSuite
 from tests.unit.test_arrow_queue import ArrowQueueSuite
 
 
-@pytest.mark.parametrize("closed", [True, False])
-@patch("databricks.sql.client.ThriftBackend")
-def test_closing_connection_closes_commands(mock_thrift_client_class, closed):
-    """Test that closing a connection properly closes commands.
-
-    This test verifies that when a connection is closed:
-    1. All result sets are marked as closed server-side
-    2. The operation state is set to CLOSED
-    3. Backend.close_command is called only for commands that weren't already closed
-
-    Args:
-        mock_thrift_client_class: Mock for ThriftBackend class
-        closed: Parameter indicating if the command is already closed
-    """
-    # Set initial state based on whether the command is already closed
-    initial_state = (
-        TOperationState.FINISHED_STATE if not closed else TOperationState.CLOSED_STATE
-    )
-
-    # Mock the execute response with controlled state
-    mock_execute_response = Mock(spec=ExecuteResponse)
-    mock_execute_response.status = initial_state
-    mock_execute_response.has_been_closed_server_side = closed
-    mock_execute_response.is_staging_operation = False
-
-    # Mock the backend that will be used
-    mock_backend = Mock(spec=ThriftBackend)
-    mock_thrift_client_class.return_value = mock_backend
-
-    # Create connection and cursor
-    connection = databricks.sql.connect(
-        server_hostname="foo",
-        http_path="dummy_path",
-        access_token="tok",
-    )
-    cursor = connection.cursor()
-
-    # Mock execute_command to return our execute response
-    cursor.thrift_backend.execute_command = Mock(return_value=mock_execute_response)
-
-    # Execute a command
-    cursor.execute("SELECT 1")
-    
-    # Get the active result set for later assertions
-    active_result_set = cursor.active_result_set
-    
-    # Close the connection
-    connection.close()
-
-    # Verify the close logic worked:
-    # 1. has_been_closed_server_side should always be True after close()
-    assert active_result_set.has_been_closed_server_side is True
-
-    # 2. op_state should always be CLOSED after close()
-    assert active_result_set.op_state == connection.thrift_backend.CLOSED_OP_STATE
-
-    # 3. Backend close_command should be called appropriately
-    if not closed:
-        # Should have called backend.close_command during the close chain
-        mock_backend.close_command.assert_called_once_with(
-            mock_execute_response.command_handle
-        )
-    else:
-        # Should NOT have called backend.close_command (already closed)
-        mock_backend.close_command.assert_not_called()
-
-
 class ThriftBackendMockFactory:
     @classmethod
     def new(cls):
@@ -237,6 +170,80 @@ class ClientTestSuite(unittest.TestCase):
         )
         http_headers = mock_client_class.call_args[0][3]
         self.assertIn(user_agent_header_with_entry, http_headers)
+
+    @patch("databricks.sql.client.ThriftBackend")
+    def test_closing_connection_closes_commands(self, mock_thrift_client_class):
+        """Test that closing a connection properly closes commands.
+
+        This test verifies that when a connection is closed:
+        1. All result sets are marked as closed server-side
+        2. The operation state is set to CLOSED
+        3. Backend.close_command is called only for commands that weren't already closed
+
+        Args:
+            mock_thrift_client_class: Mock for ThriftBackend class
+            closed: Parameter indicating if the command is already closed
+        """
+        for closed in (True, False):
+            with self.subTest(closed=closed):
+                # Set initial state based on whether the command is already closed
+                initial_state = (
+                    TOperationState.FINISHED_STATE
+                    if not closed
+                    else TOperationState.CLOSED_STATE
+                )
+
+                # Mock the execute response with controlled state
+                mock_execute_response = Mock(spec=ExecuteResponse)
+                mock_execute_response.status = initial_state
+                mock_execute_response.has_been_closed_server_side = closed
+                mock_execute_response.is_staging_operation = False
+
+                # Mock the backend that will be used
+                mock_backend = Mock(spec=ThriftBackend)
+                mock_thrift_client_class.return_value = mock_backend
+
+                # Create connection and cursor
+                connection = databricks.sql.connect(
+                    server_hostname="foo",
+                    http_path="dummy_path",
+                    access_token="tok",
+                )
+                cursor = connection.cursor()
+
+                # Mock execute_command to return our execute response
+                cursor.thrift_backend.execute_command = Mock(
+                    return_value=mock_execute_response
+                )
+
+                # Execute a command
+                cursor.execute("SELECT 1")
+
+                # Get the active result set for later assertions
+                active_result_set = cursor.active_result_set
+
+                # Close the connection
+                connection.close()
+
+                # Verify the close logic worked:
+                # 1. has_been_closed_server_side should always be True after close()
+                assert active_result_set.has_been_closed_server_side is True
+
+                # 2. op_state should always be CLOSED after close()
+                assert (
+                    active_result_set.op_state
+                    == connection.thrift_backend.CLOSED_OP_STATE
+                )
+
+                # 3. Backend close_command should be called appropriately
+                if not closed:
+                    # Should have called backend.close_command during the close chain
+                    mock_backend.close_command.assert_called_once_with(
+                        mock_execute_response.command_handle
+                    )
+                else:
+                    # Should NOT have called backend.close_command (already closed)
+                    mock_backend.close_command.assert_not_called()
 
     @patch("%s.client.ThriftBackend" % PACKAGE_NAME)
     def test_cant_open_cursor_on_closed_connection(self, mock_client_class):

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -2,7 +2,6 @@ import gc
 import re
 import sys
 import unittest
-import pytest
 from unittest.mock import patch, MagicMock, Mock, PropertyMock
 import itertools
 from decimal import Decimal

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -187,10 +187,8 @@ class ClientTestSuite(unittest.TestCase):
                 mock_execute_response.has_been_closed_server_side = closed
                 mock_execute_response.is_staging_operation = False
 
-                # Mock the backend that will be used by the real ThriftResultSet
+                # Mock the backend that will be used 
                 mock_backend = Mock(spec=ThriftBackend)
-
-                # Configure the decorator's mock to return our specific mock_backend
                 mock_thrift_client_class.return_value = mock_backend
 
                 # Create connection and cursor
@@ -207,19 +205,16 @@ class ClientTestSuite(unittest.TestCase):
                 cursor.thrift_backend.execute_command = Mock(
                     return_value=mock_execute_response
                 )
-
-                # Execute a command - this should set cursor.active_result_set to our real result set
                 cursor.execute("SELECT 1")
 
                 # Verify that cursor.execute() set up the result set correctly
                 active_result_set = cursor.active_result_set
                 self.assertEqual(active_result_set.has_been_closed_server_side, closed)
 
-                # Close the connection - this should trigger the real close chain:
-                # connection.close() -> cursor.close() -> result_set.close()
+                # Close the connection 
                 connection.close()
 
-                # Verify the REAL close logic worked through the chain:
+                # Verify the close logic worked:
                 # 1. has_been_closed_server_side should always be True after close()
                 self.assertTrue(active_result_set.has_been_closed_server_side)
 

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -68,18 +68,15 @@ def test_closing_connection_closes_commands(mock_thrift_client_class, closed):
     )
     cursor = connection.cursor()
 
-    # Verify initial state
-    assert mock_execute_response.has_been_closed_server_side == closed
-    assert mock_execute_response.status == initial_state
-
     # Mock execute_command to return our execute response
     cursor.thrift_backend.execute_command = Mock(return_value=mock_execute_response)
+
+    # Execute a command
     cursor.execute("SELECT 1")
-
-    # Verify that cursor.execute() set up the result set correctly
+    
+    # Get the active result set for later assertions
     active_result_set = cursor.active_result_set
-    assert active_result_set.has_been_closed_server_side == closed
-
+    
     # Close the connection
     connection.close()
 

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -2,6 +2,7 @@ import gc
 import re
 import sys
 import unittest
+import pytest
 from unittest.mock import patch, MagicMock, Mock, PropertyMock
 import itertools
 from decimal import Decimal
@@ -28,6 +29,76 @@ from databricks.sql.utils import ExecuteResponse
 from tests.unit.test_fetches import FetchTests
 from tests.unit.test_thrift_backend import ThriftBackendTestSuite
 from tests.unit.test_arrow_queue import ArrowQueueSuite
+
+
+@pytest.mark.parametrize("closed", [True, False])
+@patch("databricks.sql.client.ThriftBackend")
+def test_closing_connection_closes_commands(mock_thrift_client_class, closed):
+    """Test that closing a connection properly closes commands.
+
+    This test verifies that when a connection is closed:
+    1. All result sets are marked as closed server-side
+    2. The operation state is set to CLOSED
+    3. Backend.close_command is called only for commands that weren't already closed
+
+    Args:
+        mock_thrift_client_class: Mock for ThriftBackend class
+        closed: Parameter indicating if the command is already closed
+    """
+    # Set initial state based on whether the command is already closed
+    initial_state = (
+        TOperationState.FINISHED_STATE if not closed else TOperationState.CLOSED_STATE
+    )
+
+    # Mock the execute response with controlled state
+    mock_execute_response = Mock(spec=ExecuteResponse)
+    mock_execute_response.status = initial_state
+    mock_execute_response.has_been_closed_server_side = closed
+    mock_execute_response.is_staging_operation = False
+
+    # Mock the backend that will be used
+    mock_backend = Mock(spec=ThriftBackend)
+    mock_thrift_client_class.return_value = mock_backend
+
+    # Create connection and cursor
+    connection = databricks.sql.connect(
+        server_hostname="foo",
+        http_path="dummy_path",
+        access_token="tok",
+    )
+    cursor = connection.cursor()
+
+    # Verify initial state
+    assert mock_execute_response.has_been_closed_server_side == closed
+    assert mock_execute_response.status == initial_state
+
+    # Mock execute_command to return our execute response
+    cursor.thrift_backend.execute_command = Mock(return_value=mock_execute_response)
+    cursor.execute("SELECT 1")
+
+    # Verify that cursor.execute() set up the result set correctly
+    active_result_set = cursor.active_result_set
+    assert active_result_set.has_been_closed_server_side == closed
+
+    # Close the connection
+    connection.close()
+
+    # Verify the close logic worked:
+    # 1. has_been_closed_server_side should always be True after close()
+    assert active_result_set.has_been_closed_server_side is True
+
+    # 2. op_state should always be CLOSED after close()
+    assert active_result_set.op_state == connection.thrift_backend.CLOSED_OP_STATE
+
+    # 3. Backend close_command should be called appropriately
+    if not closed:
+        # Should have called backend.close_command during the close chain
+        mock_backend.close_command.assert_called_once_with(
+            mock_execute_response.command_handle
+        )
+    else:
+        # Should NOT have called backend.close_command (already closed)
+        mock_backend.close_command.assert_not_called()
 
 
 class ThriftBackendMockFactory:
@@ -169,70 +240,6 @@ class ClientTestSuite(unittest.TestCase):
         )
         http_headers = mock_client_class.call_args[0][3]
         self.assertIn(user_agent_header_with_entry, http_headers)
-
-    @patch("%s.client.ThriftBackend" % PACKAGE_NAME)
-    def test_closing_connection_closes_commands(self, mock_thrift_client_class):
-        # Test once with has_been_closed_server side, once without
-        for closed in (True, False):
-            with self.subTest(closed=closed):
-                initial_state = (
-                    TOperationState.FINISHED_STATE
-                    if not closed
-                    else TOperationState.CLOSED_STATE
-                )
-
-                # Mock the execute response with controlled state
-                mock_execute_response = Mock(spec=ExecuteResponse)
-                mock_execute_response.status = initial_state
-                mock_execute_response.has_been_closed_server_side = closed
-                mock_execute_response.is_staging_operation = False
-
-                # Mock the backend that will be used 
-                mock_backend = Mock(spec=ThriftBackend)
-                mock_thrift_client_class.return_value = mock_backend
-
-                # Create connection and cursor
-                connection = databricks.sql.connect(**self.DUMMY_CONNECTION_ARGS)
-                cursor = connection.cursor()
-
-                # Verify initial state
-                self.assertEqual(
-                    mock_execute_response.has_been_closed_server_side, closed
-                )
-                self.assertEqual(mock_execute_response.status, initial_state)
-
-                # Mock execute_command to return our execute response
-                cursor.thrift_backend.execute_command = Mock(
-                    return_value=mock_execute_response
-                )
-                cursor.execute("SELECT 1")
-
-                # Verify that cursor.execute() set up the result set correctly
-                active_result_set = cursor.active_result_set
-                self.assertEqual(active_result_set.has_been_closed_server_side, closed)
-
-                # Close the connection 
-                connection.close()
-
-                # Verify the close logic worked:
-                # 1. has_been_closed_server_side should always be True after close()
-                self.assertTrue(active_result_set.has_been_closed_server_side)
-
-                # 2. op_state should always be CLOSED after close()
-                self.assertEqual(
-                    active_result_set.op_state,
-                    connection.thrift_backend.CLOSED_OP_STATE,
-                )
-
-                # 3. Backend close_command should be called appropriately
-                if not closed:
-                    # Should have called backend.close_command during the close chain
-                    mock_backend.close_command.assert_called_once_with(
-                        mock_execute_response.command_handle
-                    )
-                else:
-                    # Should NOT have called backend.close_command (already closed)
-                    mock_backend.close_command.assert_not_called()
 
     @patch("%s.client.ThriftBackend" % PACKAGE_NAME)
     def test_cant_open_cursor_on_closed_connection(self, mock_client_class):

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -176,13 +176,12 @@ class ClientTestSuite(unittest.TestCase):
         """Test that closing a connection properly closes commands.
 
         This test verifies that when a connection is closed:
-        1. All result sets are marked as closed server-side
+        1. the active result set is marked as closed server-side
         2. The operation state is set to CLOSED
-        3. Backend.close_command is called only for commands that weren't already closed
+        3. backend.close_command is called only for commands that weren't already closed
 
         Args:
             mock_thrift_client_class: Mock for ThriftBackend class
-            closed: Parameter indicating if the command is already closed
         """
         for closed in (True, False):
             with self.subTest(closed=closed):


### PR DESCRIPTION
## What type of PR is this?
- [x] Bug Fix

## Description
Currently, `test_closing_connection_closes_commands` is incorrect because: 
- it iterates over values of `closed` but does not use them distinctly in the `subTest`s. The intention is likely to set them as the initial state of `has_been_closed_server_side`, based on the comment. 
- the entire result set is `Mock`ed, so when we check the final value of `has_been_closed_server_side`, it may extract an attribute that does not exist. This assertion will pass even if we do not set `has_been_closed_server_side` to `True` in our `close()` in the `ResultSet`. This is because the attribute is created as a new mock on being accessed, and mocks are by-default truthy. In order to test this, even if we change the assertion to `self.assertTrue(mock_result_set_class.return_value.random_attr)`, the test will pass, despite `random_attr` not existing on the type. 

## How is this tested?

- [x] Unit tests
- [ ] E2E Tests
- [ ] Manually
- [ ] N/A

## Related Tickets & Documents
N/A