### PR TITLE
fix: close unfetched async commands

### DIFF
--- a/src/databricks/sql/client.py
+++ b/src/databricks/sql/client.py
@@ -1713,9 +1713,13 @@ class Cursor:
     def close(self) -> None:
         """Close cursor"""
         self.open = False
-        self.active_command_id = None
-        if self.active_result_set:
-            self._close_and_clear_active_result_set()
+        try:
+            if self.active_result_set:
+                self._close_and_clear_active_result_set()
+            elif self.active_command_id is not None:
+                self.backend.close_command(self.active_command_id)
+        finally:
+            self.active_command_id = None
 
     @property
     def query_id(self) -> Optional[str]:

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -280,6 +280,33 @@ class ClientTestSuite(unittest.TestCase):
             cursor.close = mock_close
         mock_close.assert_called_once_with()
 
+    def test_close_closes_active_command_without_result_set(self):
+        mock_backend = Mock()
+        mock_command_id = Mock(spec=CommandId)
+        cursor = client.Cursor(Mock(), mock_backend)
+        cursor.active_command_id = mock_command_id
+
+        cursor.close()
+
+        mock_backend.close_command.assert_called_once_with(mock_command_id)
+        self.assertIsNone(cursor.active_command_id)
+        self.assertIsNone(cursor.active_result_set)
+
+    def test_close_delegates_to_active_result_set_without_double_closing_command(self):
+        mock_backend = Mock()
+        mock_result_set = Mock()
+        mock_command_id = Mock(spec=CommandId)
+        cursor = client.Cursor(Mock(), mock_backend)
+        cursor.active_result_set = mock_result_set
+        cursor.active_command_id = mock_command_id
+
+        cursor.close()
+
+        mock_result_set.close.assert_called_once_with()
+        mock_backend.close_command.assert_not_called()
+        self.assertIsNone(cursor.active_command_id)
+        self.assertIsNone(cursor.active_result_set)
+
     def dict_product(self, dicts):
         """
         Generate cartesion product of values in input dictionary, outputting a dictionary


### PR DESCRIPTION
## Summary

`Cursor.close()` now frees an active async command id when no result set has been fetched yet. This covers the `execute_async()` followed by `close()` path from #791, where `active_command_id` is set but `active_result_set` is still `None`.

When a result set exists, close still delegates to `active_result_set.close()` so that path can perform its existing backend cleanup without a duplicate `close_command` call. The cursor clears `active_command_id` in a `finally` block either way.

## Tests

- `PYTHONPATH=src uv run --with pytest --with thrift --with pandas --with lz4 --with requests --with oauthlib --with openpyxl --with urllib3 --with python-dateutil --with pyjwt --with pybreaker --python 3.12 --env-file test.env.example python -m pytest tests/unit/test_client.py -k 'close_closes_active_command_without_result_set or close_delegates_to_active_result_set_without_double_closing_command or closing_result_set_hard_closes_commands or closing_connection_closes_commands'`
- `uv run --with black==22.3.0 --python 3.12 black --check src/databricks/sql/client.py tests/unit/test_client.py`
- `git diff --check`

Closes #791
