### PR TITLE
Fix token federation warnings by making it opt-in and improving error handling [Issue #702]

### DIFF
--- a/src/databricks/sql/auth/auth.py
+++ b/src/databricks/sql/auth/auth.py
@@ -65,8 +65,8 @@ def get_auth_provider(cfg: ClientContext, http_client):
         else:
             raise RuntimeError("No valid authentication settings!")
 
-    # Always wrap with token federation (falls back gracefully if not needed)
-    if base_provider:
+    # Wrap with token federation only if explicitly enabled via identity_federation_client_id
+    if base_provider and cfg.identity_federation_client_id:
         return TokenFederationProvider(
             hostname=cfg.hostname,
             external_provider=base_provider,


### PR DESCRIPTION
<!-- We welcome contributions. All patches must include a sign-off. Please see CONTRIBUTING.md for details -->


## What type of PR is this?
Fixes token federation warnings that were appearing for users not using identity federation. Token federation is now opt-in and only enabled when `identity_federation_client_id` is explicitly provided. 


<!-- Check all that apply, delete what doesn't apply. -->

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Other

## Description

## How is this tested?

- [ ] Unit tests
- [ ] E2E Tests
- [ ] Manually
- [ ] N/A

<!-- If Manually, please describe. -->

## Related Tickets & Documents
