### PR TITLE
Removed Codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,0 @@
-# These owners will be the default owners for everything in
-# the repo. Unless a later match takes precedence, these
-# users will be requested for review when someone opens a
-# pull request.
-*       @deeksha-db @samikshya-db @jprakash-db @jackyhu-db @madhav-db @gopalldb @jayantsing-db @vikrantpuppala @shivam2680


### PR DESCRIPTION
## Description

Removed the `CODEOWNERS` file, so contributers can tag the targeted reviewers instead of everyone getting pinged for reviews. 
