### PR TITLE
Harden CI/CD workflows: fix secret exposure, script injection, and pin all actions to SHA

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -20,14 +20,12 @@ jobs:
       #       check-out repo and set-up python
       #----------------------------------------------
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.ref || github.ref_name }}
-          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
       - name: Set up python
         id: setup-python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.10"
       #----------------------------------------------
@@ -41,7 +39,7 @@ jobs:
       #  -----  install & configure poetry  -----
       #----------------------------------------------
       - name: Install Poetry
-        uses: snok/install-poetry@v1
+        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1
         with:
           version: "2.2.1"
           virtualenvs-create: true
@@ -53,7 +51,7 @@ jobs:
       #----------------------------------------------
       - name: Load cached venv
         id: cached-poetry-dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: .venv
           key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ github.event.repository.name }}-${{ hashFiles('**/poetry.lock') }}
@@ -105,8 +103,10 @@ jobs:
       #----------------------------------------------
       - name: Check for coverage override
         id: override
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
         run: |
-          OVERRIDE_COMMENT=$(echo "${{ github.event.pull_request.body }}" | grep -E "SKIP_COVERAGE_CHECK\s*=" || echo "")
+          OVERRIDE_COMMENT=$(echo "$PR_BODY" | grep -E "SKIP_COVERAGE_CHECK\s*=" || echo "")
           if [ -n "$OVERRIDE_COMMENT" ]; then
             echo "override=true" >> $GITHUB_OUTPUT
             REASON=$(echo "$OVERRIDE_COMMENT" | sed -E 's/.*SKIP_COVERAGE_CHECK\s*=\s*(.+)/\1/')
@@ -153,9 +153,12 @@ jobs:
       #         coverage enforcement summary
       #----------------------------------------------
       - name: Coverage enforcement summary
+        env:
+          OVERRIDE: ${{ steps.override.outputs.override }}
+          REASON: ${{ steps.override.outputs.reason }}
         run: |
-          if [ "${{ steps.override.outputs.override }}" == "true" ]; then
-            echo "⚠️ Coverage checks bypassed: ${{ steps.override.outputs.reason }}"
+          if [ "$OVERRIDE" == "true" ]; then
+            echo "⚠️ Coverage checks bypassed: $REASON"
             echo "Please ensure this override is justified and temporary"
           else
             echo "✅ Coverage checks enforced - minimum 85% required"

--- a/.github/workflows/code-quality-checks.yml
+++ b/.github/workflows/code-quality-checks.yml
@@ -2,6 +2,9 @@ name: Code Quality Checks
 
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   run-unit-tests:
     runs-on: ubuntu-latest
@@ -23,17 +26,17 @@ jobs:
       #       check-out repo and set-up python
       #----------------------------------------------
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Set up python ${{ matrix.python-version }}
         id: setup-python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ matrix.python-version }}
       #----------------------------------------------
       #  -----  install & configure poetry  -----
       #----------------------------------------------
       - name: Install Poetry
-        uses: snok/install-poetry@v1
+        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1
         with:
           version: "2.2.1"
           virtualenvs-create: true
@@ -45,7 +48,7 @@ jobs:
       #----------------------------------------------
       - name: Load cached venv
         id: cached-poetry-dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: .venv
           key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ matrix.dependency-version }}-${{ github.event.repository.name }}-${{ hashFiles('**/poetry.lock') }}
@@ -107,17 +110,17 @@ jobs:
       #       check-out repo and set-up python
       #----------------------------------------------
       -   name: Check out repository
-          uses: actions/checkout@v2
+          uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
       -   name: Set up python ${{ matrix.python-version }}
           id: setup-python
-          uses: actions/setup-python@v2
+          uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2
           with:
             python-version: ${{ matrix.python-version }}
       #----------------------------------------------
       #  -----  install & configure poetry  -----
       #----------------------------------------------
       -   name: Install Poetry
-          uses: snok/install-poetry@v1
+          uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1
           with:
             version: "2.2.1"
             virtualenvs-create: true
@@ -129,7 +132,7 @@ jobs:
       #----------------------------------------------
       -   name: Load cached venv
           id: cached-poetry-dependencies
-          uses: actions/cache@v4
+          uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
           with:
             path: .venv-pyarrow
             key: venv-pyarrow-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ matrix.dependency-version }}-${{ github.event.repository.name }}-${{ hashFiles('**/poetry.lock') }}
@@ -185,17 +188,17 @@ jobs:
       #       check-out repo and set-up python
       #----------------------------------------------
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Set up python ${{ matrix.python-version }}
         id: setup-python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ matrix.python-version }}
       #----------------------------------------------
       #  -----  install & configure poetry  -----
       #----------------------------------------------
       - name: Install Poetry
-        uses: snok/install-poetry@v1
+        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1
         with:
           version: "2.2.1"
           virtualenvs-create: true
@@ -207,7 +210,7 @@ jobs:
       #----------------------------------------------
       - name: Load cached venv
         id: cached-poetry-dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: .venv
           key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ github.event.repository.name }}-${{ hashFiles('**/poetry.lock') }}
@@ -238,17 +241,17 @@ jobs:
       #       check-out repo and set-up python
       #----------------------------------------------
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Set up python ${{ matrix.python-version }}
         id: setup-python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ matrix.python-version }}
       #----------------------------------------------
       #  -----  install & configure poetry  -----
       #----------------------------------------------
       - name: Install Poetry
-        uses: snok/install-poetry@v1
+        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1
         with:
           version: "2.2.1"
           virtualenvs-create: true
@@ -260,7 +263,7 @@ jobs:
       #----------------------------------------------
       - name: Load cached venv
         id: cached-poetry-dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: .venv
           key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ github.event.repository.name }}-${{ hashFiles('**/poetry.lock') }}

--- a/.github/workflows/daily-telemetry-e2e.yml
+++ b/.github/workflows/daily-telemetry-e2e.yml
@@ -12,6 +12,9 @@ on:
         default: 'tests/e2e/test_telemetry_e2e.py'
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   telemetry-e2e-tests:
     runs-on: ubuntu-latest
@@ -29,11 +32,11 @@ jobs:
       #       check-out repo and set-up python
       #----------------------------------------------
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       
       - name: Set up python
         id: setup-python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.10"
       
@@ -41,7 +44,7 @@ jobs:
       #  -----  install & configure poetry  -----
       #----------------------------------------------
       - name: Install Poetry
-        uses: snok/install-poetry@v1
+        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1
         with:
           version: "2.2.1"
           virtualenvs-create: true
@@ -53,7 +56,7 @@ jobs:
       #----------------------------------------------
       - name: Load cached venv
         id: cached-poetry-dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: .venv
           key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ github.event.repository.name }}-${{ hashFiles('**/poetry.lock') }}
@@ -82,7 +85,7 @@ jobs:
       #----------------------------------------------
       - name: Upload test results on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: telemetry-test-results
           path: |

--- a/.github/workflows/dco-check.yml
+++ b/.github/workflows/dco-check.yml
@@ -2,17 +2,19 @@ name: DCO Check
 
 on: [pull_request]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   check:
-    runs-on:
-        group: databricks-protected-runner-group
-        labels: linux-ubuntu-latest
+    runs-on: ubuntu-latest
     steps:
       - name: Check for DCO
         id: dco-check
-        uses: tisonkun/actions-dco@v1.1
+        uses: tisonkun/actions-dco@6d1f8a197db1b04df1769707b46b9366b1eca902 # v1.1
       - name: Comment about DCO status
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         if: ${{ failure() }}
         with:
           script: |

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -4,7 +4,10 @@ on:
   push:            
     branches:
       - main
-  pull_request:   
+  pull_request:
+
+permissions:
+  contents: read
 
 jobs:
   run-non-telemetry-tests:
@@ -21,17 +24,17 @@ jobs:
       #       check-out repo and set-up python
       #----------------------------------------------
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Set up python
         id: setup-python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.10"
       #----------------------------------------------
       #  -----  install & configure poetry  -----
       #----------------------------------------------
       - name: Install Poetry
-        uses: snok/install-poetry@v1
+        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1
         with:
           version: "2.2.1"
           virtualenvs-create: true
@@ -43,7 +46,7 @@ jobs:
       #----------------------------------------------
       - name: Load cached venv
         id: cached-poetry-dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: .venv
           key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ github.event.repository.name }}-${{ hashFiles('**/poetry.lock') }}
@@ -79,10 +82,10 @@ jobs:
       DATABRICKS_USER: ${{ secrets.TEST_PECO_SP_ID }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Set up python
         id: setup-python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.10"
       - name: Install system dependencies
@@ -90,14 +93,14 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libkrb5-dev
       - name: Install Poetry
-        uses: snok/install-poetry@v1
+        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1
         with:
           virtualenvs-create: true
           virtualenvs-in-project: true
           installer-parallel: true
       - name: Load cached venv
         id: cached-poetry-dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: .venv
           key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ github.event.repository.name }}-${{ hashFiles('**/poetry.lock') }}

--- a/.github/workflows/publish-manual.yml
+++ b/.github/workflows/publish-manual.yml
@@ -4,6 +4,9 @@ name: Publish to PyPI Manual [Production]
 on:
   workflow_dispatch: {}
 
+permissions:
+  contents: read
+
 jobs:
   publish:
     name: Publish
@@ -14,14 +17,14 @@ jobs:
       # Step 1: Check out the repository code
       #----------------------------------------------
       - name: Check out repository
-        uses: actions/checkout@v2  # Check out the repository to access the code
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
 
       #----------------------------------------------
       # Step 2: Set up Python environment
       #----------------------------------------------
       - name: Set up python
         id: setup-python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2
         with:
           python-version: 3.9  # Specify the Python version to be used
 
@@ -29,7 +32,7 @@ jobs:
       # Step 3: Install and configure Poetry
       #----------------------------------------------
       - name: Install Poetry
-        uses: snok/install-poetry@v1  # Install Poetry, the Python package manager
+        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1
         with:
           version: "2.2.1"
           virtualenvs-create: true

--- a/.github/workflows/publish-test.yml
+++ b/.github/workflows/publish-test.yml
@@ -1,5 +1,12 @@
 name: Publish to PyPI [Test]
-on: [push]
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
 jobs:
   test-pypi:
     name: Create patch version number and push to test-pypi
@@ -9,17 +16,17 @@ jobs:
       #       check-out repo and set-up python
       #----------------------------------------------
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Set up python
         id: setup-python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.10"
       #----------------------------------------------
       #  -----  install & configure poetry  -----
       #----------------------------------------------
       - name: Install Poetry
-        uses: snok/install-poetry@v1
+        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1
         with:
           version: "2.2.1"
           virtualenvs-create: true
@@ -30,7 +37,7 @@ jobs:
       #----------------------------------------------
       - name: Load cached venv
         id: cached-poetry-dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: .venv
           key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ github.event.repository.name }}-${{ hashFiles('**/poetry.lock') }}
@@ -48,7 +55,7 @@ jobs:
       # Get the current version and increment it (test-pypi requires a unique version number)
       #----------------------------------------------
       - name: Get next version
-        uses: reecetech/version-increment@2022.2.4
+        uses: reecetech/version-increment@ddbbe72b7f76a996076fabfdce21a16384e8644a # 2022.2.4
         id: version
         with:
           scheme: semver

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,6 +2,10 @@ name: Publish to PyPI [Production]
 on:
   release:
     types: [published]
+
+permissions:
+  contents: read
+
 jobs:
   publish:
     name: Publish
@@ -11,17 +15,17 @@ jobs:
       #       check-out repo and set-up python
       #----------------------------------------------
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Set up python
         id: setup-python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: 3.9
       #----------------------------------------------
       #  -----  install & configure poetry  -----
       #----------------------------------------------
       - name: Install Poetry
-        uses: snok/install-poetry@v1
+        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1
         with:
           version: "2.2.1"
           virtualenvs-create: true
@@ -32,7 +36,7 @@ jobs:
       #----------------------------------------------
       - name: Load cached venv
         id: cached-poetry-dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: .venv
           key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ github.event.repository.name }}-${{ hashFiles('**/poetry.lock') }}
@@ -50,7 +54,7 @@ jobs:
       # Here we use version-increment to fetch the latest tagged version (we won't increment it though)
       #------------------------------------------------------------------------------------------------
       - name: Get next version
-        uses: reecetech/version-increment@2022.2.4
+        uses: reecetech/version-increment@ddbbe72b7f76a996076fabfdce21a16384e8644a # 2022.2.4
         id: version
         with:
           scheme: semver


### PR DESCRIPTION
## Summary

This PR addresses **2 CRITICAL and 4 HIGH** supply chain security findings identified during a comprehensive CI/CD security audit of all GitHub Actions workflows. These fixes are required before the workflows can be safely re-enabled.

### Critical Fixes
- **Eliminated pwn request in `code-coverage.yml`** — Removed explicit `ref` / `repository` checkout of fork PR code that ran in a context with `azure-prod` secrets (`DATABRICKS_TOKEN`, `DATABRICKS_HOST`). An external attacker could have exfiltrated secrets by opening a malicious PR.
- **Fixed script injection in `code-coverage.yml`** — `${{ github.event.pull_request.body }}` was interpolated directly into `run:` shell steps, allowing arbitrary command execution via crafted PR descriptions. Moved all attacker-controllable expressions to `env:` blocks.

### High Fixes
- **Moved `dco-check.yml` off self-hosted runners** — Was using `databricks-protected-runner-group` on `pull_request` trigger, meaning any fork PR could execute code on internal infrastructure. Switched to `ubuntu-latest`.
- **Restricted `publish-test.yml` to `main` branch** — Was triggering on `on: [push]` for all branches, publishing to Test PyPI on every push. Now restricted to `push: branches: [main]`.
- **Pinned all 33 GitHub Action references to full SHA digests** — Every `uses:` reference across all 8 workflows was using mutable tags (`@v1`, `@v2`, `@v4`, etc.) vulnerable to upstream tag mutation or account compromise. All now use immutable commit SHAs with version comments.
- **Added explicit least-privilege `permissions:` blocks** — 7 of 8 workflows had no `permissions:` declaration (defaults can be overly broad). All now declare `contents: read` (and `pull-requests: write` only where needed for PR comments).

### Files Changed (8 workflow files)
| File | Changes Applied |
|---|---|
| `.github/workflows/code-coverage.yml` | Pwn request fix, script injection fix, SHA pinning |
| `.github/workflows/dco-check.yml` | Self-hosted runner removal, SHA pinning, permissions |
| `.github/workflows/publish-test.yml` | Branch restriction, SHA pinning, permissions |
| `.github/workflows/code-quality-checks.yml` | SHA pinning, permissions |
| `.github/workflows/integration.yml` | SHA pinning, permissions |
| `.github/workflows/daily-telemetry-e2e.yml` | SHA pinning, permissions |
| `.github/workflows/publish.yml` | SHA pinning, permissions |
| `.github/workflows/publish-manual.yml` | SHA pinning, permissions |

## Test Plan

- [ ] Verify YAML syntax is valid on all 8 workflow files
- [ ] Confirm no remaining `${{ github.event.* }}` expressions inside `run:` blocks (all moved to `env:`)
- [ ] Confirm no remaining unpinned action references (all use full SHA with `# tag` comments)
- [ ] Confirm `dco-check.yml` uses `ubuntu-latest` (no self-hosted runner references)
- [ ] Confirm `publish-test.yml` only triggers on `push` to `main`
- [ ] Confirm all workflows have explicit `permissions:` blocks
- [ ] Re-enable workflows and verify they trigger correctly on a test PR

This pull request was AI-assisted by Isaac.