### PR TITLE
fix: Check if connection initialized when deleting Connection

### DIFF
--- a/src/databricks/sql/client.py
+++ b/src/databricks/sql/client.py
@@ -434,7 +434,8 @@ class Connection:
         self.close()
 
     def __del__(self):
-        if self.open:
+        initialized = hasattr(self, "session")
+        if initialized and self.open:
             logger.debug(
                 "Closing unclosed connection for session "
                 "{}".format(self.get_session_id_hex())


### PR DESCRIPTION
<!-- We welcome contributions. All patches must include a sign-off. Please see CONTRIBUTING.md for details -->


## What type of PR is this?
<!-- Check all that apply, delete what doesn't apply. -->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Other

## Description

The session is cleaned up when deleting a connection. But, if the connection was not fully initialized (e.g. due to a connection error) then no session will be set.

This will cause `__del__` to fail and warnings to be printed to stderr.

We can avoid this by checking if session is set and short-circuiting before checking if the session is open.

## How is this tested?

- [ ] Unit tests
- [ ] E2E Tests
- [ ] Manually
- [x] N/A

<!-- If Manually, please describe. -->

## Related Tickets & Documents

https://github.com/databricks/databricks-sql-python/issues/746