### PR TITLE
Bug fixes in telemetry

### DIFF
--- a/src/databricks/sql/telemetry/telemetry_client.py
+++ b/src/databricks/sql/telemetry/telemetry_client.py
@@ -127,6 +127,9 @@ class NoopTelemetryClient(BaseTelemetryClient):
     def close(self):
         pass
 
+    def _flush(self):
+        pass
+
 
 class TelemetryClient(BaseTelemetryClient):
     """

--- a/tests/e2e/test_concurrent_telemetry.py
+++ b/tests/e2e/test_concurrent_telemetry.py
@@ -1,3 +1,4 @@
+from concurrent.futures import wait
 import random
 import threading
 import time
@@ -48,8 +49,7 @@ class TestE2ETelemetry(PySQLPytestTestCase):
         captured_telemetry = []
         captured_session_ids = []
         captured_statement_ids = []
-        captured_responses = []
-        captured_exceptions = []
+        captured_futures = []
 
         original_send_telemetry = TelemetryClient._send_telemetry
         original_callback = TelemetryClient._telemetry_request_callback
@@ -64,18 +64,9 @@ class TestE2ETelemetry(PySQLPytestTestCase):
             Wraps the original callback to capture the server's response
             or any exceptions from the async network call.
             """
-            try:
-                original_callback(self_client, future, sent_count)
-                
-                # Now, capture the result for our assertions
-                response = future.result()
-                response.raise_for_status() # Raise an exception for 4xx/5xx errors
-                telemetry_response = response.json()
-                with capture_lock:
-                    captured_responses.append(telemetry_response)
-            except Exception as e:
-                with capture_lock:
-                    captured_exceptions.append(e)
+            with capture_lock:
+                captured_futures.append(future)
+            original_callback(self_client, future, sent_count)
 
         with patch.object(TelemetryClient, "_send_telemetry", send_telemetry_wrapper), \
              patch.object(TelemetryClient, "_telemetry_request_callback", callback_wrapper):
@@ -102,17 +93,26 @@ class TestE2ETelemetry(PySQLPytestTestCase):
             # Run the workers concurrently
             run_in_threads(execute_query_worker, num_threads, pass_index=True)
 
-            timeout_seconds = 60  # Max time to wait for telemetry to arrive
+            timeout_seconds = 60
             start_time = time.time()
-            expected_event_count = num_threads * 2  # initial_log + latency_log per thread
+            expected_event_count = num_threads
 
-            # Poll until the expected number of events are captured or we time out
-            while len(captured_telemetry) < expected_event_count:
-                if time.time() - start_time > timeout_seconds:
-                    break  # Exit loop if timeout is reached
-                time.sleep(0.1) 
+            while len(captured_futures) < expected_event_count and time.time() - start_time < timeout_seconds:
+                time.sleep(0.1)
 
-            # --- VERIFICATION ---
+            done, not_done = wait(captured_futures, timeout=timeout_seconds)
+            assert not not_done
+
+            captured_exceptions = []
+            captured_responses = []
+            for future in done:
+                try:
+                    response = future.result()
+                    response.raise_for_status()
+                    captured_responses.append(response.json())
+                except Exception as e:
+                    captured_exceptions.append(e)
+
             assert not captured_exceptions
             assert len(captured_responses) > 0
             


### PR DESCRIPTION
<!-- We welcome contributions. All patches must include a sign-off. Please see CONTRIBUTING.md for details -->


## What type of PR is this?
<!-- Check all that apply, delete what doesn't apply. -->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Other

## Description
The background flush thread crashed because it tried to call the _flush() method on NoopTelemetryClient objects, which didn't have one.

In the test in test_concurrent_telemetry.py: 
The main thread ran assertions immediately after the network tasks completed, creating a race condition where their callbacks had not yet finished writing the results.

## How is this tested?

- [ ] Unit tests
- [ ] E2E Tests
- [ ] Manually
- [ ] N/A

<!-- If Manually, please describe. -->

## Related Tickets & Documents
