### PR TITLE
Update native.py: use dict instead of Dict

### DIFF
--- a/src/databricks/sql/parameters/native.py
+++ b/src/databricks/sql/parameters/native.py
@@ -13,7 +13,7 @@ from databricks.sql.thrift_api.TCLIService.ttypes import (
 import datetime
 import decimal
 from enum import Enum, auto
-from typing import Dict, List, Union
+from typing import List, Union
 
 
 class ParameterApproach(Enum):
@@ -699,7 +699,7 @@ TDbsqlParameter = Union[
 
 
 TParameterSequence = Sequence[Union[TDbsqlParameter, TAllowedParameterValue]]
-TParameterDict = Dict[str, TAllowedParameterValue]
+TParameterDict = dict[str, TAllowedParameterValue]
 TParameterCollection = Union[TParameterSequence, TParameterDict]
 
 


### PR DESCRIPTION
The capital letter version from typing has been deprecated since Python 3.9 https://docs.python.org/3/library/typing.html#typing.Dict

## What type of PR is this?

- [x] Refactor

## How is this tested?

Type check in the CI
