### PR TITLE
Backport: Add _retry_server_directed_only mode for Retry-After header compliance

### DIFF
--- a/.github/workflows/code-quality-checks.yml
+++ b/.github/workflows/code-quality-checks.yml
@@ -35,6 +35,7 @@ jobs:
       - name: Install Poetry
         uses: snok/install-poetry@v1
         with:
+          version: "2.2.1"
           virtualenvs-create: true
           virtualenvs-in-project: true
           installer-parallel: true
@@ -106,10 +107,10 @@ jobs:
       #       check-out repo and set-up python
       #----------------------------------------------
       -   name: Check out repository
-          uses: actions/checkout@v2
+          uses: actions/checkout@v4
       -   name: Set up python ${{ matrix.python-version }}
           id: setup-python
-          uses: actions/setup-python@v2
+          uses: actions/setup-python@v5
           with:
             python-version: ${{ matrix.python-version }}
       #----------------------------------------------
@@ -118,6 +119,7 @@ jobs:
       -   name: Install Poetry
           uses: snok/install-poetry@v1
           with:
+            version: "2.2.1"
             virtualenvs-create: true
             virtualenvs-in-project: true
             installer-parallel: true
@@ -191,6 +193,7 @@ jobs:
       - name: Install Poetry
         uses: snok/install-poetry@v1
         with:
+          version: "2.2.1"
           virtualenvs-create: true
           virtualenvs-in-project: true
           installer-parallel: true
@@ -243,6 +246,7 @@ jobs:
       - name: Install Poetry
         uses: snok/install-poetry@v1
         with:
+          version: "2.2.1"
           virtualenvs-create: true
           virtualenvs-in-project: true
           installer-parallel: true

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -33,6 +33,7 @@ jobs:
       - name: Install Poetry
         uses: snok/install-poetry@v1
         with:
+          version: "2.2.1"
           virtualenvs-create: true
           virtualenvs-in-project: true
           installer-parallel: true

--- a/.github/workflows/publish-test.yml
+++ b/.github/workflows/publish-test.yml
@@ -21,6 +21,7 @@ jobs:
       - name: Install Poetry
         uses: snok/install-poetry@v1
         with:
+          version: "2.2.1"
           virtualenvs-create: true
           virtualenvs-in-project: true
           installer-parallel: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,6 +23,7 @@ jobs:
       - name: Install Poetry
         uses: snok/install-poetry@v1
         with:
+          version: "2.2.1"
           virtualenvs-create: true
           virtualenvs-in-project: true
           installer-parallel: true

--- a/src/databricks/sql/auth/common.py
+++ b/src/databricks/sql/auth/common.py
@@ -47,7 +47,7 @@ class ClientContext:
         retry_stop_after_attempts_duration: Optional[float] = None,
         retry_delay_default: Optional[float] = None,
         retry_dangerous_codes: Optional[List[int]] = None,
-        retry_server_directed_only: Optional[bool] = None,
+        respect_server_retry_after_header: Optional[bool] = None,
         proxy_auth_method: Optional[str] = None,
         pool_connections: Optional[int] = None,
         pool_maxsize: Optional[int] = None,
@@ -80,7 +80,7 @@ class ClientContext:
         )
         self.retry_delay_default = retry_delay_default or 5.0
         self.retry_dangerous_codes = retry_dangerous_codes or []
-        self.retry_server_directed_only = bool(retry_server_directed_only)
+        self.respect_server_retry_after_header = bool(respect_server_retry_after_header)
         self.proxy_auth_method = proxy_auth_method
         self.pool_connections = pool_connections or 10
         self.pool_maxsize = pool_maxsize or 20

--- a/src/databricks/sql/auth/common.py
+++ b/src/databricks/sql/auth/common.py
@@ -47,6 +47,7 @@ class ClientContext:
         retry_stop_after_attempts_duration: Optional[float] = None,
         retry_delay_default: Optional[float] = None,
         retry_dangerous_codes: Optional[List[int]] = None,
+        retry_server_directed_only: Optional[bool] = None,
         proxy_auth_method: Optional[str] = None,
         pool_connections: Optional[int] = None,
         pool_maxsize: Optional[int] = None,
@@ -79,6 +80,7 @@ class ClientContext:
         )
         self.retry_delay_default = retry_delay_default or 5.0
         self.retry_dangerous_codes = retry_dangerous_codes or []
+        self.retry_server_directed_only = bool(retry_server_directed_only)
         self.proxy_auth_method = proxy_auth_method
         self.pool_connections = pool_connections or 10
         self.pool_maxsize = pool_maxsize or 20

--- a/src/databricks/sql/auth/retry.py
+++ b/src/databricks/sql/auth/retry.py
@@ -94,6 +94,7 @@ class DatabricksRetryPolicy(Retry):
         stop_after_attempts_duration: float,
         delay_default: float,
         force_dangerous_codes: List[int],
+        server_directed_only: bool = False,
         urllib3_kwargs: dict = {},
     ):
         # These values do not change from one command to the next
@@ -103,6 +104,7 @@ class DatabricksRetryPolicy(Retry):
         self.stop_after_attempts_duration = stop_after_attempts_duration
         self._delay_default = delay_default
         self.force_dangerous_codes = force_dangerous_codes
+        self.server_directed_only = server_directed_only
 
         # the urllib3 kwargs are a mix of configuration (some of which we override)
         # and counters like `total` or `connect` which may change between successive retries
@@ -202,6 +204,7 @@ class DatabricksRetryPolicy(Retry):
             stop_after_attempts_duration=self.stop_after_attempts_duration,
             delay_default=self.delay_default,
             force_dangerous_codes=self.force_dangerous_codes,
+            server_directed_only=self.server_directed_only,
             urllib3_kwargs={},
         )
 
@@ -323,7 +326,9 @@ class DatabricksRetryPolicy(Retry):
 
         return proposed_backoff
 
-    def should_retry(self, method: str, status_code: int) -> Tuple[bool, str]:
+    def should_retry(
+        self, method: str, status_code: int, has_retry_after: bool = False
+    ) -> Tuple[bool, str]:
         """This method encapsulates the connector's approach to retries.
 
         We always retry a request unless one of these conditions is met:
@@ -380,6 +385,12 @@ class DatabricksRetryPolicy(Retry):
         # Request failed and this method is not retryable. We only retry POST requests.
         if not self._is_method_retryable(method):
             return False, "Only POST requests are retried"
+
+        # In server_directed_only mode, only retry when the server explicitly signals
+        # it's safe via a Retry-After header. This prevents duplicate side effects for
+        # non-idempotent operations.
+        if self.server_directed_only and not has_retry_after:
+            return (False, "server_directed_only mode: no Retry-After header present")
 
         # Request failed with 404 and was a GetOperationStatus. This is not recoverable. Don't retry.
         if status_code == 404 and self.command_type == CommandType.GET_OPERATION_STATUS:
@@ -450,7 +461,7 @@ class DatabricksRetryPolicy(Retry):
         Logs a debug message if the request will be retried
         """
 
-        should_retry, msg = self.should_retry(method, status_code)
+        should_retry, msg = self.should_retry(method, status_code, has_retry_after)
 
         if should_retry:
             logger.debug(msg)

--- a/src/databricks/sql/auth/retry.py
+++ b/src/databricks/sql/auth/retry.py
@@ -390,7 +390,10 @@ class DatabricksRetryPolicy(Retry):
         # server explicitly signals it's safe via a Retry-After header. This prevents
         # duplicate side effects for non-idempotent operations.
         if self.respect_server_retry_after_header and not has_retry_after:
-            return (False, "respect_server_retry_after_header mode: no Retry-After header present")
+            return (
+                False,
+                "respect_server_retry_after_header mode: no Retry-After header present",
+            )
 
         # Request failed with 404 and was a GetOperationStatus. This is not recoverable. Don't retry.
         if status_code == 404 and self.command_type == CommandType.GET_OPERATION_STATUS:

--- a/src/databricks/sql/auth/retry.py
+++ b/src/databricks/sql/auth/retry.py
@@ -94,7 +94,7 @@ class DatabricksRetryPolicy(Retry):
         stop_after_attempts_duration: float,
         delay_default: float,
         force_dangerous_codes: List[int],
-        server_directed_only: bool = False,
+        respect_server_retry_after_header: bool = False,
         urllib3_kwargs: dict = {},
     ):
         # These values do not change from one command to the next
@@ -104,7 +104,7 @@ class DatabricksRetryPolicy(Retry):
         self.stop_after_attempts_duration = stop_after_attempts_duration
         self._delay_default = delay_default
         self.force_dangerous_codes = force_dangerous_codes
-        self.server_directed_only = server_directed_only
+        self.respect_server_retry_after_header = respect_server_retry_after_header
 
         # the urllib3 kwargs are a mix of configuration (some of which we override)
         # and counters like `total` or `connect` which may change between successive retries
@@ -204,7 +204,7 @@ class DatabricksRetryPolicy(Retry):
             stop_after_attempts_duration=self.stop_after_attempts_duration,
             delay_default=self.delay_default,
             force_dangerous_codes=self.force_dangerous_codes,
-            server_directed_only=self.server_directed_only,
+            respect_server_retry_after_header=self.respect_server_retry_after_header,
             urllib3_kwargs={},
         )
 
@@ -386,11 +386,11 @@ class DatabricksRetryPolicy(Retry):
         if not self._is_method_retryable(method):
             return False, "Only POST requests are retried"
 
-        # In server_directed_only mode, only retry when the server explicitly signals
-        # it's safe via a Retry-After header. This prevents duplicate side effects for
-        # non-idempotent operations.
-        if self.server_directed_only and not has_retry_after:
-            return (False, "server_directed_only mode: no Retry-After header present")
+        # When respect_server_retry_after_header is enabled, only retry when the
+        # server explicitly signals it's safe via a Retry-After header. This prevents
+        # duplicate side effects for non-idempotent operations.
+        if self.respect_server_retry_after_header and not has_retry_after:
+            return (False, "respect_server_retry_after_header mode: no Retry-After header present")
 
         # Request failed with 404 and was a GetOperationStatus. This is not recoverable. Don't retry.
         if status_code == 404 and self.command_type == CommandType.GET_OPERATION_STATUS:

--- a/src/databricks/sql/backend/sea/utils/http_client.py
+++ b/src/databricks/sql/backend/sea/utils/http_client.py
@@ -90,6 +90,9 @@ class SeaHttpClient:
         )
         self._retry_delay_default = kwargs.get("_retry_delay_default", 5.0)
         self.force_dangerous_codes = kwargs.get("_retry_dangerous_codes", [])
+        self._retry_server_directed_only = kwargs.get(
+            "_retry_server_directed_only", False
+        )
 
         # Connection pooling settings
         self.max_connections = kwargs.get("max_connections", 10)
@@ -114,6 +117,7 @@ class SeaHttpClient:
                 stop_after_attempts_duration=self._retry_stop_after_attempts_duration,
                 delay_default=self._retry_delay_default,
                 force_dangerous_codes=self.force_dangerous_codes,
+                server_directed_only=self._retry_server_directed_only,
                 urllib3_kwargs=urllib3_kwargs,
             )
         else:

--- a/src/databricks/sql/backend/sea/utils/http_client.py
+++ b/src/databricks/sql/backend/sea/utils/http_client.py
@@ -90,9 +90,6 @@ class SeaHttpClient:
         )
         self._retry_delay_default = kwargs.get("_retry_delay_default", 5.0)
         self.force_dangerous_codes = kwargs.get("_retry_dangerous_codes", [])
-        self._retry_server_directed_only = kwargs.get(
-            "_retry_server_directed_only", False
-        )
 
         # Connection pooling settings
         self.max_connections = kwargs.get("max_connections", 10)
@@ -117,7 +114,7 @@ class SeaHttpClient:
                 stop_after_attempts_duration=self._retry_stop_after_attempts_duration,
                 delay_default=self._retry_delay_default,
                 force_dangerous_codes=self.force_dangerous_codes,
-                server_directed_only=self._retry_server_directed_only,
+                server_directed_only=kwargs.get("_retry_server_directed_only", False),
                 urllib3_kwargs=urllib3_kwargs,
             )
         else:

--- a/src/databricks/sql/backend/sea/utils/http_client.py
+++ b/src/databricks/sql/backend/sea/utils/http_client.py
@@ -90,6 +90,9 @@ class SeaHttpClient:
         )
         self._retry_delay_default = kwargs.get("_retry_delay_default", 5.0)
         self.force_dangerous_codes = kwargs.get("_retry_dangerous_codes", [])
+        self._respect_server_retry_after_header = kwargs.get(
+            "_respect_server_retry_after_header", False
+        )
 
         # Connection pooling settings
         self.max_connections = kwargs.get("max_connections", 10)
@@ -114,7 +117,7 @@ class SeaHttpClient:
                 stop_after_attempts_duration=self._retry_stop_after_attempts_duration,
                 delay_default=self._retry_delay_default,
                 force_dangerous_codes=self.force_dangerous_codes,
-                server_directed_only=kwargs.get("_retry_server_directed_only", False),
+                respect_server_retry_after_header=self._respect_server_retry_after_header,
                 urllib3_kwargs=urllib3_kwargs,
             )
         else:

--- a/src/databricks/sql/backend/thrift_backend.py
+++ b/src/databricks/sql/backend/thrift_backend.py
@@ -189,9 +189,6 @@ class ThriftDatabricksClient(DatabricksClient):
                 " This behaviour is deprecated and will be removed in a future release."
             )
         self.force_dangerous_codes = kwargs.get("_retry_dangerous_codes", [])
-        self._retry_server_directed_only = kwargs.get(
-            "_retry_server_directed_only", False
-        )
 
         additional_transport_args = {}
 
@@ -218,7 +215,7 @@ class ThriftDatabricksClient(DatabricksClient):
                 stop_after_attempts_duration=self._retry_stop_after_attempts_duration,
                 delay_default=self._retry_delay_default,
                 force_dangerous_codes=self.force_dangerous_codes,
-                server_directed_only=self._retry_server_directed_only,
+                server_directed_only=kwargs.get("_retry_server_directed_only", False),
                 urllib3_kwargs=urllib3_kwargs,
             )
 

--- a/src/databricks/sql/backend/thrift_backend.py
+++ b/src/databricks/sql/backend/thrift_backend.py
@@ -189,6 +189,9 @@ class ThriftDatabricksClient(DatabricksClient):
                 " This behaviour is deprecated and will be removed in a future release."
             )
         self.force_dangerous_codes = kwargs.get("_retry_dangerous_codes", [])
+        self._respect_server_retry_after_header = kwargs.get(
+            "_respect_server_retry_after_header", False
+        )
 
         additional_transport_args = {}
 
@@ -215,7 +218,7 @@ class ThriftDatabricksClient(DatabricksClient):
                 stop_after_attempts_duration=self._retry_stop_after_attempts_duration,
                 delay_default=self._retry_delay_default,
                 force_dangerous_codes=self.force_dangerous_codes,
-                server_directed_only=kwargs.get("_retry_server_directed_only", False),
+                respect_server_retry_after_header=self._respect_server_retry_after_header,
                 urllib3_kwargs=urllib3_kwargs,
             )
 

--- a/src/databricks/sql/backend/thrift_backend.py
+++ b/src/databricks/sql/backend/thrift_backend.py
@@ -189,6 +189,9 @@ class ThriftDatabricksClient(DatabricksClient):
                 " This behaviour is deprecated and will be removed in a future release."
             )
         self.force_dangerous_codes = kwargs.get("_retry_dangerous_codes", [])
+        self._retry_server_directed_only = kwargs.get(
+            "_retry_server_directed_only", False
+        )
 
         additional_transport_args = {}
 
@@ -215,6 +218,7 @@ class ThriftDatabricksClient(DatabricksClient):
                 stop_after_attempts_duration=self._retry_stop_after_attempts_duration,
                 delay_default=self._retry_delay_default,
                 force_dangerous_codes=self.force_dangerous_codes,
+                server_directed_only=self._retry_server_directed_only,
                 urllib3_kwargs=urllib3_kwargs,
             )
 

--- a/src/databricks/sql/common/unified_http_client.py
+++ b/src/databricks/sql/common/unified_http_client.py
@@ -99,6 +99,7 @@ class UnifiedHttpClient:
             stop_after_attempts_duration=self.config.retry_stop_after_attempts_duration,
             delay_default=self.config.retry_delay_default,
             force_dangerous_codes=self.config.retry_dangerous_codes,
+            server_directed_only=self.config.retry_server_directed_only,
         )
 
         # Initialize the required attributes that DatabricksRetryPolicy expects

--- a/src/databricks/sql/common/unified_http_client.py
+++ b/src/databricks/sql/common/unified_http_client.py
@@ -99,7 +99,7 @@ class UnifiedHttpClient:
             stop_after_attempts_duration=self.config.retry_stop_after_attempts_duration,
             delay_default=self.config.retry_delay_default,
             force_dangerous_codes=self.config.retry_dangerous_codes,
-            server_directed_only=self.config.retry_server_directed_only,
+            respect_server_retry_after_header=self.config.respect_server_retry_after_header,
         )
 
         # Initialize the required attributes that DatabricksRetryPolicy expects

--- a/src/databricks/sql/utils.py
+++ b/src/databricks/sql/utils.py
@@ -919,7 +919,9 @@ def build_client_context(server_hostname: str, version: str, **kwargs):
         ),
         retry_delay_default=kwargs.get("_retry_delay_default"),
         retry_dangerous_codes=kwargs.get("_retry_dangerous_codes"),
-        respect_server_retry_after_header=kwargs.get("_respect_server_retry_after_header"),
+        respect_server_retry_after_header=kwargs.get(
+            "_respect_server_retry_after_header"
+        ),
         proxy_auth_method=kwargs.get("_proxy_auth_method"),
         pool_connections=kwargs.get("_pool_connections"),
         pool_maxsize=kwargs.get("_pool_maxsize"),

--- a/src/databricks/sql/utils.py
+++ b/src/databricks/sql/utils.py
@@ -919,7 +919,7 @@ def build_client_context(server_hostname: str, version: str, **kwargs):
         ),
         retry_delay_default=kwargs.get("_retry_delay_default"),
         retry_dangerous_codes=kwargs.get("_retry_dangerous_codes"),
-        retry_server_directed_only=kwargs.get("_retry_server_directed_only"),
+        respect_server_retry_after_header=kwargs.get("_respect_server_retry_after_header"),
         proxy_auth_method=kwargs.get("_proxy_auth_method"),
         pool_connections=kwargs.get("_pool_connections"),
         pool_maxsize=kwargs.get("_pool_maxsize"),

--- a/src/databricks/sql/utils.py
+++ b/src/databricks/sql/utils.py
@@ -919,6 +919,7 @@ def build_client_context(server_hostname: str, version: str, **kwargs):
         ),
         retry_delay_default=kwargs.get("_retry_delay_default"),
         retry_dangerous_codes=kwargs.get("_retry_dangerous_codes"),
+        retry_server_directed_only=kwargs.get("_retry_server_directed_only"),
         proxy_auth_method=kwargs.get("_proxy_auth_method"),
         pool_connections=kwargs.get("_pool_connections"),
         pool_maxsize=kwargs.get("_pool_maxsize"),

--- a/tests/e2e/common/large_queries_mixin.py
+++ b/tests/e2e/common/large_queries_mixin.py
@@ -106,11 +106,11 @@ class LargeQueriesMixin:
         ],
     )
     def test_long_running_query(self, extra_params):
-        """Incrementally increase query size until it takes at least 3 minutes,
+        """Incrementally increase query size until it takes at least 2 minutes,
         and asserts that the query completes successfully.
         """
         minutes = 60
-        min_duration = 3 * minutes
+        min_duration = 2 * minutes
 
         duration = -1
         scale0 = 10000
@@ -136,5 +136,5 @@ class LargeQueriesMixin:
                 duration = time.time() - start
                 current_fraction = duration / min_duration
                 print("Took {} s with scale factor={}".format(duration, scale_factor))
-                # Extrapolate linearly to reach 3 min and add 50% padding to push over the limit
+                # Extrapolate linearly to reach 2 min and add 50% padding to push over the limit
                 scale_factor = math.ceil(1.5 * scale_factor / current_fraction)

--- a/tests/e2e/common/staging_ingestion_tests.py
+++ b/tests/e2e/common/staging_ingestion_tests.py
@@ -109,7 +109,7 @@ class PySQLStagingIngestionTestSuiteMixin:
         ):
             with self.connection() as conn:
                 cursor = conn.cursor()
-                query = f"PUT '{temp_path}' INTO 'stage://tmp/{ingestion_user}/tmp/11/15/file1.csv' OVERWRITE"
+                query = f"PUT '{temp_path}' INTO 'stage://tmp/{ingestion_user}/tmp/11/16/file1.csv' OVERWRITE"
                 cursor.execute(query)
 
     def test_staging_ingestion_put_fails_if_localFile_not_in_staging_allowed_local_path(
@@ -136,7 +136,7 @@ class PySQLStagingIngestionTestSuiteMixin:
                 extra_params={"staging_allowed_local_path": base_path}
             ) as conn:
                 cursor = conn.cursor()
-                query = f"PUT '{temp_path}' INTO 'stage://tmp/{ingestion_user}/tmp/11/15/file1.csv' OVERWRITE"
+                query = f"PUT '{temp_path}' INTO 'stage://tmp/{ingestion_user}/tmp/11/16/file1.csv' OVERWRITE"
                 cursor.execute(query)
 
     def test_staging_ingestion_put_fails_if_file_exists_and_overwrite_not_set(
@@ -222,7 +222,7 @@ class PySQLStagingIngestionTestSuiteMixin:
                 extra_params={"staging_allowed_local_path": temp_path}
             ) as conn:
                 cursor = conn.cursor()
-                query = f"GET 'stage://tmp/{some_other_user}/tmp/11/15/file1.csv' TO '{temp_path}'"
+                query = f"GET 'stage://tmp/{some_other_user}/tmp/11/16/file1.csv' TO '{temp_path}'"
                 cursor.execute(query)
 
         # PUT should fail with permissions error
@@ -258,7 +258,7 @@ class PySQLStagingIngestionTestSuiteMixin:
                 extra_params={"staging_allowed_local_path": staging_allowed_local_path}
             ) as conn:
                 cursor = conn.cursor()
-                query = f"PUT '{target_file}' INTO 'stage://tmp/{ingestion_user}/tmp/11/15/file1.csv' OVERWRITE"
+                query = f"PUT '{target_file}' INTO 'stage://tmp/{ingestion_user}/tmp/11/16/file1.csv' OVERWRITE"
                 cursor.execute(query)
 
     def test_staging_ingestion_empty_local_path_fails_to_parse_at_server(
@@ -272,7 +272,7 @@ class PySQLStagingIngestionTestSuiteMixin:
                 extra_params={"staging_allowed_local_path": staging_allowed_local_path}
             ) as conn:
                 cursor = conn.cursor()
-                query = f"PUT '{target_file}' INTO 'stage://tmp/{ingestion_user}/tmp/11/15/file1.csv' OVERWRITE"
+                query = f"PUT '{target_file}' INTO 'stage://tmp/{ingestion_user}/tmp/11/16/file1.csv' OVERWRITE"
                 cursor.execute(query)
 
     def test_staging_ingestion_invalid_staging_path_fails_at_server(
@@ -286,7 +286,7 @@ class PySQLStagingIngestionTestSuiteMixin:
                 extra_params={"staging_allowed_local_path": staging_allowed_local_path}
             ) as conn:
                 cursor = conn.cursor()
-                query = f"PUT '{target_file}' INTO 'stageRANDOMSTRINGOFCHARACTERS://tmp/{ingestion_user}/tmp/11/15/file1.csv' OVERWRITE"
+                query = f"PUT '{target_file}' INTO 'stageRANDOMSTRINGOFCHARACTERS://tmp/{ingestion_user}/tmp/11/16/file1.csv' OVERWRITE"
                 cursor.execute(query)
 
     def test_staging_ingestion_supports_multiple_staging_allowed_local_path_values(

--- a/tests/e2e/common/staging_ingestion_tests.py
+++ b/tests/e2e/common/staging_ingestion_tests.py
@@ -310,9 +310,9 @@ class PySQLStagingIngestionTestSuiteMixin:
             with open(fh, "wb") as fp:
                 original_text = "hello world!".encode("utf-8")
                 fp.write(original_text)
-            put_query = f"PUT '{temp_path}' INTO 'stage://tmp/{ingestion_user}/tmp/11/15/{id(temp_path)}.csv' OVERWRITE"
+            put_query = f"PUT '{temp_path}' INTO 'stage://tmp/{ingestion_user}/tmp/11/16/{id(temp_path)}.csv' OVERWRITE"
             remove_query = (
-                f"REMOVE 'stage://tmp/{ingestion_user}/tmp/11/15/{id(temp_path)}.csv'"
+                f"REMOVE 'stage://tmp/{ingestion_user}/tmp/11/16/{id(temp_path)}.csv'"
             )
             return fh, temp_path, put_query, remove_query
 

--- a/tests/unit/test_retry.py
+++ b/tests/unit/test_retry.py
@@ -83,3 +83,123 @@ class TestRetry:
                 retry_policy.sleep(HTTPResponse(status=503))
                 # Internally urllib3 calls the increment function generating a new instance for every retry
                 retry_policy = retry_policy.increment()
+
+    @pytest.fixture()
+    def server_directed_retry_policy(self) -> DatabricksRetryPolicy:
+        return DatabricksRetryPolicy(
+            delay_min=1,
+            delay_max=30,
+            stop_after_attempts_count=3,
+            stop_after_attempts_duration=900,
+            delay_default=2,
+            force_dangerous_codes=[],
+            server_directed_only=True,
+        )
+
+    def test_server_directed_only__retries_with_retry_after(
+        self, server_directed_retry_policy
+    ):
+        """429 + Retry-After header → should retry"""
+        server_directed_retry_policy._retry_start_time = time.time()
+        server_directed_retry_policy.command_type = CommandType.OTHER
+        should_retry, msg = server_directed_retry_policy.should_retry(
+            "POST", 429, has_retry_after=True
+        )
+        assert should_retry is True
+
+    def test_server_directed_only__no_retry_without_retry_after(
+        self, server_directed_retry_policy
+    ):
+        """429 without Retry-After header → no retry"""
+        server_directed_retry_policy._retry_start_time = time.time()
+        server_directed_retry_policy.command_type = CommandType.OTHER
+        should_retry, msg = server_directed_retry_policy.should_retry(
+            "POST", 429, has_retry_after=False
+        )
+        assert should_retry is False
+        assert "server_directed_only" in msg
+
+    def test_server_directed_only__no_retry_503_without_header(
+        self, server_directed_retry_policy
+    ):
+        """503 without Retry-After header → no retry"""
+        server_directed_retry_policy._retry_start_time = time.time()
+        server_directed_retry_policy.command_type = CommandType.OTHER
+        should_retry, msg = server_directed_retry_policy.should_retry(
+            "POST", 503, has_retry_after=False
+        )
+        assert should_retry is False
+        assert "server_directed_only" in msg
+
+    def test_server_directed_only__overrides_dangerous_codes(self):
+        """force_dangerous_codes=[500] + no Retry-After → no retry in server_directed_only mode"""
+        policy = DatabricksRetryPolicy(
+            delay_min=1,
+            delay_max=30,
+            stop_after_attempts_count=3,
+            stop_after_attempts_duration=900,
+            delay_default=2,
+            force_dangerous_codes=[500],
+            server_directed_only=True,
+        )
+        policy._retry_start_time = time.time()
+        policy.command_type = CommandType.EXECUTE_STATEMENT
+        should_retry, msg = policy.should_retry("POST", 500, has_retry_after=False)
+        assert should_retry is False
+        assert "server_directed_only" in msg
+
+    def test_server_directed_only__non_retryable_codes_unaffected(
+        self, server_directed_retry_policy
+    ):
+        """401/403/501 still don't retry even with Retry-After header"""
+        server_directed_retry_policy._retry_start_time = time.time()
+        server_directed_retry_policy.command_type = CommandType.OTHER
+        for code in [401, 403, 501]:
+            should_retry, msg = server_directed_retry_policy.should_retry(
+                "POST", code, has_retry_after=True
+            )
+            assert should_retry is False, f"Code {code} should never retry"
+
+    def test_default_mode_unchanged(self, retry_policy):
+        """server_directed_only=False preserves existing behavior — 429 retries without header"""
+        retry_policy._retry_start_time = time.time()
+        retry_policy.command_type = CommandType.OTHER
+        should_retry, msg = retry_policy.should_retry(
+            "POST", 429, has_retry_after=False
+        )
+        assert should_retry is True
+
+    def test_server_directed_only__survives_new(self, server_directed_retry_policy):
+        """urllib3 calls .new() between retries to create a fresh policy instance.
+        Verify that server_directed_only is carried over and still enforced."""
+        server_directed_retry_policy._retry_start_time = time.time()
+        server_directed_retry_policy.command_type = CommandType.OTHER
+        new_policy = server_directed_retry_policy.new()
+        assert new_policy.server_directed_only is True
+        # The new instance should still block retries without Retry-After
+        should_retry, msg = new_policy.should_retry("POST", 429, has_retry_after=False)
+        assert should_retry is False
+        assert "server_directed_only" in msg
+
+    def test_server_directed_only__execute_statement_with_retry_after(
+        self, server_directed_retry_policy
+    ):
+        """EXECUTE_STATEMENT + 429 + Retry-After header → retry"""
+        server_directed_retry_policy._retry_start_time = time.time()
+        server_directed_retry_policy.command_type = CommandType.EXECUTE_STATEMENT
+        should_retry, msg = server_directed_retry_policy.should_retry(
+            "POST", 429, has_retry_after=True
+        )
+        assert should_retry is True
+
+    def test_404_does_not_retry_for_any_command_type(self, retry_policy):
+        """Test that 404 never retries for any CommandType"""
+        retry_policy._retry_start_time = time.time()
+
+        # Test for each CommandType
+        for command_type in CommandType:
+            retry_policy.command_type = command_type
+            should_retry, msg = retry_policy.should_retry("POST", 404)
+
+            assert should_retry is False, f"404 should not retry for {command_type}"
+            assert "404" in msg or "NOT_FOUND" in msg

--- a/tests/unit/test_retry.py
+++ b/tests/unit/test_retry.py
@@ -7,9 +7,8 @@ from urllib3.exceptions import MaxRetryError
 
 
 class TestRetry:
-    @pytest.fixture()
-    def retry_policy(self) -> DatabricksRetryPolicy:
-        return DatabricksRetryPolicy(
+    def _make_retry_policy(self, **overrides) -> DatabricksRetryPolicy:
+        defaults = dict(
             delay_min=1,
             delay_max=30,
             stop_after_attempts_count=3,
@@ -17,6 +16,12 @@ class TestRetry:
             delay_default=2,
             force_dangerous_codes=[],
         )
+        defaults.update(overrides)
+        return DatabricksRetryPolicy(**defaults)
+
+    @pytest.fixture()
+    def retry_policy(self) -> DatabricksRetryPolicy:
+        return self._make_retry_policy()
 
     @pytest.fixture()
     def error_history(self) -> RequestHistory:
@@ -84,84 +89,56 @@ class TestRetry:
                 # Internally urllib3 calls the increment function generating a new instance for every retry
                 retry_policy = retry_policy.increment()
 
-    @pytest.fixture()
-    def server_directed_retry_policy(self) -> DatabricksRetryPolicy:
-        return DatabricksRetryPolicy(
-            delay_min=1,
-            delay_max=30,
-            stop_after_attempts_count=3,
-            stop_after_attempts_duration=900,
-            delay_default=2,
-            force_dangerous_codes=[],
-            server_directed_only=True,
-        )
-
-    def test_server_directed_only__retries_with_retry_after(
-        self, server_directed_retry_policy
-    ):
+    def test_respect_server_retry_after__retries_with_retry_after(self):
         """429 + Retry-After header → should retry"""
-        server_directed_retry_policy._retry_start_time = time.time()
-        server_directed_retry_policy.command_type = CommandType.OTHER
-        should_retry, msg = server_directed_retry_policy.should_retry(
-            "POST", 429, has_retry_after=True
-        )
+        policy = self._make_retry_policy(respect_server_retry_after_header=True)
+        policy._retry_start_time = time.time()
+        policy.command_type = CommandType.OTHER
+        should_retry, msg = policy.should_retry("POST", 429, has_retry_after=True)
         assert should_retry is True
 
-    def test_server_directed_only__no_retry_without_retry_after(
-        self, server_directed_retry_policy
-    ):
+    def test_respect_server_retry_after__no_retry_without_retry_after(self):
         """429 without Retry-After header → no retry"""
-        server_directed_retry_policy._retry_start_time = time.time()
-        server_directed_retry_policy.command_type = CommandType.OTHER
-        should_retry, msg = server_directed_retry_policy.should_retry(
-            "POST", 429, has_retry_after=False
-        )
+        policy = self._make_retry_policy(respect_server_retry_after_header=True)
+        policy._retry_start_time = time.time()
+        policy.command_type = CommandType.OTHER
+        should_retry, msg = policy.should_retry("POST", 429, has_retry_after=False)
         assert should_retry is False
-        assert "server_directed_only" in msg
+        assert "respect_server_retry_after_header" in msg
 
-    def test_server_directed_only__no_retry_503_without_header(
-        self, server_directed_retry_policy
-    ):
+    def test_respect_server_retry_after__no_retry_503_without_header(self):
         """503 without Retry-After header → no retry"""
-        server_directed_retry_policy._retry_start_time = time.time()
-        server_directed_retry_policy.command_type = CommandType.OTHER
-        should_retry, msg = server_directed_retry_policy.should_retry(
-            "POST", 503, has_retry_after=False
-        )
+        policy = self._make_retry_policy(respect_server_retry_after_header=True)
+        policy._retry_start_time = time.time()
+        policy.command_type = CommandType.OTHER
+        should_retry, msg = policy.should_retry("POST", 503, has_retry_after=False)
         assert should_retry is False
-        assert "server_directed_only" in msg
+        assert "respect_server_retry_after_header" in msg
 
-    def test_server_directed_only__overrides_dangerous_codes(self):
-        """force_dangerous_codes=[500] + no Retry-After → no retry in server_directed_only mode"""
-        policy = DatabricksRetryPolicy(
-            delay_min=1,
-            delay_max=30,
-            stop_after_attempts_count=3,
-            stop_after_attempts_duration=900,
-            delay_default=2,
-            force_dangerous_codes=[500],
-            server_directed_only=True,
+    def test_respect_server_retry_after__overrides_dangerous_codes(self):
+        """force_dangerous_codes=[500] + no Retry-After → no retry in respect_server_retry_after_header mode"""
+        policy = self._make_retry_policy(
+            force_dangerous_codes=[500], respect_server_retry_after_header=True
         )
         policy._retry_start_time = time.time()
         policy.command_type = CommandType.EXECUTE_STATEMENT
         should_retry, msg = policy.should_retry("POST", 500, has_retry_after=False)
         assert should_retry is False
-        assert "server_directed_only" in msg
+        assert "respect_server_retry_after_header" in msg
 
-    def test_server_directed_only__non_retryable_codes_unaffected(
-        self, server_directed_retry_policy
-    ):
+    def test_respect_server_retry_after__non_retryable_codes_unaffected(self):
         """401/403/501 still don't retry even with Retry-After header"""
-        server_directed_retry_policy._retry_start_time = time.time()
-        server_directed_retry_policy.command_type = CommandType.OTHER
+        policy = self._make_retry_policy(respect_server_retry_after_header=True)
+        policy._retry_start_time = time.time()
+        policy.command_type = CommandType.OTHER
         for code in [401, 403, 501]:
-            should_retry, msg = server_directed_retry_policy.should_retry(
+            should_retry, msg = policy.should_retry(
                 "POST", code, has_retry_after=True
             )
             assert should_retry is False, f"Code {code} should never retry"
 
     def test_default_mode_unchanged(self, retry_policy):
-        """server_directed_only=False preserves existing behavior — 429 retries without header"""
+        """respect_server_retry_after_header=False preserves existing behavior — 429 retries without header"""
         retry_policy._retry_start_time = time.time()
         retry_policy.command_type = CommandType.OTHER
         should_retry, msg = retry_policy.should_retry(
@@ -169,27 +146,25 @@ class TestRetry:
         )
         assert should_retry is True
 
-    def test_server_directed_only__survives_new(self, server_directed_retry_policy):
+    def test_respect_server_retry_after__survives_new(self):
         """urllib3 calls .new() between retries to create a fresh policy instance.
-        Verify that server_directed_only is carried over and still enforced."""
-        server_directed_retry_policy._retry_start_time = time.time()
-        server_directed_retry_policy.command_type = CommandType.OTHER
-        new_policy = server_directed_retry_policy.new()
-        assert new_policy.server_directed_only is True
+        Verify that respect_server_retry_after_header is carried over and still enforced."""
+        policy = self._make_retry_policy(respect_server_retry_after_header=True)
+        policy._retry_start_time = time.time()
+        policy.command_type = CommandType.OTHER
+        new_policy = policy.new()
+        assert new_policy.respect_server_retry_after_header is True
         # The new instance should still block retries without Retry-After
         should_retry, msg = new_policy.should_retry("POST", 429, has_retry_after=False)
         assert should_retry is False
-        assert "server_directed_only" in msg
+        assert "respect_server_retry_after_header" in msg
 
-    def test_server_directed_only__execute_statement_with_retry_after(
-        self, server_directed_retry_policy
-    ):
+    def test_respect_server_retry_after__execute_statement_with_retry_after(self):
         """EXECUTE_STATEMENT + 429 + Retry-After header → retry"""
-        server_directed_retry_policy._retry_start_time = time.time()
-        server_directed_retry_policy.command_type = CommandType.EXECUTE_STATEMENT
-        should_retry, msg = server_directed_retry_policy.should_retry(
-            "POST", 429, has_retry_after=True
-        )
+        policy = self._make_retry_policy(respect_server_retry_after_header=True)
+        policy._retry_start_time = time.time()
+        policy.command_type = CommandType.EXECUTE_STATEMENT
+        should_retry, msg = policy.should_retry("POST", 429, has_retry_after=True)
         assert should_retry is True
 
     def test_404_does_not_retry_for_any_command_type(self, retry_policy):

--- a/tests/unit/test_retry.py
+++ b/tests/unit/test_retry.py
@@ -167,14 +167,3 @@ class TestRetry:
         should_retry, msg = policy.should_retry("POST", 429, has_retry_after=True)
         assert should_retry is True
 
-    def test_404_does_not_retry_for_any_command_type(self, retry_policy):
-        """Test that 404 never retries for any CommandType"""
-        retry_policy._retry_start_time = time.time()
-
-        # Test for each CommandType
-        for command_type in CommandType:
-            retry_policy.command_type = command_type
-            should_retry, msg = retry_policy.should_retry("POST", 404)
-
-            assert should_retry is False, f"404 should not retry for {command_type}"
-            assert "404" in msg or "NOT_FOUND" in msg


### PR DESCRIPTION
## Summary

Backport of #756 to `release/v4.1.5` for patch release.

- Adds opt-in `_respect_server_retry_after_header` connection parameter that restricts retries to only occur when the server includes a `Retry-After` header in the response
- Prevents duplicate side effects for non-idempotent `ExecuteStatement` operations where the server has not explicitly signaled that retry is safe
- Threads the parameter through `ClientContext`, all three `DatabricksRetryPolicy` construction sites (Thrift, SEA, UnifiedHttpClient), and the retry policy's `should_retry`/`is_retry` methods
- Default behavior (retry without requiring the header) is unchanged

## Test plan

- [x] 8 new unit tests covering server-directed-only mode in `tests/unit/test_retry.py`
- [x] Full unit test suite for retry passes (`poetry run python -m pytest tests/unit/test_retry.py`)