### PR TITLE
Change default use_hybrid_disposition to False

### DIFF
--- a/src/databricks/sql/backend/sea/backend.py
+++ b/src/databricks/sql/backend/sea/backend.py
@@ -157,7 +157,7 @@ class SeaDatabricksClient(DatabricksClient):
             "_use_arrow_native_complex_types", True
         )
 
-        self.use_hybrid_disposition = kwargs.get("use_hybrid_disposition", True)
+        self.use_hybrid_disposition = kwargs.get("use_hybrid_disposition", False)
         self.use_cloud_fetch = kwargs.get("use_cloud_fetch", True)
 
         # Extract warehouse ID from http_path


### PR DESCRIPTION
## Summary
- Changed the default value of `use_hybrid_disposition` from `True` to `False` in the SEA backend
- Currently, backend is not ready for turning on this feature by default in this driver, we will skip it's usage till then

## Changes
- This disables hybrid disposition by default for SEA backend connections

## Test plan
- Verify existing tests pass
- Confirm that users can still explicitly enable hybrid disposition by passing `use_hybrid_disposition=True`