### PR TITLE
Updated the PyArrow concatenation of tables to use promote_options as default

### DIFF
--- a/src/databricks/sql/utils.py
+++ b/src/databricks/sql/utils.py
@@ -895,7 +895,7 @@ def concat_table_chunks(
                 result_table[j].extend(table_chunks[i].column_table[j])
         return ColumnTable(result_table, table_chunks[0].column_names)
     else:
-        return pyarrow.concat_tables(table_chunks)
+        return pyarrow.concat_tables(table_chunks, promote_options="default")
 
 
 def serialize_query_tags(

--- a/tests/unit/test_cloud_fetch_queue.py
+++ b/tests/unit/test_cloud_fetch_queue.py
@@ -174,7 +174,7 @@ class CloudFetchQueueSuite(unittest.TestCase):
         assert (
             result
             == pyarrow.concat_tables(
-                [self.make_arrow_table(), self.make_arrow_table()]
+                [self.make_arrow_table(), self.make_arrow_table()],promote_options="default"
             )[:7]
         )
 
@@ -266,7 +266,7 @@ class CloudFetchQueueSuite(unittest.TestCase):
         assert (
             result
             == pyarrow.concat_tables(
-                [self.make_arrow_table(), self.make_arrow_table()]
+                [self.make_arrow_table(), self.make_arrow_table()], promote_options="default"
             )[3:]
         )
 


### PR DESCRIPTION
Updated the PyArrow concatenation of tables to use promote_options as default

Resolves this issue - https://github.com/databricks/databricks-sql-python/issues/418
