### PR TITLE
Fix dependency_manager: handle PEP 440 ~= compatible release syntax

### DIFF
--- a/scripts/dependency_manager.py
+++ b/scripts/dependency_manager.py
@@ -69,16 +69,21 @@ class DependencyManager:
     def _extract_versions_from_specifier(self, spec_set_str):
         """Extract minimum version from a specifier set"""
         try:
-            # Handle caret (^) and tilde (~) constraints that packaging doesn't support
+            # Handle caret (^) and tilde (~, ~=) constraints that packaging doesn't
+            # support (Poetry ^, Poetry ~, and PEP 440 ~=).
             if spec_set_str.startswith('^'):
                 # ^1.2.3 means >=1.2.3, <2.0.0
                 min_version = spec_set_str[1:]  # Remove ^
                 return min_version, None
+            elif spec_set_str.startswith('~='):
+                # PEP 440 compatible release: ~=1.2.3 means >=1.2.3, <1.3.0
+                min_version = spec_set_str[2:]  # Remove ~=
+                return min_version, None
             elif spec_set_str.startswith('~'):
-                # ~1.2.3 means >=1.2.3, <1.3.0
+                # Poetry tilde: ~1.2.3 means >=1.2.3, <1.3.0
                 min_version = spec_set_str[1:]  # Remove ~
                 return min_version, None
-            
+
             spec_set = SpecifierSet(spec_set_str)
             min_version = None
             


### PR DESCRIPTION
## Summary
Fixes a bug in `scripts/dependency_manager.py` where PEP 440 compatible release syntax (`~=`) was incorrectly handled, breaking every PR's "Unit Tests (min deps)" job.

## What broke
PR #733 ("Bump thrift to fix deprecation warning") changed `pyproject.toml`:
```toml
- thrift = ">=0.16.0,<0.21.0"
+ thrift = "~=0.22.0"
```

`scripts/dependency_manager.py::_extract_versions_from_specifier` had a branch for Poetry-style `~` (single tilde) that strips one character. When applied to `~=0.22.0`, it left `=0.22.0` (with stray `=`). The downstream `_create_flexible_minimum_constraint` then produced the invalid constraint:
```
thrift>==0.22.0,<=0.23.0
```

`pip install` rejects this with `InvalidRequirement: Expected end or semicolon`, failing every PR's min-deps install step.

## Fix
Add an explicit branch for `~=` that strips both characters before extracting the minimum version. The Poetry-style single `~` branch is preserved for backward compatibility.

```python
elif spec_set_str.startswith('~='):
    # PEP 440 compatible release: ~=1.2.3 means >=1.2.3, <1.3.0
    min_version = spec_set_str[2:]  # Remove ~=
    return min_version, None
```

## How #733 got merged
PR #733 was merged with **no CI checks reported on the branch** — branch protection allowed the merge to bypass the unit test workflows that would have caught this. Worth investigating that separately.

## Test plan
- [x] Generated min requirements locally before fix → `thrift>==0.22.0,<=0.23.0` (invalid)
- [x] Generated min requirements locally after fix → `thrift>=0.22.0,<0.23.0` (valid)
- [ ] Verify CI's Unit Tests (min deps) jobs pass on this PR

NO_CHANGELOG=true

This pull request was AI-assisted by Isaac.