### PR TITLE
Migrate CI to protected runners and JFrog PyPI proxy

### DIFF
--- a/.github/actions/setup-jfrog/action.yml
+++ b/.github/actions/setup-jfrog/action.yml
@@ -1,5 +1,5 @@
 name: Setup JFrog OIDC
-description: Obtain a JFrog access token via GitHub OIDC and configure pip and poetry to use JFrog PyPI proxy
+description: Obtain a JFrog access token via GitHub OIDC and configure pip to use JFrog PyPI proxy
 
 runs:
   using: composite
@@ -30,4 +30,3 @@ runs:
         set -euo pipefail
         echo "PIP_INDEX_URL=https://gha-service-account:${JFROG_ACCESS_TOKEN}@databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple" >> "$GITHUB_ENV"
         echo "pip configured to use JFrog registry"
-

--- a/.github/actions/setup-jfrog/action.yml
+++ b/.github/actions/setup-jfrog/action.yml
@@ -1,5 +1,5 @@
 name: Setup JFrog OIDC
-description: Obtain a JFrog access token via GitHub OIDC and configure pip to use JFrog PyPI proxy
+description: Obtain a JFrog access token via GitHub OIDC and configure pip and poetry to use JFrog PyPI proxy
 
 runs:
   using: composite
@@ -30,3 +30,4 @@ runs:
         set -euo pipefail
         echo "PIP_INDEX_URL=https://gha-service-account:${JFROG_ACCESS_TOKEN}@databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple" >> "$GITHUB_ENV"
         echo "pip configured to use JFrog registry"
+

--- a/.github/actions/setup-jfrog/action.yml
+++ b/.github/actions/setup-jfrog/action.yml
@@ -1,0 +1,32 @@
+name: Setup JFrog OIDC
+description: Obtain a JFrog access token via GitHub OIDC and configure pip to use JFrog PyPI proxy
+
+runs:
+  using: composite
+  steps:
+    - name: Get JFrog OIDC token
+      shell: bash
+      run: |
+        set -euo pipefail
+        ID_TOKEN=$(curl -sLS \
+          -H "User-Agent: actions/oidc-client" \
+          -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+          "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=jfrog-github" | jq .value | tr -d '"')
+        echo "::add-mask::${ID_TOKEN}"
+        ACCESS_TOKEN=$(curl -sLS -XPOST -H "Content-Type: application/json" \
+          "https://databricks.jfrog.io/access/api/v1/oidc/token" \
+          -d "{\"grant_type\": \"urn:ietf:params:oauth:grant-type:token-exchange\", \"subject_token_type\":\"urn:ietf:params:oauth:token-type:id_token\", \"subject_token\": \"${ID_TOKEN}\", \"provider_name\": \"github-actions\"}" | jq .access_token | tr -d '"')
+        echo "::add-mask::${ACCESS_TOKEN}"
+        if [ -z "$ACCESS_TOKEN" ] || [ "$ACCESS_TOKEN" = "null" ]; then
+          echo "FAIL: Could not extract JFrog access token"
+          exit 1
+        fi
+        echo "JFROG_ACCESS_TOKEN=${ACCESS_TOKEN}" >> "$GITHUB_ENV"
+        echo "JFrog OIDC token obtained successfully"
+
+    - name: Configure pip
+      shell: bash
+      run: |
+        set -euo pipefail
+        echo "PIP_INDEX_URL=https://gha-service-account:${JFROG_ACCESS_TOKEN}@databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple" >> "$GITHUB_ENV"
+        echo "pip configured to use JFrog registry"

--- a/.github/actions/setup-poetry/action.yml
+++ b/.github/actions/setup-poetry/action.yml
@@ -1,0 +1,63 @@
+name: Setup Poetry with JFrog
+description: Install Poetry, configure JFrog as primary PyPI source, and install project dependencies
+
+inputs:
+  python-version:
+    description: Python version to set up
+    required: true
+  install-args:
+    description: Extra arguments for poetry install (e.g. --all-extras)
+    required: false
+    default: ""
+  cache-path:
+    description: Path to the virtualenv for caching (e.g. .venv or .venv-pyarrow)
+    required: false
+    default: ".venv"
+  cache-suffix:
+    description: Extra suffix for the cache key to avoid collisions across job variants
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Setup JFrog
+      uses: ./.github/actions/setup-jfrog
+
+    - name: Set up python ${{ inputs.python-version }}
+      id: setup-python
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    - name: Install Poetry
+      shell: bash
+      run: |
+        pip install poetry==2.2.1
+        poetry config virtualenvs.create true
+        poetry config virtualenvs.in-project true
+        poetry config installer.parallel true
+
+    - name: Configure Poetry JFrog source
+      shell: bash
+      run: |
+        poetry config repositories.jfrog https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple
+        poetry config http-basic.jfrog gha-service-account "${JFROG_ACCESS_TOKEN}"
+        poetry source add --priority=primary jfrog https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple
+        poetry lock
+
+    - name: Load cached venv
+      id: cached-poetry-dependencies
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      with:
+        path: ${{ inputs.cache-path }}
+        key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ inputs.cache-suffix }}${{ github.event.repository.name }}-${{ hashFiles('**/poetry.lock') }}
+
+    - name: Install dependencies
+      if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
+      shell: bash
+      run: poetry install --no-interaction --no-root
+
+    - name: Install library
+      shell: bash
+      run: poetry install --no-interaction ${{ inputs.install-args }}

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -50,6 +50,11 @@ jobs:
           virtualenvs-create: true
           virtualenvs-in-project: true
           installer-parallel: true
+      - name: Configure Poetry for JFrog
+        run: |
+          poetry config repositories.jfrog https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple
+          poetry config http-basic.jfrog gha-service-account "${JFROG_ACCESS_TOKEN}"
+          poetry source add --priority=primary jfrog https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple
 
       #----------------------------------------------
       #       load cached venv if cache exists

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -23,44 +23,15 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
-      - name: Setup JFrog
-        uses: ./.github/actions/setup-jfrog
-      - name: Set up python
-        id: setup-python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
-        with:
-          python-version: "3.10"
       - name: Install system dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y libkrb5-dev
-      - name: Install Poetry
-        run: |
-          pip install poetry==2.2.1
-          poetry config virtualenvs.create true
-          poetry config virtualenvs.in-project true
-          poetry config installer.parallel true
-      - name: Configure Poetry for JFrog
-        run: |
-          poetry config repositories.jfrog https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple
-          poetry config http-basic.jfrog gha-service-account "${JFROG_ACCESS_TOKEN}"
-          poetry source add --priority=primary jfrog https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple
-          poetry lock
-      - name: Load cached venv
-        id: cached-poetry-dependencies
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      - name: Setup Poetry
+        uses: ./.github/actions/setup-poetry
         with:
-          path: .venv
-          key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ github.event.repository.name }}-${{ hashFiles('**/poetry.lock') }}
-      - name: Install dependencies
-        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
-        run: poetry install --no-interaction --no-root
-      - name: Install Kerberos system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libkrb5-dev
-      - name: Install library
-        run: poetry install --no-interaction --all-extras
+          python-version: "3.10"
+          install-args: "--all-extras"
       - name: Run parallel tests with coverage
         continue-on-error: false
         run: |

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -57,7 +57,7 @@ jobs:
           poetry config repositories.jfrog https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple
           poetry config http-basic.jfrog gha-service-account "${JFROG_ACCESS_TOKEN}"
           poetry source add --priority=primary jfrog https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple
-          poetry lock --no-update
+          poetry lock
 
       #----------------------------------------------
       #       load cached venv if cache exists

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -57,6 +57,7 @@ jobs:
           poetry config repositories.jfrog https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple
           poetry config http-basic.jfrog gha-service-account "${JFROG_ACCESS_TOKEN}"
           poetry source add --priority=primary jfrog https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple
+          poetry lock --no-update
 
       #----------------------------------------------
       #       load cached venv if cache exists

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -19,33 +19,21 @@ jobs:
       DATABRICKS_CATALOG: peco
       DATABRICKS_USER: ${{ secrets.TEST_PECO_SP_ID }}
     steps:
-      #----------------------------------------------
-      #       check-out repo and set-up python
-      #----------------------------------------------
       - name: Check out repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
+      - name: Setup JFrog
+        uses: ./.github/actions/setup-jfrog
       - name: Set up python
         id: setup-python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.10"
-      #----------------------------------------------
-      #  -----  configure JFrog PyPI proxy  -----
-      #----------------------------------------------
-      - name: Setup JFrog
-        uses: ./.github/actions/setup-jfrog
-      #----------------------------------------------
-      #  -----  install system dependencies  -----
-      #----------------------------------------------
       - name: Install system dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y libkrb5-dev
-      #----------------------------------------------
-      #  -----  install & configure poetry  -----
-      #----------------------------------------------
       - name: Install Poetry
         run: |
           pip install poetry==2.2.1
@@ -58,34 +46,21 @@ jobs:
           poetry config http-basic.jfrog gha-service-account "${JFROG_ACCESS_TOKEN}"
           poetry source add --priority=primary jfrog https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple
           poetry lock
-
-      #----------------------------------------------
-      #       load cached venv if cache exists
-      #----------------------------------------------
       - name: Load cached venv
         id: cached-poetry-dependencies
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: .venv
           key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ github.event.repository.name }}-${{ hashFiles('**/poetry.lock') }}
-      #----------------------------------------------
-      # install dependencies if cache does not exist
-      #----------------------------------------------
       - name: Install dependencies
         if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
         run: poetry install --no-interaction --no-root
-      #----------------------------------------------
-      # install your root project, if required
-      #----------------------------------------------
       - name: Install Kerberos system dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y libkrb5-dev
       - name: Install library
         run: poetry install --no-interaction --all-extras
-      #----------------------------------------------
-      #    run parallel tests with coverage
-      #----------------------------------------------
       - name: Run parallel tests with coverage
         continue-on-error: false
         run: |
@@ -96,24 +71,15 @@ jobs:
             --cov-report=xml \
             --cov-report=term \
             -v
-
-      #----------------------------------------------
-      #    run telemetry tests with coverage (isolated)
-      #----------------------------------------------
       - name: Run telemetry tests with coverage (isolated)
         continue-on-error: false
         run: |
-          # Run test_concurrent_telemetry.py separately for isolation
           poetry run pytest tests/e2e/test_concurrent_telemetry.py \
             --cov=src \
             --cov-append \
             --cov-report=xml \
             --cov-report=term \
             -v
-
-      #----------------------------------------------
-      #         check for coverage override
-      #----------------------------------------------
       - name: Check for coverage override
         id: override
         env:
@@ -129,9 +95,6 @@ jobs:
             echo "override=false" >> $GITHUB_OUTPUT
             echo "No coverage override found"
           fi
-      #----------------------------------------------
-      #         check coverage percentage
-      #----------------------------------------------
       - name: Check coverage percentage
         if: steps.override.outputs.override == 'false'
         run: |
@@ -140,20 +103,14 @@ jobs:
             echo "ERROR: Coverage file not found at $COVERAGE_FILE"
             exit 1
           fi
-
-          # Install xmllint if not available
           if ! command -v xmllint &> /dev/null; then
             sudo apt-get update && sudo apt-get install -y libxml2-utils
           fi
-
           COVERED=$(xmllint --xpath "string(//coverage/@lines-covered)" "$COVERAGE_FILE")
           TOTAL=$(xmllint --xpath "string(//coverage/@lines-valid)" "$COVERAGE_FILE")
           PERCENTAGE=$(python3 -c "covered=${COVERED}; total=${TOTAL}; print(round((covered/total)*100, 2))")
-
           echo "Branch Coverage: $PERCENTAGE%"
           echo "Required Coverage: 85%"
-
-          # Use Python to compare the coverage with 85
           python3 -c "import sys; sys.exit(0 if float('$PERCENTAGE') >= 85 else 1)"
           if [ $? -eq 1 ]; then
             echo "ERROR: Coverage is $PERCENTAGE%, which is less than the required 85%"
@@ -161,18 +118,14 @@ jobs:
           else
             echo "SUCCESS: Coverage is $PERCENTAGE%, which meets the required 85%"
           fi
-
-      #----------------------------------------------
-      #         coverage enforcement summary
-      #----------------------------------------------
       - name: Coverage enforcement summary
         env:
           OVERRIDE: ${{ steps.override.outputs.override }}
           REASON: ${{ steps.override.outputs.reason }}
         run: |
           if [ "$OVERRIDE" == "true" ]; then
-            echo "⚠️ Coverage checks bypassed: $REASON"
+            echo "Coverage checks bypassed: $REASON"
             echo "Please ensure this override is justified and temporary"
           else
-            echo "✅ Coverage checks enforced - minimum 85% required"
+            echo "Coverage checks enforced - minimum 85% required"
           fi

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -32,6 +32,11 @@ jobs:
         with:
           python-version: "3.10"
       #----------------------------------------------
+      #  -----  configure JFrog PyPI proxy  -----
+      #----------------------------------------------
+      - name: Setup JFrog
+        uses: ./.github/actions/setup-jfrog
+      #----------------------------------------------
       #  -----  install system dependencies  -----
       #----------------------------------------------
       - name: Install system dependencies
@@ -42,17 +47,11 @@ jobs:
       #  -----  install & configure poetry  -----
       #----------------------------------------------
       - name: Install Poetry
-        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1
-        with:
-          version: "2.2.1"
-          virtualenvs-create: true
-          virtualenvs-in-project: true
-          installer-parallel: true
-      #----------------------------------------------
-      #  -----  configure JFrog PyPI proxy  -----
-      #----------------------------------------------
-      - name: Setup JFrog
-        uses: ./.github/actions/setup-jfrog
+        run: |
+          pip install poetry==2.2.1
+          poetry config virtualenvs.create true
+          poetry config virtualenvs.in-project true
+          poetry config installer.parallel true
       - name: Configure Poetry for JFrog
         run: |
           poetry config repositories.jfrog https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -2,12 +2,15 @@ name: Code Coverage
 
 permissions:
   contents: read
+  id-token: write
 
 on: [pull_request, workflow_dispatch]
 
 jobs:
   test-with-coverage:
-    runs-on: ubuntu-latest
+    runs-on:
+      group: databricks-protected-runner-group
+      labels: linux-ubuntu-latest
     environment: azure-prod
     env:
       DATABRICKS_SERVER_HOSTNAME: ${{ secrets.DATABRICKS_HOST }}
@@ -23,6 +26,8 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
+      - name: Setup JFrog
+        uses: ./.github/actions/setup-jfrog
       - name: Set up python
         id: setup-python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -26,8 +26,6 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
-      - name: Setup JFrog
-        uses: ./.github/actions/setup-jfrog
       - name: Set up python
         id: setup-python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
@@ -50,6 +48,11 @@ jobs:
           virtualenvs-create: true
           virtualenvs-in-project: true
           installer-parallel: true
+      #----------------------------------------------
+      #  -----  configure JFrog PyPI proxy  -----
+      #----------------------------------------------
+      - name: Setup JFrog
+        uses: ./.github/actions/setup-jfrog
       - name: Configure Poetry for JFrog
         run: |
           poetry config repositories.jfrog https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple
@@ -107,7 +110,7 @@ jobs:
             --cov-report=xml \
             --cov-report=term \
             -v
-          
+
       #----------------------------------------------
       #         check for coverage override
       #----------------------------------------------
@@ -137,19 +140,19 @@ jobs:
             echo "ERROR: Coverage file not found at $COVERAGE_FILE"
             exit 1
           fi
-          
+
           # Install xmllint if not available
           if ! command -v xmllint &> /dev/null; then
             sudo apt-get update && sudo apt-get install -y libxml2-utils
           fi
-          
+
           COVERED=$(xmllint --xpath "string(//coverage/@lines-covered)" "$COVERAGE_FILE")
           TOTAL=$(xmllint --xpath "string(//coverage/@lines-valid)" "$COVERAGE_FILE")
           PERCENTAGE=$(python3 -c "covered=${COVERED}; total=${TOTAL}; print(round((covered/total)*100, 2))")
-          
+
           echo "Branch Coverage: $PERCENTAGE%"
           echo "Required Coverage: 85%"
-          
+
           # Use Python to compare the coverage with 85
           python3 -c "import sys; sys.exit(0 if float('$PERCENTAGE') >= 85 else 1)"
           if [ $? -eq 1 ]; then
@@ -158,7 +161,7 @@ jobs:
           else
             echo "SUCCESS: Coverage is $PERCENTAGE%, which meets the required 85%"
           fi
-          
+
       #----------------------------------------------
       #         coverage enforcement summary
       #----------------------------------------------
@@ -173,4 +176,3 @@ jobs:
           else
             echo "✅ Coverage checks enforced - minimum 85% required"
           fi
-

--- a/.github/workflows/code-quality-checks.yml
+++ b/.github/workflows/code-quality-checks.yml
@@ -21,17 +21,15 @@ jobs:
             dependency-version: "min"
           - python-version: "3.13"
             dependency-version: "min"
-    
+
     name: "Unit Tests (Python ${{ matrix.python-version }}, ${{ matrix.dependency-version }} deps)"
-    
+
     steps:
       #----------------------------------------------
       #       check-out repo and set-up python
       #----------------------------------------------
       - name: Check out repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - name: Setup JFrog
-        uses: ./.github/actions/setup-jfrog
       - name: Set up python ${{ matrix.python-version }}
         id: setup-python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
@@ -47,6 +45,11 @@ jobs:
           virtualenvs-create: true
           virtualenvs-in-project: true
           installer-parallel: true
+      #----------------------------------------------
+      #  -----  configure JFrog PyPI proxy  -----
+      #----------------------------------------------
+      - name: Setup JFrog
+        uses: ./.github/actions/setup-jfrog
       - name: Configure Poetry for JFrog
         run: |
           poetry config repositories.jfrog https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple
@@ -114,17 +117,15 @@ jobs:
             dependency-version: "min"
           - python-version: "3.13"
             dependency-version: "min"
-    
+
     name: "Unit Tests + PyArrow (Python ${{ matrix.python-version }}, ${{ matrix.dependency-version }} deps)"
-    
+
     steps:
       #----------------------------------------------
       #       check-out repo and set-up python
       #----------------------------------------------
       -   name: Check out repository
           uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
-      -   name: Setup JFrog
-          uses: ./.github/actions/setup-jfrog
       -   name: Set up python ${{ matrix.python-version }}
           id: setup-python
           uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2
@@ -140,6 +141,11 @@ jobs:
             virtualenvs-create: true
             virtualenvs-in-project: true
             installer-parallel: true
+      #----------------------------------------------
+      #  -----  configure JFrog PyPI proxy  -----
+      #----------------------------------------------
+      -   name: Setup JFrog
+          uses: ./.github/actions/setup-jfrog
       -   name: Configure Poetry for JFrog
           run: |
             poetry config repositories.jfrog https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple
@@ -210,8 +216,6 @@ jobs:
       #----------------------------------------------
       - name: Check out repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - name: Setup JFrog
-        uses: ./.github/actions/setup-jfrog
       - name: Set up python ${{ matrix.python-version }}
         id: setup-python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
@@ -227,6 +231,11 @@ jobs:
           virtualenvs-create: true
           virtualenvs-in-project: true
           installer-parallel: true
+      #----------------------------------------------
+      #  -----  configure JFrog PyPI proxy  -----
+      #----------------------------------------------
+      - name: Setup JFrog
+        uses: ./.github/actions/setup-jfrog
       - name: Configure Poetry for JFrog
         run: |
           poetry config repositories.jfrog https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple
@@ -272,8 +281,6 @@ jobs:
       #----------------------------------------------
       - name: Check out repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - name: Setup JFrog
-        uses: ./.github/actions/setup-jfrog
       - name: Set up python ${{ matrix.python-version }}
         id: setup-python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
@@ -289,6 +296,11 @@ jobs:
           virtualenvs-create: true
           virtualenvs-in-project: true
           installer-parallel: true
+      #----------------------------------------------
+      #  -----  configure JFrog PyPI proxy  -----
+      #----------------------------------------------
+      - name: Setup JFrog
+        uses: ./.github/actions/setup-jfrog
       - name: Configure Poetry for JFrog
         run: |
           poetry config repositories.jfrog https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple

--- a/.github/workflows/code-quality-checks.yml
+++ b/.github/workflows/code-quality-checks.yml
@@ -36,20 +36,19 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       #----------------------------------------------
-      #  -----  install & configure poetry  -----
-      #----------------------------------------------
-      - name: Install Poetry
-        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1
-        with:
-          version: "2.2.1"
-          virtualenvs-create: true
-          virtualenvs-in-project: true
-          installer-parallel: true
-      #----------------------------------------------
       #  -----  configure JFrog PyPI proxy  -----
       #----------------------------------------------
       - name: Setup JFrog
         uses: ./.github/actions/setup-jfrog
+      #----------------------------------------------
+      #  -----  install & configure poetry  -----
+      #----------------------------------------------
+      - name: Install Poetry
+        run: |
+          pip install poetry==2.2.1
+          poetry config virtualenvs.create true
+          poetry config virtualenvs.in-project true
+          poetry config installer.parallel true
       - name: Configure Poetry for JFrog
         run: |
           poetry config repositories.jfrog https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple
@@ -132,20 +131,19 @@ jobs:
           with:
             python-version: ${{ matrix.python-version }}
       #----------------------------------------------
-      #  -----  install & configure poetry  -----
-      #----------------------------------------------
-      -   name: Install Poetry
-          uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1
-          with:
-            version: "2.2.1"
-            virtualenvs-create: true
-            virtualenvs-in-project: true
-            installer-parallel: true
-      #----------------------------------------------
       #  -----  configure JFrog PyPI proxy  -----
       #----------------------------------------------
       -   name: Setup JFrog
           uses: ./.github/actions/setup-jfrog
+      #----------------------------------------------
+      #  -----  install & configure poetry  -----
+      #----------------------------------------------
+      -   name: Install Poetry
+          run: |
+            pip install poetry==2.2.1
+            poetry config virtualenvs.create true
+            poetry config virtualenvs.in-project true
+            poetry config installer.parallel true
       -   name: Configure Poetry for JFrog
           run: |
             poetry config repositories.jfrog https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple
@@ -222,20 +220,19 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       #----------------------------------------------
-      #  -----  install & configure poetry  -----
-      #----------------------------------------------
-      - name: Install Poetry
-        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1
-        with:
-          version: "2.2.1"
-          virtualenvs-create: true
-          virtualenvs-in-project: true
-          installer-parallel: true
-      #----------------------------------------------
       #  -----  configure JFrog PyPI proxy  -----
       #----------------------------------------------
       - name: Setup JFrog
         uses: ./.github/actions/setup-jfrog
+      #----------------------------------------------
+      #  -----  install & configure poetry  -----
+      #----------------------------------------------
+      - name: Install Poetry
+        run: |
+          pip install poetry==2.2.1
+          poetry config virtualenvs.create true
+          poetry config virtualenvs.in-project true
+          poetry config installer.parallel true
       - name: Configure Poetry for JFrog
         run: |
           poetry config repositories.jfrog https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple
@@ -287,20 +284,19 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       #----------------------------------------------
-      #  -----  install & configure poetry  -----
-      #----------------------------------------------
-      - name: Install Poetry
-        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1
-        with:
-          version: "2.2.1"
-          virtualenvs-create: true
-          virtualenvs-in-project: true
-          installer-parallel: true
-      #----------------------------------------------
       #  -----  configure JFrog PyPI proxy  -----
       #----------------------------------------------
       - name: Setup JFrog
         uses: ./.github/actions/setup-jfrog
+      #----------------------------------------------
+      #  -----  install & configure poetry  -----
+      #----------------------------------------------
+      - name: Install Poetry
+        run: |
+          pip install poetry==2.2.1
+          poetry config virtualenvs.create true
+          poetry config virtualenvs.in-project true
+          poetry config installer.parallel true
       - name: Configure Poetry for JFrog
         run: |
           poetry config repositories.jfrog https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple

--- a/.github/workflows/code-quality-checks.yml
+++ b/.github/workflows/code-quality-checks.yml
@@ -54,7 +54,7 @@ jobs:
           poetry config repositories.jfrog https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple
           poetry config http-basic.jfrog gha-service-account "${JFROG_ACCESS_TOKEN}"
           poetry source add --priority=primary jfrog https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple
-          poetry lock --no-update
+          poetry lock
 
       #----------------------------------------------
       #       load cached venv if cache exists
@@ -150,7 +150,7 @@ jobs:
             poetry config repositories.jfrog https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple
             poetry config http-basic.jfrog gha-service-account "${JFROG_ACCESS_TOKEN}"
             poetry source add --priority=primary jfrog https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple
-          poetry lock --no-update
+            poetry lock
 
       #----------------------------------------------
       #       load cached venv if cache exists
@@ -240,7 +240,7 @@ jobs:
           poetry config repositories.jfrog https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple
           poetry config http-basic.jfrog gha-service-account "${JFROG_ACCESS_TOKEN}"
           poetry source add --priority=primary jfrog https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple
-          poetry lock --no-update
+          poetry lock
 
       #----------------------------------------------
       #       load cached venv if cache exists
@@ -305,7 +305,7 @@ jobs:
           poetry config repositories.jfrog https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple
           poetry config http-basic.jfrog gha-service-account "${JFROG_ACCESS_TOKEN}"
           poetry source add --priority=primary jfrog https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple
-          poetry lock --no-update
+          poetry lock
 
       #----------------------------------------------
       #       load cached venv if cache exists

--- a/.github/workflows/code-quality-checks.yml
+++ b/.github/workflows/code-quality-checks.yml
@@ -4,10 +4,13 @@ on: [pull_request]
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   run-unit-tests:
-    runs-on: ubuntu-latest
+    runs-on:
+      group: databricks-protected-runner-group
+      labels: linux-ubuntu-latest
     strategy:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
@@ -27,6 +30,8 @@ jobs:
       #----------------------------------------------
       - name: Check out repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Setup JFrog
+        uses: ./.github/actions/setup-jfrog
       - name: Set up python ${{ matrix.python-version }}
         id: setup-python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
@@ -92,7 +97,9 @@ jobs:
       - name: Run tests
         run: poetry run python -m pytest tests/unit
   run-unit-tests-with-arrow:
-    runs-on: ubuntu-latest
+    runs-on:
+      group: databricks-protected-runner-group
+      labels: linux-ubuntu-latest
     strategy:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
@@ -111,6 +118,8 @@ jobs:
       #----------------------------------------------
       -   name: Check out repository
           uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
+      -   name: Setup JFrog
+          uses: ./.github/actions/setup-jfrog
       -   name: Set up python ${{ matrix.python-version }}
           id: setup-python
           uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2
@@ -179,7 +188,9 @@ jobs:
       -   name: Run tests
           run: poetry run python -m pytest tests/unit
   check-linting:
-    runs-on: ubuntu-latest
+    runs-on:
+      group: databricks-protected-runner-group
+      labels: linux-ubuntu-latest
     strategy:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
@@ -189,6 +200,8 @@ jobs:
       #----------------------------------------------
       - name: Check out repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Setup JFrog
+        uses: ./.github/actions/setup-jfrog
       - name: Set up python ${{ matrix.python-version }}
         id: setup-python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
@@ -232,7 +245,9 @@ jobs:
         run: poetry run black --check src
 
   check-types:
-    runs-on: ubuntu-latest
+    runs-on:
+      group: databricks-protected-runner-group
+      labels: linux-ubuntu-latest
     strategy:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
@@ -242,6 +257,8 @@ jobs:
       #----------------------------------------------
       - name: Check out repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Setup JFrog
+        uses: ./.github/actions/setup-jfrog
       - name: Set up python ${{ matrix.python-version }}
         id: setup-python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/code-quality-checks.yml
+++ b/.github/workflows/code-quality-checks.yml
@@ -47,6 +47,11 @@ jobs:
           virtualenvs-create: true
           virtualenvs-in-project: true
           installer-parallel: true
+      - name: Configure Poetry for JFrog
+        run: |
+          poetry config repositories.jfrog https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple
+          poetry config http-basic.jfrog gha-service-account "${JFROG_ACCESS_TOKEN}"
+          poetry source add --priority=primary jfrog https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple
 
       #----------------------------------------------
       #       load cached venv if cache exists
@@ -135,6 +140,11 @@ jobs:
             virtualenvs-create: true
             virtualenvs-in-project: true
             installer-parallel: true
+      -   name: Configure Poetry for JFrog
+          run: |
+            poetry config repositories.jfrog https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple
+            poetry config http-basic.jfrog gha-service-account "${JFROG_ACCESS_TOKEN}"
+            poetry source add --priority=primary jfrog https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple
 
       #----------------------------------------------
       #       load cached venv if cache exists
@@ -217,6 +227,11 @@ jobs:
           virtualenvs-create: true
           virtualenvs-in-project: true
           installer-parallel: true
+      - name: Configure Poetry for JFrog
+        run: |
+          poetry config repositories.jfrog https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple
+          poetry config http-basic.jfrog gha-service-account "${JFROG_ACCESS_TOKEN}"
+          poetry source add --priority=primary jfrog https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple
 
       #----------------------------------------------
       #       load cached venv if cache exists
@@ -274,6 +289,11 @@ jobs:
           virtualenvs-create: true
           virtualenvs-in-project: true
           installer-parallel: true
+      - name: Configure Poetry for JFrog
+        run: |
+          poetry config repositories.jfrog https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple
+          poetry config http-basic.jfrog gha-service-account "${JFROG_ACCESS_TOKEN}"
+          poetry source add --priority=primary jfrog https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple
 
       #----------------------------------------------
       #       load cached venv if cache exists

--- a/.github/workflows/code-quality-checks.yml
+++ b/.github/workflows/code-quality-checks.yml
@@ -54,6 +54,7 @@ jobs:
           poetry config repositories.jfrog https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple
           poetry config http-basic.jfrog gha-service-account "${JFROG_ACCESS_TOKEN}"
           poetry source add --priority=primary jfrog https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple
+          poetry lock --no-update
 
       #----------------------------------------------
       #       load cached venv if cache exists
@@ -149,6 +150,7 @@ jobs:
             poetry config repositories.jfrog https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple
             poetry config http-basic.jfrog gha-service-account "${JFROG_ACCESS_TOKEN}"
             poetry source add --priority=primary jfrog https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple
+          poetry lock --no-update
 
       #----------------------------------------------
       #       load cached venv if cache exists
@@ -238,6 +240,7 @@ jobs:
           poetry config repositories.jfrog https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple
           poetry config http-basic.jfrog gha-service-account "${JFROG_ACCESS_TOKEN}"
           poetry source add --priority=primary jfrog https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple
+          poetry lock --no-update
 
       #----------------------------------------------
       #       load cached venv if cache exists
@@ -302,6 +305,7 @@ jobs:
           poetry config repositories.jfrog https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple
           poetry config http-basic.jfrog gha-service-account "${JFROG_ACCESS_TOKEN}"
           poetry source add --priority=primary jfrog https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple
+          poetry lock --no-update
 
       #----------------------------------------------
       #       load cached venv if cache exists

--- a/.github/workflows/code-quality-checks.yml
+++ b/.github/workflows/code-quality-checks.yml
@@ -25,24 +25,15 @@ jobs:
     name: "Unit Tests (Python ${{ matrix.python-version }}, ${{ matrix.dependency-version }} deps)"
 
     steps:
-      #----------------------------------------------
-      #       check-out repo and set-up python
-      #----------------------------------------------
       - name: Check out repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Setup JFrog
+        uses: ./.github/actions/setup-jfrog
       - name: Set up python ${{ matrix.python-version }}
         id: setup-python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ matrix.python-version }}
-      #----------------------------------------------
-      #  -----  configure JFrog PyPI proxy  -----
-      #----------------------------------------------
-      - name: Setup JFrog
-        uses: ./.github/actions/setup-jfrog
-      #----------------------------------------------
-      #  -----  install & configure poetry  -----
-      #----------------------------------------------
       - name: Install Poetry
         run: |
           pip install poetry==2.2.1
@@ -55,55 +46,36 @@ jobs:
           poetry config http-basic.jfrog gha-service-account "${JFROG_ACCESS_TOKEN}"
           poetry source add --priority=primary jfrog https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple
           poetry lock
-
-      #----------------------------------------------
-      #       load cached venv if cache exists
-      #----------------------------------------------
       - name: Load cached venv
         id: cached-poetry-dependencies
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: .venv
           key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ matrix.dependency-version }}-${{ github.event.repository.name }}-${{ hashFiles('**/poetry.lock') }}
-      #----------------------------------------------
-      # install dependencies if cache does not exist
-      #----------------------------------------------
       - name: Install dependencies
         if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
         run: poetry install --no-interaction --no-root
-      #----------------------------------------------
-      # install your root project, if required
-      #----------------------------------------------
       - name: Install library
         run: poetry install --no-interaction
-      #----------------------------------------------
-      # override with custom dependency versions
-      #----------------------------------------------
       - name: Install Python tools for custom versions
         if: matrix.dependency-version != 'default'
         run: poetry run pip install toml packaging
-
       - name: Generate requirements file
         if: matrix.dependency-version != 'default'
         run: |
           poetry run python scripts/dependency_manager.py ${{ matrix.dependency-version }} --output requirements-${{ matrix.dependency-version }}.txt
           echo "Generated requirements for ${{ matrix.dependency-version }} versions:"
           cat requirements-${{ matrix.dependency-version }}.txt
-
       - name: Override with custom dependency versions
         if: matrix.dependency-version != 'default'
         run: poetry run pip install -r requirements-${{ matrix.dependency-version }}.txt
-
-      #----------------------------------------------
-      #              run test suite
-      #----------------------------------------------
       - name: Show installed versions
         run: |
           echo "=== Dependency Version: ${{ matrix.dependency-version }} ==="
           poetry run pip list
-
       - name: Run tests
         run: poetry run python -m pytest tests/unit
+
   run-unit-tests-with-arrow:
     runs-on:
       group: databricks-protected-runner-group
@@ -121,114 +93,15 @@ jobs:
     name: "Unit Tests + PyArrow (Python ${{ matrix.python-version }}, ${{ matrix.dependency-version }} deps)"
 
     steps:
-      #----------------------------------------------
-      #       check-out repo and set-up python
-      #----------------------------------------------
-      -   name: Check out repository
-          uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
-      -   name: Set up python ${{ matrix.python-version }}
-          id: setup-python
-          uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2
-          with:
-            python-version: ${{ matrix.python-version }}
-      #----------------------------------------------
-      #  -----  configure JFrog PyPI proxy  -----
-      #----------------------------------------------
-      -   name: Setup JFrog
-          uses: ./.github/actions/setup-jfrog
-      #----------------------------------------------
-      #  -----  install & configure poetry  -----
-      #----------------------------------------------
-      -   name: Install Poetry
-          run: |
-            pip install poetry==2.2.1
-            poetry config virtualenvs.create true
-            poetry config virtualenvs.in-project true
-            poetry config installer.parallel true
-      -   name: Configure Poetry for JFrog
-          run: |
-            poetry config repositories.jfrog https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple
-            poetry config http-basic.jfrog gha-service-account "${JFROG_ACCESS_TOKEN}"
-            poetry source add --priority=primary jfrog https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple
-            poetry lock
-
-      #----------------------------------------------
-      #       load cached venv if cache exists
-      #----------------------------------------------
-      -   name: Load cached venv
-          id: cached-poetry-dependencies
-          uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
-          with:
-            path: .venv-pyarrow
-            key: venv-pyarrow-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ matrix.dependency-version }}-${{ github.event.repository.name }}-${{ hashFiles('**/poetry.lock') }}
-      #----------------------------------------------
-      # install dependencies if cache does not exist
-      #----------------------------------------------
-      -   name: Install dependencies
-          if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
-          run: poetry install --no-interaction --no-root
-      #----------------------------------------------
-      # install your root project, if required
-      #----------------------------------------------
-      -   name: Install Kerberos system dependencies
-          run: |
-            sudo apt-get update
-            sudo apt-get install -y libkrb5-dev
-      -   name: Install library
-          run: poetry install --no-interaction --all-extras
-      #----------------------------------------------
-      # override with custom dependency versions
-      #----------------------------------------------
-      -   name: Install Python tools for custom versions
-          if: matrix.dependency-version != 'default'
-          run: poetry run pip install toml packaging
-
-      -   name: Generate requirements file with pyarrow
-          if: matrix.dependency-version != 'default'
-          run: |
-            poetry run python scripts/dependency_manager.py ${{ matrix.dependency-version }} --output requirements-${{ matrix.dependency-version }}-arrow.txt
-            echo "Generated requirements for ${{ matrix.dependency-version }} versions with PyArrow:"
-            cat requirements-${{ matrix.dependency-version }}-arrow.txt
-
-      -   name: Override with custom dependency versions
-          if: matrix.dependency-version != 'default'
-          run: poetry run pip install -r requirements-${{ matrix.dependency-version }}-arrow.txt
-      #----------------------------------------------
-      #              run test suite
-      #----------------------------------------------
-      -   name: Show installed versions
-          run: |
-            echo "=== Dependency Version: ${{ matrix.dependency-version }} with PyArrow ==="
-            poetry run pip list
-
-      -   name: Run tests
-          run: poetry run python -m pytest tests/unit
-  check-linting:
-    runs-on:
-      group: databricks-protected-runner-group
-      labels: linux-ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
-    steps:
-      #----------------------------------------------
-      #       check-out repo and set-up python
-      #----------------------------------------------
       - name: Check out repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - name: Set up python ${{ matrix.python-version }}
-        id: setup-python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
-        with:
-          python-version: ${{ matrix.python-version }}
-      #----------------------------------------------
-      #  -----  configure JFrog PyPI proxy  -----
-      #----------------------------------------------
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
       - name: Setup JFrog
         uses: ./.github/actions/setup-jfrog
-      #----------------------------------------------
-      #  -----  install & configure poetry  -----
-      #----------------------------------------------
+      - name: Set up python ${{ matrix.python-version }}
+        id: setup-python
+        uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2
+        with:
+          python-version: ${{ matrix.python-version }}
       - name: Install Poetry
         run: |
           pip install poetry==2.2.1
@@ -241,30 +114,80 @@ jobs:
           poetry config http-basic.jfrog gha-service-account "${JFROG_ACCESS_TOKEN}"
           poetry source add --priority=primary jfrog https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple
           poetry lock
+      - name: Load cached venv
+        id: cached-poetry-dependencies
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: .venv-pyarrow
+          key: venv-pyarrow-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ matrix.dependency-version }}-${{ github.event.repository.name }}-${{ hashFiles('**/poetry.lock') }}
+      - name: Install dependencies
+        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
+        run: poetry install --no-interaction --no-root
+      - name: Install Kerberos system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libkrb5-dev
+      - name: Install library
+        run: poetry install --no-interaction --all-extras
+      - name: Install Python tools for custom versions
+        if: matrix.dependency-version != 'default'
+        run: poetry run pip install toml packaging
+      - name: Generate requirements file with pyarrow
+        if: matrix.dependency-version != 'default'
+        run: |
+          poetry run python scripts/dependency_manager.py ${{ matrix.dependency-version }} --output requirements-${{ matrix.dependency-version }}-arrow.txt
+          echo "Generated requirements for ${{ matrix.dependency-version }} versions with PyArrow:"
+          cat requirements-${{ matrix.dependency-version }}-arrow.txt
+      - name: Override with custom dependency versions
+        if: matrix.dependency-version != 'default'
+        run: poetry run pip install -r requirements-${{ matrix.dependency-version }}-arrow.txt
+      - name: Show installed versions
+        run: |
+          echo "=== Dependency Version: ${{ matrix.dependency-version }} with PyArrow ==="
+          poetry run pip list
+      - name: Run tests
+        run: poetry run python -m pytest tests/unit
 
-      #----------------------------------------------
-      #       load cached venv if cache exists
-      #----------------------------------------------
+  check-linting:
+    runs-on:
+      group: databricks-protected-runner-group
+      labels: linux-ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Setup JFrog
+        uses: ./.github/actions/setup-jfrog
+      - name: Set up python ${{ matrix.python-version }}
+        id: setup-python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install Poetry
+        run: |
+          pip install poetry==2.2.1
+          poetry config virtualenvs.create true
+          poetry config virtualenvs.in-project true
+          poetry config installer.parallel true
+      - name: Configure Poetry for JFrog
+        run: |
+          poetry config repositories.jfrog https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple
+          poetry config http-basic.jfrog gha-service-account "${JFROG_ACCESS_TOKEN}"
+          poetry source add --priority=primary jfrog https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple
+          poetry lock
       - name: Load cached venv
         id: cached-poetry-dependencies
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: .venv
           key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ github.event.repository.name }}-${{ hashFiles('**/poetry.lock') }}
-      #----------------------------------------------
-      # install dependencies if cache does not exist
-      #----------------------------------------------
       - name: Install dependencies
         if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
         run: poetry install --no-interaction --no-root
-      #----------------------------------------------
-      # install your root project, if required
-      #----------------------------------------------
       - name: Install library
         run: poetry install --no-interaction
-      #----------------------------------------------
-      #              black the code
-      #----------------------------------------------
       - name: Black
         run: poetry run black --check src
 
@@ -276,24 +199,15 @@ jobs:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
-      #----------------------------------------------
-      #       check-out repo and set-up python
-      #----------------------------------------------
       - name: Check out repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Setup JFrog
+        uses: ./.github/actions/setup-jfrog
       - name: Set up python ${{ matrix.python-version }}
         id: setup-python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ matrix.python-version }}
-      #----------------------------------------------
-      #  -----  configure JFrog PyPI proxy  -----
-      #----------------------------------------------
-      - name: Setup JFrog
-        uses: ./.github/actions/setup-jfrog
-      #----------------------------------------------
-      #  -----  install & configure poetry  -----
-      #----------------------------------------------
       - name: Install Poetry
         run: |
           pip install poetry==2.2.1
@@ -306,30 +220,17 @@ jobs:
           poetry config http-basic.jfrog gha-service-account "${JFROG_ACCESS_TOKEN}"
           poetry source add --priority=primary jfrog https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple
           poetry lock
-
-      #----------------------------------------------
-      #       load cached venv if cache exists
-      #----------------------------------------------
       - name: Load cached venv
         id: cached-poetry-dependencies
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: .venv
           key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ github.event.repository.name }}-${{ hashFiles('**/poetry.lock') }}
-      #----------------------------------------------
-      # install dependencies if cache does not exist
-      #----------------------------------------------
       - name: Install dependencies
         if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
         run: poetry install --no-interaction --no-root
-      #----------------------------------------------
-      # install your root project, if required
-      #----------------------------------------------
       - name: Install library
         run: poetry install --no-interaction
-      #----------------------------------------------
-      #              mypy the code
-      #----------------------------------------------
       - name: Mypy
         run: |
           mkdir .mypy_cache # Workaround for bad error message "error: --install-types failed (no mypy cache directory)"; see https://github.com/python/mypy/issues/10768#issuecomment-2178450153

--- a/.github/workflows/code-quality-checks.yml
+++ b/.github/workflows/code-quality-checks.yml
@@ -15,7 +15,6 @@ jobs:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
         dependency-version: ["default", "min"]
-        # Optimize matrix - test min/max on subset of Python versions
         exclude:
           - python-version: "3.12"
             dependency-version: "min"
@@ -27,36 +26,11 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - name: Setup JFrog
-        uses: ./.github/actions/setup-jfrog
-      - name: Set up python ${{ matrix.python-version }}
-        id: setup-python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+      - name: Setup Poetry
+        uses: ./.github/actions/setup-poetry
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install Poetry
-        run: |
-          pip install poetry==2.2.1
-          poetry config virtualenvs.create true
-          poetry config virtualenvs.in-project true
-          poetry config installer.parallel true
-      - name: Configure Poetry for JFrog
-        run: |
-          poetry config repositories.jfrog https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple
-          poetry config http-basic.jfrog gha-service-account "${JFROG_ACCESS_TOKEN}"
-          poetry source add --priority=primary jfrog https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple
-          poetry lock
-      - name: Load cached venv
-        id: cached-poetry-dependencies
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
-        with:
-          path: .venv
-          key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ matrix.dependency-version }}-${{ github.event.repository.name }}-${{ hashFiles('**/poetry.lock') }}
-      - name: Install dependencies
-        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
-        run: poetry install --no-interaction --no-root
-      - name: Install library
-        run: poetry install --no-interaction
+          cache-suffix: "${{ matrix.dependency-version }}-"
       - name: Install Python tools for custom versions
         if: matrix.dependency-version != 'default'
         run: poetry run pip install toml packaging
@@ -94,41 +68,18 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
-      - name: Setup JFrog
-        uses: ./.github/actions/setup-jfrog
-      - name: Set up python ${{ matrix.python-version }}
-        id: setup-python
-        uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install Poetry
-        run: |
-          pip install poetry==2.2.1
-          poetry config virtualenvs.create true
-          poetry config virtualenvs.in-project true
-          poetry config installer.parallel true
-      - name: Configure Poetry for JFrog
-        run: |
-          poetry config repositories.jfrog https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple
-          poetry config http-basic.jfrog gha-service-account "${JFROG_ACCESS_TOKEN}"
-          poetry source add --priority=primary jfrog https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple
-          poetry lock
-      - name: Load cached venv
-        id: cached-poetry-dependencies
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
-        with:
-          path: .venv-pyarrow
-          key: venv-pyarrow-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ matrix.dependency-version }}-${{ github.event.repository.name }}-${{ hashFiles('**/poetry.lock') }}
-      - name: Install dependencies
-        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
-        run: poetry install --no-interaction --no-root
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Install Kerberos system dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y libkrb5-dev
-      - name: Install library
-        run: poetry install --no-interaction --all-extras
+      - name: Setup Poetry
+        uses: ./.github/actions/setup-poetry
+        with:
+          python-version: ${{ matrix.python-version }}
+          install-args: "--all-extras"
+          cache-path: ".venv-pyarrow"
+          cache-suffix: "pyarrow-${{ matrix.dependency-version }}-"
       - name: Install Python tools for custom versions
         if: matrix.dependency-version != 'default'
         run: poetry run pip install toml packaging
@@ -158,36 +109,10 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - name: Setup JFrog
-        uses: ./.github/actions/setup-jfrog
-      - name: Set up python ${{ matrix.python-version }}
-        id: setup-python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+      - name: Setup Poetry
+        uses: ./.github/actions/setup-poetry
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install Poetry
-        run: |
-          pip install poetry==2.2.1
-          poetry config virtualenvs.create true
-          poetry config virtualenvs.in-project true
-          poetry config installer.parallel true
-      - name: Configure Poetry for JFrog
-        run: |
-          poetry config repositories.jfrog https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple
-          poetry config http-basic.jfrog gha-service-account "${JFROG_ACCESS_TOKEN}"
-          poetry source add --priority=primary jfrog https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple
-          poetry lock
-      - name: Load cached venv
-        id: cached-poetry-dependencies
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
-        with:
-          path: .venv
-          key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ github.event.repository.name }}-${{ hashFiles('**/poetry.lock') }}
-      - name: Install dependencies
-        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
-        run: poetry install --no-interaction --no-root
-      - name: Install library
-        run: poetry install --no-interaction
       - name: Black
         run: poetry run black --check src
 
@@ -201,37 +126,11 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - name: Setup JFrog
-        uses: ./.github/actions/setup-jfrog
-      - name: Set up python ${{ matrix.python-version }}
-        id: setup-python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+      - name: Setup Poetry
+        uses: ./.github/actions/setup-poetry
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install Poetry
-        run: |
-          pip install poetry==2.2.1
-          poetry config virtualenvs.create true
-          poetry config virtualenvs.in-project true
-          poetry config installer.parallel true
-      - name: Configure Poetry for JFrog
-        run: |
-          poetry config repositories.jfrog https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple
-          poetry config http-basic.jfrog gha-service-account "${JFROG_ACCESS_TOKEN}"
-          poetry source add --priority=primary jfrog https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple
-          poetry lock
-      - name: Load cached venv
-        id: cached-poetry-dependencies
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
-        with:
-          path: .venv
-          key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ github.event.repository.name }}-${{ hashFiles('**/poetry.lock') }}
-      - name: Install dependencies
-        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
-        run: poetry install --no-interaction --no-root
-      - name: Install library
-        run: poetry install --no-interaction
       - name: Mypy
         run: |
-          mkdir .mypy_cache # Workaround for bad error message "error: --install-types failed (no mypy cache directory)"; see https://github.com/python/mypy/issues/10768#issuecomment-2178450153
+          mkdir .mypy_cache
           poetry run mypy --install-types --non-interactive src

--- a/.github/workflows/daily-telemetry-e2e.yml
+++ b/.github/workflows/daily-telemetry-e2e.yml
@@ -3,7 +3,7 @@ name: Daily Telemetry E2E Tests
 on:
   schedule:
     - cron: '0 0 * * 0'  # Run every Sunday at midnight UTC
-  
+
   workflow_dispatch:  # Allow manual triggering
     inputs:
       test_pattern:
@@ -22,14 +22,14 @@ jobs:
       group: databricks-protected-runner-group
       labels: linux-ubuntu-latest
     environment: azure-prod
-    
+
     env:
       DATABRICKS_SERVER_HOSTNAME: ${{ secrets.DATABRICKS_HOST }}
       DATABRICKS_HTTP_PATH: ${{ secrets.TEST_PECO_WAREHOUSE_HTTP_PATH }}
       DATABRICKS_TOKEN: ${{ secrets.DATABRICKS_TOKEN }}
       DATABRICKS_CATALOG: peco
       DATABRICKS_USER: ${{ secrets.TEST_PECO_SP_ID }}
-    
+
     steps:
       #----------------------------------------------
       #       check-out repo and set-up python
@@ -37,15 +37,12 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Setup JFrog
-        uses: ./.github/actions/setup-jfrog
-
       - name: Set up python
         id: setup-python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.10"
-      
+
       #----------------------------------------------
       #  -----  install & configure poetry  -----
       #----------------------------------------------
@@ -56,6 +53,11 @@ jobs:
           virtualenvs-create: true
           virtualenvs-in-project: true
           installer-parallel: true
+      #----------------------------------------------
+      #  -----  configure JFrog PyPI proxy  -----
+      #----------------------------------------------
+      - name: Setup JFrog
+        uses: ./.github/actions/setup-jfrog
       - name: Configure Poetry for JFrog
         run: |
           poetry config repositories.jfrog https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple
@@ -71,7 +73,7 @@ jobs:
         with:
           path: .venv
           key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ github.event.repository.name }}-${{ hashFiles('**/poetry.lock') }}
-      
+
       #----------------------------------------------
       # install dependencies if cache does not exist
       #----------------------------------------------
@@ -81,7 +83,7 @@ jobs:
           sudo apt-get install -y libkrb5-dev
       - name: Install dependencies
         run: poetry install --no-interaction --all-extras
-      
+
       #----------------------------------------------
       #         run telemetry E2E tests
       #----------------------------------------------
@@ -90,7 +92,7 @@ jobs:
           TEST_PATTERN="${{ github.event.inputs.test_pattern || 'tests/e2e/test_telemetry_e2e.py' }}"
           echo "Running tests: $TEST_PATTERN"
           poetry run python -m pytest $TEST_PATTERN -v -s
-        
+
       #----------------------------------------------
       #       upload test results on failure
       #----------------------------------------------
@@ -103,4 +105,3 @@ jobs:
             .pytest_cache/
             tests-unsafe.log
           retention-days: 7
-

--- a/.github/workflows/daily-telemetry-e2e.yml
+++ b/.github/workflows/daily-telemetry-e2e.yml
@@ -33,37 +33,15 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - name: Setup JFrog
-        uses: ./.github/actions/setup-jfrog
-      - name: Set up python
-        id: setup-python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
-        with:
-          python-version: "3.10"
       - name: Install Kerberos system dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y libkrb5-dev
-      - name: Install Poetry
-        run: |
-          pip install poetry==2.2.1
-          poetry config virtualenvs.create true
-          poetry config virtualenvs.in-project true
-          poetry config installer.parallel true
-      - name: Configure Poetry for JFrog
-        run: |
-          poetry config repositories.jfrog https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple
-          poetry config http-basic.jfrog gha-service-account "${JFROG_ACCESS_TOKEN}"
-          poetry source add --priority=primary jfrog https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple
-          poetry lock
-      - name: Load cached venv
-        id: cached-poetry-dependencies
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      - name: Setup Poetry
+        uses: ./.github/actions/setup-poetry
         with:
-          path: .venv
-          key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ github.event.repository.name }}-${{ hashFiles('**/poetry.lock') }}
-      - name: Install dependencies
-        run: poetry install --no-interaction --all-extras
+          python-version: "3.10"
+          install-args: "--all-extras"
       - name: Run telemetry E2E tests
         run: |
           TEST_PATTERN="${{ github.event.inputs.test_pattern || 'tests/e2e/test_telemetry_e2e.py' }}"

--- a/.github/workflows/daily-telemetry-e2e.yml
+++ b/.github/workflows/daily-telemetry-e2e.yml
@@ -14,10 +14,13 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   telemetry-e2e-tests:
-    runs-on: ubuntu-latest
+    runs-on:
+      group: databricks-protected-runner-group
+      labels: linux-ubuntu-latest
     environment: azure-prod
     
     env:
@@ -33,7 +36,10 @@ jobs:
       #----------------------------------------------
       - name: Check out repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      
+
+      - name: Setup JFrog
+        uses: ./.github/actions/setup-jfrog
+
       - name: Set up python
         id: setup-python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/daily-telemetry-e2e.yml
+++ b/.github/workflows/daily-telemetry-e2e.yml
@@ -56,6 +56,11 @@ jobs:
           virtualenvs-create: true
           virtualenvs-in-project: true
           installer-parallel: true
+      - name: Configure Poetry for JFrog
+        run: |
+          poetry config repositories.jfrog https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple
+          poetry config http-basic.jfrog gha-service-account "${JFROG_ACCESS_TOKEN}"
+          poetry source add --priority=primary jfrog https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple
 
       #----------------------------------------------
       #       load cached venv if cache exists

--- a/.github/workflows/daily-telemetry-e2e.yml
+++ b/.github/workflows/daily-telemetry-e2e.yml
@@ -42,22 +42,20 @@ jobs:
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.10"
-
-      #----------------------------------------------
-      #  -----  install & configure poetry  -----
-      #----------------------------------------------
-      - name: Install Poetry
-        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1
-        with:
-          version: "2.2.1"
-          virtualenvs-create: true
-          virtualenvs-in-project: true
-          installer-parallel: true
       #----------------------------------------------
       #  -----  configure JFrog PyPI proxy  -----
       #----------------------------------------------
       - name: Setup JFrog
         uses: ./.github/actions/setup-jfrog
+      #----------------------------------------------
+      #  -----  install & configure poetry  -----
+      #----------------------------------------------
+      - name: Install Poetry
+        run: |
+          pip install poetry==2.2.1
+          poetry config virtualenvs.create true
+          poetry config virtualenvs.in-project true
+          poetry config installer.parallel true
       - name: Configure Poetry for JFrog
         run: |
           poetry config repositories.jfrog https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple

--- a/.github/workflows/daily-telemetry-e2e.yml
+++ b/.github/workflows/daily-telemetry-e2e.yml
@@ -61,7 +61,7 @@ jobs:
           poetry config repositories.jfrog https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple
           poetry config http-basic.jfrog gha-service-account "${JFROG_ACCESS_TOKEN}"
           poetry source add --priority=primary jfrog https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple
-          poetry lock --no-update
+          poetry lock
 
       #----------------------------------------------
       #       load cached venv if cache exists

--- a/.github/workflows/daily-telemetry-e2e.yml
+++ b/.github/workflows/daily-telemetry-e2e.yml
@@ -31,25 +31,19 @@ jobs:
       DATABRICKS_USER: ${{ secrets.TEST_PECO_SP_ID }}
 
     steps:
-      #----------------------------------------------
-      #       check-out repo and set-up python
-      #----------------------------------------------
       - name: Check out repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-
+      - name: Setup JFrog
+        uses: ./.github/actions/setup-jfrog
       - name: Set up python
         id: setup-python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.10"
-      #----------------------------------------------
-      #  -----  configure JFrog PyPI proxy  -----
-      #----------------------------------------------
-      - name: Setup JFrog
-        uses: ./.github/actions/setup-jfrog
-      #----------------------------------------------
-      #  -----  install & configure poetry  -----
-      #----------------------------------------------
+      - name: Install Kerberos system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libkrb5-dev
       - name: Install Poetry
         run: |
           pip install poetry==2.2.1
@@ -62,39 +56,19 @@ jobs:
           poetry config http-basic.jfrog gha-service-account "${JFROG_ACCESS_TOKEN}"
           poetry source add --priority=primary jfrog https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple
           poetry lock
-
-      #----------------------------------------------
-      #       load cached venv if cache exists
-      #----------------------------------------------
       - name: Load cached venv
         id: cached-poetry-dependencies
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: .venv
           key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ github.event.repository.name }}-${{ hashFiles('**/poetry.lock') }}
-
-      #----------------------------------------------
-      # install dependencies if cache does not exist
-      #----------------------------------------------
-      - name: Install Kerberos system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libkrb5-dev
       - name: Install dependencies
         run: poetry install --no-interaction --all-extras
-
-      #----------------------------------------------
-      #         run telemetry E2E tests
-      #----------------------------------------------
       - name: Run telemetry E2E tests
         run: |
           TEST_PATTERN="${{ github.event.inputs.test_pattern || 'tests/e2e/test_telemetry_e2e.py' }}"
           echo "Running tests: $TEST_PATTERN"
           poetry run python -m pytest $TEST_PATTERN -v -s
-
-      #----------------------------------------------
-      #       upload test results on failure
-      #----------------------------------------------
       - name: Upload test results on failure
         if: failure()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4

--- a/.github/workflows/daily-telemetry-e2e.yml
+++ b/.github/workflows/daily-telemetry-e2e.yml
@@ -61,6 +61,7 @@ jobs:
           poetry config repositories.jfrog https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple
           poetry config http-basic.jfrog gha-service-account "${JFROG_ACCESS_TOKEN}"
           poetry source add --priority=primary jfrog https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple
+          poetry lock --no-update
 
       #----------------------------------------------
       #       load cached venv if cache exists

--- a/.github/workflows/dco-check.yml
+++ b/.github/workflows/dco-check.yml
@@ -10,7 +10,9 @@ permissions:
 
 jobs:
   dco-check:
-    runs-on: ubuntu-latest
+    runs-on:
+      group: databricks-protected-runner-group
+      labels: linux-ubuntu-latest
     name: Check DCO Sign-off
     steps:
       - name: Checkout

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,7 +1,7 @@
 name: Integration Tests
 
 on:
-  push:            
+  push:
     branches:
       - main
   pull_request:
@@ -28,8 +28,6 @@ jobs:
       #----------------------------------------------
       - name: Check out repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - name: Setup JFrog
-        uses: ./.github/actions/setup-jfrog
       - name: Set up python
         id: setup-python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
@@ -45,6 +43,11 @@ jobs:
           virtualenvs-create: true
           virtualenvs-in-project: true
           installer-parallel: true
+      #----------------------------------------------
+      #  -----  configure JFrog PyPI proxy  -----
+      #----------------------------------------------
+      - name: Setup JFrog
+        uses: ./.github/actions/setup-jfrog
       - name: Configure Poetry for JFrog
         run: |
           poetry config repositories.jfrog https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple
@@ -95,8 +98,6 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - name: Setup JFrog
-        uses: ./.github/actions/setup-jfrog
       - name: Set up python
         id: setup-python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
@@ -112,6 +113,11 @@ jobs:
           virtualenvs-create: true
           virtualenvs-in-project: true
           installer-parallel: true
+      #----------------------------------------------
+      #  -----  configure JFrog PyPI proxy  -----
+      #----------------------------------------------
+      - name: Setup JFrog
+        uses: ./.github/actions/setup-jfrog
       - name: Configure Poetry for JFrog
         run: |
           poetry config repositories.jfrog https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -52,7 +52,7 @@ jobs:
           poetry config repositories.jfrog https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple
           poetry config http-basic.jfrog gha-service-account "${JFROG_ACCESS_TOKEN}"
           poetry source add --priority=primary jfrog https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple
-          poetry lock --no-update
+          poetry lock
 
       #----------------------------------------------
       #       load cached venv if cache exists
@@ -123,7 +123,7 @@ jobs:
           poetry config repositories.jfrog https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple
           poetry config http-basic.jfrog gha-service-account "${JFROG_ACCESS_TOKEN}"
           poetry source add --priority=primary jfrog https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple
-          poetry lock --no-update
+          poetry lock
       - name: Load cached venv
         id: cached-poetry-dependencies
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -25,37 +25,15 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - name: Setup JFrog
-        uses: ./.github/actions/setup-jfrog
-      - name: Set up python
-        id: setup-python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
-        with:
-          python-version: "3.10"
-      - name: Install Poetry
-        run: |
-          pip install poetry==2.2.1
-          poetry config virtualenvs.create true
-          poetry config virtualenvs.in-project true
-          poetry config installer.parallel true
-      - name: Configure Poetry for JFrog
-        run: |
-          poetry config repositories.jfrog https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple
-          poetry config http-basic.jfrog gha-service-account "${JFROG_ACCESS_TOKEN}"
-          poetry source add --priority=primary jfrog https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple
-          poetry lock
-      - name: Load cached venv
-        id: cached-poetry-dependencies
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
-        with:
-          path: .venv
-          key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ github.event.repository.name }}-${{ hashFiles('**/poetry.lock') }}
       - name: Install Kerberos system dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y libkrb5-dev
-      - name: Install dependencies
-        run: poetry install --no-interaction --all-extras
+      - name: Setup Poetry
+        uses: ./.github/actions/setup-poetry
+        with:
+          python-version: "3.10"
+          install-args: "--all-extras"
       - name: Run non-telemetry e2e tests
         run: |
           poetry run python -m pytest tests/e2e \
@@ -78,37 +56,15 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - name: Setup JFrog
-        uses: ./.github/actions/setup-jfrog
-      - name: Set up python
-        id: setup-python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
-        with:
-          python-version: "3.10"
       - name: Install system dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y libkrb5-dev
-      - name: Install Poetry
-        run: |
-          pip install poetry==2.2.1
-          poetry config virtualenvs.create true
-          poetry config virtualenvs.in-project true
-          poetry config installer.parallel true
-      - name: Configure Poetry for JFrog
-        run: |
-          poetry config repositories.jfrog https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple
-          poetry config http-basic.jfrog gha-service-account "${JFROG_ACCESS_TOKEN}"
-          poetry source add --priority=primary jfrog https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple
-          poetry lock
-      - name: Load cached venv
-        id: cached-poetry-dependencies
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      - name: Setup Poetry
+        uses: ./.github/actions/setup-poetry
         with:
-          path: .venv
-          key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ github.event.repository.name }}-${{ hashFiles('**/poetry.lock') }}
-      - name: Install dependencies
-        run: poetry install --no-interaction --all-extras
+          python-version: "3.10"
+          install-args: "--all-extras"
       - name: Run telemetry tests in isolation
         run: |
           poetry run python -m pytest tests/e2e/test_concurrent_telemetry.py \

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -34,20 +34,19 @@ jobs:
         with:
           python-version: "3.10"
       #----------------------------------------------
-      #  -----  install & configure poetry  -----
-      #----------------------------------------------
-      - name: Install Poetry
-        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1
-        with:
-          version: "2.2.1"
-          virtualenvs-create: true
-          virtualenvs-in-project: true
-          installer-parallel: true
-      #----------------------------------------------
       #  -----  configure JFrog PyPI proxy  -----
       #----------------------------------------------
       - name: Setup JFrog
         uses: ./.github/actions/setup-jfrog
+      #----------------------------------------------
+      #  -----  install & configure poetry  -----
+      #----------------------------------------------
+      - name: Install Poetry
+        run: |
+          pip install poetry==2.2.1
+          poetry config virtualenvs.create true
+          poetry config virtualenvs.in-project true
+          poetry config installer.parallel true
       - name: Configure Poetry for JFrog
         run: |
           poetry config repositories.jfrog https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple
@@ -103,21 +102,21 @@ jobs:
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.10"
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libkrb5-dev
-      - name: Install Poetry
-        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1
-        with:
-          virtualenvs-create: true
-          virtualenvs-in-project: true
-          installer-parallel: true
       #----------------------------------------------
       #  -----  configure JFrog PyPI proxy  -----
       #----------------------------------------------
       - name: Setup JFrog
         uses: ./.github/actions/setup-jfrog
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libkrb5-dev
+      - name: Install Poetry
+        run: |
+          pip install poetry==2.2.1
+          poetry config virtualenvs.create true
+          poetry config virtualenvs.in-project true
+          poetry config installer.parallel true
       - name: Configure Poetry for JFrog
         run: |
           poetry config repositories.jfrog https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -45,6 +45,11 @@ jobs:
           virtualenvs-create: true
           virtualenvs-in-project: true
           installer-parallel: true
+      - name: Configure Poetry for JFrog
+        run: |
+          poetry config repositories.jfrog https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple
+          poetry config http-basic.jfrog gha-service-account "${JFROG_ACCESS_TOKEN}"
+          poetry source add --priority=primary jfrog https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple
 
       #----------------------------------------------
       #       load cached venv if cache exists
@@ -107,6 +112,11 @@ jobs:
           virtualenvs-create: true
           virtualenvs-in-project: true
           installer-parallel: true
+      - name: Configure Poetry for JFrog
+        run: |
+          poetry config repositories.jfrog https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple
+          poetry config http-basic.jfrog gha-service-account "${JFROG_ACCESS_TOKEN}"
+          poetry source add --priority=primary jfrog https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple
       - name: Load cached venv
         id: cached-poetry-dependencies
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -23,24 +23,15 @@ jobs:
       DATABRICKS_CATALOG: peco
       DATABRICKS_USER: ${{ secrets.TEST_PECO_SP_ID }}
     steps:
-      #----------------------------------------------
-      #       check-out repo and set-up python
-      #----------------------------------------------
       - name: Check out repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Setup JFrog
+        uses: ./.github/actions/setup-jfrog
       - name: Set up python
         id: setup-python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.10"
-      #----------------------------------------------
-      #  -----  configure JFrog PyPI proxy  -----
-      #----------------------------------------------
-      - name: Setup JFrog
-        uses: ./.github/actions/setup-jfrog
-      #----------------------------------------------
-      #  -----  install & configure poetry  -----
-      #----------------------------------------------
       - name: Install Poetry
         run: |
           pip install poetry==2.2.1
@@ -53,31 +44,20 @@ jobs:
           poetry config http-basic.jfrog gha-service-account "${JFROG_ACCESS_TOKEN}"
           poetry source add --priority=primary jfrog https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple
           poetry lock
-
-      #----------------------------------------------
-      #       load cached venv if cache exists
-      #----------------------------------------------
       - name: Load cached venv
         id: cached-poetry-dependencies
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: .venv
           key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ github.event.repository.name }}-${{ hashFiles('**/poetry.lock') }}
-      #----------------------------------------------
-      # install dependencies if cache does not exist
-      #----------------------------------------------
       - name: Install Kerberos system dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y libkrb5-dev
       - name: Install dependencies
         run: poetry install --no-interaction --all-extras
-      #----------------------------------------------
-      #              run test suite
-      #----------------------------------------------
       - name: Run non-telemetry e2e tests
         run: |
-          # Exclude all telemetry tests - they run in separate job for isolation
           poetry run python -m pytest tests/e2e \
             --ignore=tests/e2e/test_telemetry_e2e.py \
             --ignore=tests/e2e/test_concurrent_telemetry.py \
@@ -87,7 +67,7 @@ jobs:
     runs-on:
       group: databricks-protected-runner-group
       labels: linux-ubuntu-latest
-    needs: run-non-telemetry-tests  # Run after non-telemetry tests complete
+    needs: run-non-telemetry-tests
     environment: azure-prod
     env:
       DATABRICKS_SERVER_HOSTNAME: ${{ secrets.DATABRICKS_HOST }}
@@ -98,16 +78,13 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Setup JFrog
+        uses: ./.github/actions/setup-jfrog
       - name: Set up python
         id: setup-python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.10"
-      #----------------------------------------------
-      #  -----  configure JFrog PyPI proxy  -----
-      #----------------------------------------------
-      - name: Setup JFrog
-        uses: ./.github/actions/setup-jfrog
       - name: Install system dependencies
         run: |
           sudo apt-get update
@@ -134,7 +111,5 @@ jobs:
         run: poetry install --no-interaction --all-extras
       - name: Run telemetry tests in isolation
         run: |
-          # Run test_concurrent_telemetry.py in isolation with complete process separation
-          # Use --dist=loadgroup to respect @pytest.mark.xdist_group markers
           poetry run python -m pytest tests/e2e/test_concurrent_telemetry.py \
             -n auto --dist=loadgroup -v

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -52,6 +52,7 @@ jobs:
           poetry config repositories.jfrog https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple
           poetry config http-basic.jfrog gha-service-account "${JFROG_ACCESS_TOKEN}"
           poetry source add --priority=primary jfrog https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple
+          poetry lock --no-update
 
       #----------------------------------------------
       #       load cached venv if cache exists
@@ -122,6 +123,7 @@ jobs:
           poetry config repositories.jfrog https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple
           poetry config http-basic.jfrog gha-service-account "${JFROG_ACCESS_TOKEN}"
           poetry source add --priority=primary jfrog https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple
+          poetry lock --no-update
       - name: Load cached venv
         id: cached-poetry-dependencies
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -8,10 +8,13 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   run-non-telemetry-tests:
-    runs-on: ubuntu-latest
+    runs-on:
+      group: databricks-protected-runner-group
+      labels: linux-ubuntu-latest
     environment: azure-prod
     env:
       DATABRICKS_SERVER_HOSTNAME: ${{ secrets.DATABRICKS_HOST }}
@@ -25,6 +28,8 @@ jobs:
       #----------------------------------------------
       - name: Check out repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Setup JFrog
+        uses: ./.github/actions/setup-jfrog
       - name: Set up python
         id: setup-python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
@@ -71,7 +76,9 @@ jobs:
             -n auto
 
   run-telemetry-tests:
-    runs-on: ubuntu-latest
+    runs-on:
+      group: databricks-protected-runner-group
+      labels: linux-ubuntu-latest
     needs: run-non-telemetry-tests  # Run after non-telemetry tests complete
     environment: azure-prod
     env:
@@ -83,6 +90,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Setup JFrog
+        uses: ./.github/actions/setup-jfrog
       - name: Set up python
         id: setup-python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5


### PR DESCRIPTION
## Summary
- Switched all workflow jobs (9 total across 5 workflows) from `ubuntu-latest` to `databricks-protected-runner-group` with `linux-ubuntu-latest` labels
- Added `.github/actions/setup-jfrog/action.yml` composite action that obtains a JFrog access token via GitHub OIDC and sets `PIP_INDEX_URL` so all pip/poetry installs route through `databricks.jfrog.io/artifactory/api/pypi/db-pypi`
- Added `id-token: write` permission to all workflows that install Python packages (required for the OIDC token exchange)
- Setup mirrors the pattern used in `databricks-odbc` for consistency across repos

## Test plan
- [ ] Verify all CI checks pass on this PR (protected runner access + JFrog OIDC working)
- [ ] Confirm package installation succeeds through JFrog proxy (check poetry install logs)
- [ ] DCO check still works (no JFrog needed, just runner change)

This pull request was AI-assisted by Isaac.