### PR TITLE
bugfix: stalling test issue (close in TelemetryClientFactory)

### DIFF
--- a/src/databricks/sql/telemetry/telemetry_client.py
+++ b/src/databricks/sql/telemetry/telemetry_client.py
@@ -317,6 +317,7 @@ class TelemetryClientFactory:
     _executor: Optional[ThreadPoolExecutor] = None
     _initialized: bool = False
     _lock = threading.RLock()  # Thread safety for factory operations
+    # used RLock instead of Lock to avoid deadlocks when garbage collection is triggered
     _original_excepthook = None
     _excepthook_installed = False
 


### PR DESCRIPTION
<!-- We welcome contributions. All patches must include a sign-off. Please see CONTRIBUTING.md for details -->


## What type of PR is this?
<!-- Check all that apply, delete what doesn't apply. -->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Other

## Description
A test was stalling in python 3.13 with pytest 7.4.4. 
When pytest version changed to 8.3.2, py3.13 ran fine but got stuck in py3.9.
Removed test before it with the same patch, passes
Removed module level lock, passes
Changed conditional check logic, passes
Remove test before stalling test, passes
Changed order by appending a in start of stalling test name, got stuck in a different test

Figured out the problem: garbage collector runs on the same thread that triggers it and interrupts the current function to execute.
Solution: changed Lock to RLock as RLock allows the same thread to acquire the lock multiple times without blocking.

## How is this tested?

- [ ] Unit tests
- [ ] E2E Tests
- [ ] Manually
- [ ] N/A

<!-- If Manually, please describe. -->

## Related Tickets & Documents
