### PR TITLE
Add ignore_transactions config to disable transaction operations

### DIFF
--- a/tests/e2e/test_transactions.py
+++ b/tests/e2e/test_transactions.py
@@ -48,6 +48,7 @@ class TestTransactions:
             "server_hostname": connection_details["host"],
             "http_path": connection_details["http_path"],
             "access_token": connection_details.get("access_token"),
+            "ignore_transactions": False,  # Enable actual transaction functionality for these tests
         }
 
         # Get catalog and schema from environment or use defaults


### PR DESCRIPTION
Introduces a new `ignore_transactions` configuration parameter (default: True) to control transaction-related behavior in the Connection class.

When ignore_transactions=True (default):
- commit(): no-op, returns immediately
- rollback(): raises NotSupportedError with message "Transactions are not supported on Databricks"
- autocommit setter: no-op, returns immediately

When ignore_transactions=False:
- All transaction methods execute normally

Changes:
- Added ignore_transactions parameter to Connection.__init__() with default value True
- Modified commit(), rollback(), and autocommit setter to check ignore_transactions flag
- Updated unit tests to pass ignore_transactions=False when testing transaction functionality
- Updated e2e transaction tests to pass ignore_transactions=False
- Added three new unit tests to verify ignore_transactions

<!-- We welcome contributions. All patches must include a sign-off. Please see CONTRIBUTING.md for details -->


## What type of PR is this?
<!-- Check all that apply, delete what doesn't apply. -->

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Other

## Description

## How is this tested?

- [ ] Unit tests
- [ ] E2E Tests
- [ ] Manually
- [ ] N/A

<!-- If Manually, please describe. -->

## Related Tickets & Documents
