### PR TITLE
Migrate all CI workflows to databricks-protected-runner-group

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -7,7 +7,9 @@ on: [pull_request, workflow_dispatch]
 
 jobs:
   test-with-coverage:
-    runs-on: ubuntu-latest
+    runs-on:
+      group: databricks-protected-runner-group
+      labels: linux-ubuntu-latest
     environment: azure-prod
     env:
       DATABRICKS_SERVER_HOSTNAME: ${{ secrets.DATABRICKS_HOST }}

--- a/.github/workflows/code-quality-checks.yml
+++ b/.github/workflows/code-quality-checks.yml
@@ -7,7 +7,9 @@ permissions:
 
 jobs:
   run-unit-tests:
-    runs-on: ubuntu-latest
+    runs-on:
+      group: databricks-protected-runner-group
+      labels: linux-ubuntu-latest
     strategy:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
@@ -92,7 +94,9 @@ jobs:
       - name: Run tests
         run: poetry run python -m pytest tests/unit
   run-unit-tests-with-arrow:
-    runs-on: ubuntu-latest
+    runs-on:
+      group: databricks-protected-runner-group
+      labels: linux-ubuntu-latest
     strategy:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
@@ -179,7 +183,9 @@ jobs:
       -   name: Run tests
           run: poetry run python -m pytest tests/unit
   check-linting:
-    runs-on: ubuntu-latest
+    runs-on:
+      group: databricks-protected-runner-group
+      labels: linux-ubuntu-latest
     strategy:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
@@ -232,7 +238,9 @@ jobs:
         run: poetry run black --check src
 
   check-types:
-    runs-on: ubuntu-latest
+    runs-on:
+      group: databricks-protected-runner-group
+      labels: linux-ubuntu-latest
     strategy:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]

--- a/.github/workflows/daily-telemetry-e2e.yml
+++ b/.github/workflows/daily-telemetry-e2e.yml
@@ -17,7 +17,9 @@ permissions:
 
 jobs:
   telemetry-e2e-tests:
-    runs-on: ubuntu-latest
+    runs-on:
+      group: databricks-protected-runner-group
+      labels: linux-ubuntu-latest
     environment: azure-prod
     
     env:

--- a/.github/workflows/dco-check.yml
+++ b/.github/workflows/dco-check.yml
@@ -8,7 +8,9 @@ permissions:
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    runs-on:
+      group: databricks-protected-runner-group
+      labels: linux-ubuntu-latest
     steps:
       - name: Check for DCO
         id: dco-check

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -11,7 +11,9 @@ permissions:
 
 jobs:
   run-non-telemetry-tests:
-    runs-on: ubuntu-latest
+    runs-on:
+      group: databricks-protected-runner-group
+      labels: linux-ubuntu-latest
     environment: azure-prod
     env:
       DATABRICKS_SERVER_HOSTNAME: ${{ secrets.DATABRICKS_HOST }}
@@ -71,7 +73,9 @@ jobs:
             -n auto
 
   run-telemetry-tests:
-    runs-on: ubuntu-latest
+    runs-on:
+      group: databricks-protected-runner-group
+      labels: linux-ubuntu-latest
     needs: run-non-telemetry-tests  # Run after non-telemetry tests complete
     environment: azure-prod
     env:


### PR DESCRIPTION
## Summary
- Replace `runs-on: ubuntu-latest` with `databricks-protected-runner-group` (label: `linux-ubuntu-latest`) across all 5 workflow files and 9 jobs
- Affected workflows: `code-coverage.yml`, `code-quality-checks.yml`, `daily-telemetry-e2e.yml`, `dco-check.yml`, `integration.yml`

## Test plan
- [ ] Verify all CI jobs pick up runners from the `databricks-protected-runner-group`
- [ ] Confirm all existing tests pass on the new runner infrastructure
- [ ] Validate that environment-gated jobs (`azure-prod`) still function correctly

This pull request was AI-assisted by Isaac.