### PR TITLE
Fixed the exception handler close() on _TelemetryClientHolder 

### DIFF
--- a/src/databricks/sql/telemetry/telemetry_client.py
+++ b/src/databricks/sql/telemetry/telemetry_client.py
@@ -542,8 +542,8 @@ class TelemetryClientFactory:
         logger.debug("Handling unhandled exception: %s", exc_type.__name__)
 
         clients_to_close = list(cls._clients.values())
-        for client in clients_to_close:
-            client.close()
+        for holder in clients_to_close:
+            holder.client.close()
 
         # Call the original exception handler to maintain normal behavior
         if cls._original_excepthook:


### PR DESCRIPTION


<!-- We welcome contributions. All patches must include a sign-off. Please see CONTRIBUTING.md for details -->


## What type of PR is this?
<!-- Check all that apply, delete what doesn't apply. -->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Other

## Description
Fixed the exception handler close() on _TelemetryClientHolder objects instead of accessing the client inside them.
## How is this tested?

- [ ] Unit tests
- [ ] E2E Tests
- [x] Manually
- [ ] N/A

<!-- If Manually, please describe. -->

## Related Tickets & Documents
