### PR TITLE
Replace third-party DCO action with custom script

### DIFF
--- a/.github/workflows/dco-check.yml
+++ b/.github/workflows/dco-check.yml
@@ -1,29 +1,72 @@
 name: DCO Check
 
-on: [pull_request]
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [main]
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
-  check:
+  dco-check:
     runs-on: ubuntu-latest
+    name: Check DCO Sign-off
     steps:
-      - name: Check for DCO
-        id: dco-check
-        uses: tisonkun/actions-dco@6d1f8a197db1b04df1769707b46b9366b1eca902 # v1.1
-      - name: Comment about DCO status
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
-        if: ${{ failure() }}
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
-          script: |
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: `Thanks for your contribution! To satisfy the DCO policy in our \
-              [contributing guide](https://github.com/databricks/databricks-sql-python/blob/main/CONTRIBUTING.md) \
-              every commit message must include a sign-off message. One or more of your commits is missing this message. \
-              You can reword previous commit messages with an interactive rebase (\`git rebase -i main\`).`
-            })
+          fetch-depth: 0
+
+      - name: Check DCO Sign-off
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          #!/bin/bash
+          set -e
+
+          echo "Checking commits from $BASE_SHA to $HEAD_SHA"
+
+          COMMITS=$(git rev-list --no-merges "$BASE_SHA..$HEAD_SHA")
+
+          if [ -z "$COMMITS" ]; then
+            echo "No commits found in this PR"
+            exit 0
+          fi
+
+          FAILED_COMMITS=()
+
+          for commit in $COMMITS; do
+            echo "Checking commit: $commit"
+            COMMIT_MSG=$(git log --format=%B -n 1 "$commit")
+            if echo "$COMMIT_MSG" | grep -q "^Signed-off-by: "; then
+              echo "  Commit $commit has DCO sign-off"
+            else
+              echo "  Commit $commit is missing DCO sign-off"
+              FAILED_COMMITS+=("$commit")
+            fi
+          done
+
+          if [ ${#FAILED_COMMITS[@]} -ne 0 ]; then
+            echo ""
+            echo "DCO Check Failed!"
+            echo "The following commits are missing the required 'Signed-off-by' line:"
+            for commit in "${FAILED_COMMITS[@]}"; do
+              echo "  - $commit: $(git log --format=%s -n 1 "$commit")"
+            done
+            echo ""
+            echo "To fix this, you need to sign off your commits. You can:"
+            echo "1. Add sign-off to new commits: git commit -s -m 'Your commit message'"
+            echo "2. Amend existing commits: git commit --amend --signoff"
+            echo "3. For multiple commits, use: git rebase --signoff HEAD~N (where N is the number of commits)"
+            echo ""
+            echo "The sign-off should be in the format:"
+            echo "Signed-off-by: Your Name <your.email@example.com>"
+            echo ""
+            echo "For more details, see CONTRIBUTING.md"
+            exit 1
+          else
+            echo ""
+            echo "All commits have proper DCO sign-off!"
+          fi


### PR DESCRIPTION
## Summary
- Replaced the unreliable `tisonkun/actions-dco` third-party action with a custom inline bash script that checks each commit for a `Signed-off-by` line
- Aligned the DCO check implementation with `databricks-sql-go` for consistency across repos
- Scoped the workflow trigger to `opened`, `synchronize`, and `reopened` PR events on `main` (instead of all PR events)
- Removed unnecessary `pull-requests: write` permission since the workflow no longer posts comments

## Test plan
- [ ] Verify the DCO check passes on this PR (commit is signed off)
- [ ] Open a test PR without sign-off to confirm the check fails with clear error output

This pull request was AI-assisted by Isaac.