### PR TITLE
[PECOBLR-2461] Fix test_show_columns_blocked: SHOW COLUMNS now allowed in MST

### DIFF
--- a/tests/e2e/test_transactions.py
+++ b/tests/e2e/test_transactions.py
@@ -624,17 +624,21 @@ class TestMstMetadata:
 class TestMstBlockedSql:
     """SQL introspection statements inside active transactions.
 
-    The server restricts MST to a specific allowlist of commands. The error
-    message from TRANSACTION_NOT_SUPPORTED.COMMAND is explicit:
+    The server restricts MST to an allowlist enforced by MSTCheckRule. The
+    TRANSACTION_NOT_SUPPORTED.COMMAND error originally advertised only:
     "Only SELECT / INSERT / MERGE / UPDATE / DELETE / DESCRIBE TABLE are supported."
 
+    The server has since broadened the allowlist to include SHOW COLUMNS
+    (ShowDeltaTableColumnsCommand), observed on current DBSQL warehouses.
+
     Blocked (throw + abort txn):
-    - SHOW COLUMNS, SHOW TABLES, SHOW SCHEMAS, SHOW CATALOGS, SHOW FUNCTIONS
+    - SHOW TABLES, SHOW SCHEMAS, SHOW CATALOGS, SHOW FUNCTIONS
     - DESCRIBE QUERY, DESCRIBE TABLE EXTENDED
     - SELECT FROM information_schema
 
     Allowed:
-    - DESCRIBE TABLE (basic form — explicitly listed in server's allowlist)
+    - DESCRIBE TABLE (basic form)
+    - SHOW COLUMNS
     """
 
     def _assert_blocked_and_txn_aborted(self, mst_conn_params, fq_table, blocked_sql):
@@ -704,10 +708,10 @@ class TestMstBlockedSql:
             f"SELECT * FROM {mst_catalog}.information_schema.columns LIMIT 1",
         )
 
-    def test_show_columns_blocked(self, mst_conn_params, mst_table):
-        """SHOW COLUMNS is blocked in MST (ShowDeltaTableColumnsCommand)."""
+    def test_show_columns_not_blocked(self, mst_conn_params, mst_table):
+        """SHOW COLUMNS succeeds in MST — allowed by the server's MSTCheckRule allowlist."""
         fq_table, _ = mst_table
-        self._assert_blocked_and_txn_aborted(
+        self._assert_not_blocked(
             mst_conn_params, fq_table, f"SHOW COLUMNS IN {fq_table}"
         )
 


### PR DESCRIPTION
## Summary

`test_show_columns_blocked` started failing on main after PR #775 merged ([example CI run](https://github.com/databricks/databricks-sql-python/actions/runs/24820384682/job/72646856071)). Root cause: the server's MSTCheckRule allowlist has been broadened to include `SHOW COLUMNS` (`ShowDeltaTableColumnsCommand`), so executing `SHOW COLUMNS IN <table>` inside an MST transaction no longer raises.

This PR flips the test to assert `SHOW COLUMNS` **succeeds** inside an active transaction, mirroring the existing `test_describe_table_not_blocked` pattern.

All other MST-blocked SQL assertions (`SHOW SCHEMAS` / `TABLES` / `CATALOGS` / `FUNCTIONS`, `DESCRIBE QUERY`, `DESCRIBE TABLE EXTENDED`, `information_schema`) still correctly raise, so the rest of the `TestMstBlockedSql` class is unchanged.

## Changes

- Renamed `test_show_columns_blocked` → `test_show_columns_not_blocked` and switched it to `_assert_not_blocked`.
- Updated the `TestMstBlockedSql` class docstring to reflect the current allowlist (SHOW COLUMNS moved from Blocked → Allowed).

## Test plan

- [ ] Re-run e2e suite on main after merge; `test_show_columns_not_blocked` should PASS.
- [ ] Confirm other `TestMstBlockedSql::test_show_*_blocked` tests still PASS.

This pull request and its description were written by Isaac.

---
_This PR was created with [GitHub MCP](http://go/mcps)._