### PR TITLE
Fix inline list parameter rendering for IN clauses

### DIFF
--- a/src/databricks/sql/utils.py
+++ b/src/databricks/sql/utils.py
@@ -542,15 +542,21 @@ class ParamEscaper:
     _TIME_FORMAT = "%H:%M:%S.%f %z"
     _DATETIME_FORMAT = "{} {}".format(_DATE_FORMAT, _TIME_FORMAT)
 
-    def escape_args(self, parameters):
+        def escape_args(self, parameters):
         if isinstance(parameters, dict):
-            return {k: self.escape_item(v) for k, v in parameters.items()}
+            return {k: self.escape_inline_arg(v) for k, v in parameters.items()}
         elif isinstance(parameters, (list, tuple)):
-            return tuple(self.escape_item(x) for x in parameters)
+            return tuple(self.escape_inline_arg(x) for x in parameters)
         else:
             raise exc.ProgrammingError(
                 "Unsupported param format: {}".format(parameters)
             )
+
+    def escape_inline_arg(self, item):
+        if isinstance(item, (list, tuple)):
+            escaped_items = list(map(str, map(self.escape_item, item)))
+            return "(" + ",".join(escaped_items) + ")"
+        return self.escape_item(item)
 
     def escape_number(self, item):
         return item

--- a/tests/unit/test_param_escaper.py
+++ b/tests/unit/test_param_escaper.py
@@ -196,6 +196,21 @@ class TestFullQueryEscaping(object):
         with pytest.raises(Exception):
             inject_parameters(INPUT, pe.escape_args(args))
 
+    def test_in_clause_with_positional_list_param(self):
+        query = "SELECT * FROM table WHERE something IN %s"
+        args = ([1, 2, 3],)
+
+        rendered = inject_parameters(query, pe.escape_args(args))
+
+        assert rendered == "SELECT * FROM table WHERE something IN (1,2,3)"
+
+    def test_in_clause_with_named_list_param(self):
+        query = "SELECT * FROM table WHERE something IN %(ids)s"
+        args = {"ids": [1, 2, 3]}
+
+        rendered = inject_parameters(query, pe.escape_args(args))
+
+        assert rendered == "SELECT * FROM table WHERE something IN (1,2,3)"
 
 class TestInlineToNativeTransformer(object):
     @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- We welcome contributions. All patches must include a sign-off. Please see CONTRIBUTING.md for details -->


## What type of PR is this?
<!-- Check all that apply, delete what doesn't apply. -->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Other

## Description
Fixes #629
Closes #629 

Summary
- add regression tests for inline list parameters used in `IN` clauses
- render top-level inline list parameters as `(…)` instead of `ARRAY(…)`
- keep nested sequence escaping behavior unchanged

## How is this tested?
- poetry run python -m pytest tests/unit/test_param_escaper.py
- poetry run python -m pytest tests/unit/test_parameters.py tests/unit/test_param_escaper.py
- poetry run python -m pytest tests/unit
- poetry run python -m black src tests --check


- [x] Unit tests
- [ ] E2E Tests
- [ ] Manually
- [ ] N/A

<!-- If Manually, please describe. -->

## Related Tickets & Documents
Closes #629 