### PR TITLE
SEA: Cleanup 

### DIFF
--- a/src/databricks/sql/backend/sea/backend.py
+++ b/src/databricks/sql/backend/sea/backend.py
@@ -620,7 +620,6 @@ class SeaDatabricksClient(DatabricksClient):
         return SeaResultSet(
             connection=cursor.connection,
             execute_response=execute_response,
-            sea_client=self,
             result_data=response.result,
             manifest=response.manifest,
             buffer_size_bytes=cursor.buffer_size_bytes,

--- a/src/databricks/sql/backend/sea/utils/filters.py
+++ b/src/databricks/sql/backend/sea/utils/filters.py
@@ -12,14 +12,13 @@ from typing import (
     Optional,
     Any,
     Callable,
-    cast,
     TYPE_CHECKING,
 )
 
 if TYPE_CHECKING:
     from databricks.sql.backend.sea.result_set import SeaResultSet
 
-from databricks.sql.backend.types import ExecuteResponse
+from databricks.sql.backend.types import ExecuteResponse, CommandId, CommandState
 
 logger = logging.getLogger(__name__)
 
@@ -45,6 +44,9 @@ class ResultSetFilter:
         """
 
         # Get all remaining rows
+        if result_set.results is None:
+            raise RuntimeError("Results queue is not initialized")
+
         all_rows = result_set.results.remaining_rows()
 
         # Filter rows
@@ -79,7 +81,6 @@ class ResultSetFilter:
         filtered_result_set = SeaResultSet(
             connection=result_set.connection,
             execute_response=execute_response,
-            sea_client=cast(SeaDatabricksClient, result_set.backend),
             result_data=result_data,
             manifest=manifest,
             buffer_size_bytes=result_set.buffer_size_bytes,

--- a/src/databricks/sql/backend/thrift_backend.py
+++ b/src/databricks/sql/backend/thrift_backend.py
@@ -856,7 +856,6 @@ class ThriftDatabricksClient(DatabricksClient):
         return ThriftResultSet(
             connection=cursor.connection,
             execute_response=execute_response,
-            thrift_client=self,
             buffer_size_bytes=cursor.buffer_size_bytes,
             arraysize=cursor.arraysize,
             use_cloud_fetch=cursor.connection.use_cloud_fetch,
@@ -987,7 +986,6 @@ class ThriftDatabricksClient(DatabricksClient):
             return ThriftResultSet(
                 connection=cursor.connection,
                 execute_response=execute_response,
-                thrift_client=self,
                 buffer_size_bytes=max_bytes,
                 arraysize=max_rows,
                 use_cloud_fetch=use_cloud_fetch,
@@ -1027,7 +1025,6 @@ class ThriftDatabricksClient(DatabricksClient):
         return ThriftResultSet(
             connection=cursor.connection,
             execute_response=execute_response,
-            thrift_client=self,
             buffer_size_bytes=max_bytes,
             arraysize=max_rows,
             use_cloud_fetch=cursor.connection.use_cloud_fetch,
@@ -1071,7 +1068,6 @@ class ThriftDatabricksClient(DatabricksClient):
         return ThriftResultSet(
             connection=cursor.connection,
             execute_response=execute_response,
-            thrift_client=self,
             buffer_size_bytes=max_bytes,
             arraysize=max_rows,
             use_cloud_fetch=cursor.connection.use_cloud_fetch,
@@ -1119,7 +1115,6 @@ class ThriftDatabricksClient(DatabricksClient):
         return ThriftResultSet(
             connection=cursor.connection,
             execute_response=execute_response,
-            thrift_client=self,
             buffer_size_bytes=max_bytes,
             arraysize=max_rows,
             use_cloud_fetch=cursor.connection.use_cloud_fetch,
@@ -1167,7 +1162,6 @@ class ThriftDatabricksClient(DatabricksClient):
         return ThriftResultSet(
             connection=cursor.connection,
             execute_response=execute_response,
-            thrift_client=self,
             buffer_size_bytes=max_bytes,
             arraysize=max_rows,
             use_cloud_fetch=cursor.connection.use_cloud_fetch,

--- a/tests/unit/test_sea_backend.py
+++ b/tests/unit/test_sea_backend.py
@@ -68,12 +68,20 @@ class TestSeaBackend:
         return CommandId.from_sea_statement_id("test-statement-123")
 
     @pytest.fixture
-    def mock_cursor(self):
+    def mock_cursor(self, sea_client):
         """Create a mock cursor."""
         cursor = Mock()
         cursor.active_command_id = None
         cursor.buffer_size_bytes = 1000
         cursor.arraysize = 100
+
+        # Set up a mock connection with session.backend pointing to the sea_client
+        mock_connection = Mock()
+        mock_session = Mock()
+        mock_session.backend = sea_client
+        mock_connection.session = mock_session
+        cursor.connection = mock_connection
+
         return cursor
 
     @pytest.fixture


### PR DESCRIPTION
## What type of PR is this?
- [x] Refactor

## Description
- [x] Remove Client param from `ResultSet`, infer from `Connection` instead
- [ ]  Consider grouping primitive types in `Session` constructor into a type / namedtuple `ConnectionParams`
- [ ] Evaluate setting `session` `closed` flag in the beginning of `session` `close()` (currently set at the end)
- [ ] Remove service specific state from `ExecuteResponse`
- [ ] Re-organise `sea/` and `backend/` relation 

## How is this tested?

- [x] Unit tests
- [ ] E2E Tests
- [ ] Manually
- [ ] N/A

## Related Tickets & Documents
[PECOBLR-531](https://databricks.atlassian.net/browse/PECOBLR-531)
[PECOBLR-447](https://databricks.atlassian.net/browse/PECOBLR-447)
[PECOBLR-448](https://databricks.atlassian.net/browse/PECOBLR-448)
[PECOBLR-603](https://databricks.atlassian.net/browse/PECOBLR-603)
[PECOBLR-606](https://databricks.atlassian.net/browse/PECOBLR-606)