### PR TITLE
Bump thrift to 0.23.0

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1849,19 +1849,19 @@ files = [
 
 [[package]]
 name = "thrift"
-version = "0.22.0"
+version = "0.23.0"
 description = "Python bindings for the Apache Thrift RPC system"
 optional = false
 python-versions = "*"
 groups = ["main"]
 files = [
-    {file = "thrift-0.22.0.tar.gz", hash = "sha256:42e8276afbd5f54fe1d364858b6877bc5e5a4a5ed69f6a005b94ca4918fe1466"},
+    {file = "thrift-0.23.0.tar.gz", hash = "sha256:5f43448a92c36ed6a450048355d10e231a1787e4c28965f08fabac0eb978914c"},
 ]
 
 [package.extras]
-all = ["tornado (>=4.0)", "twisted"]
-tornado = ["tornado (>=4.0)"]
-twisted = ["twisted"]
+all = ["tornado (>=6.3.0)", "twisted (>=24.3.0)", "zope.interface (>=6.1)"]
+tornado = ["tornado (>=6.3.0)"]
+twisted = ["twisted (>=24.3.0)", "zope.interface (>=6.1)"]
 
 [[package]]
 name = "tomli"
@@ -1966,4 +1966,4 @@ pyarrow = ["pyarrow", "pyarrow", "pyarrow"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.8.0"
-content-hash = "d1739e84dcbd6e7ac311eb6fbb9cf87ad110491f7d954f07fdfc32b704b4413f"
+content-hash = "57acf6fd11366f2c4952f904e54084533866126686043525ef6ca5f2f1a73df6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ include = ["CHANGELOG.md"]
 
 [tool.poetry.dependencies]
 python = "^3.8.0"
-thrift = "~=0.22.0"
+thrift = ">=0.22.0,<0.24.0"
 pandas = [
     { version = ">=1.2.5,<4.0.0", python = ">=3.8,<3.13" },
     { version = ">=2.2.3,<4.0.0", python = ">=3.13" }


### PR DESCRIPTION
## Motivation

`databricks-sql-connector` currently constrains thrift with `~=0.22.0`, which prevents downstream consumers from resolving `thrift 0.23.0`. Issue #783 requests allowing thrift 0.23.0 so consumers can pick up the latest thrift security fixes.

Fixes #783.

cc @Korijn @jprakash-db

## Changes

- Widen the runtime thrift constraint to `>=0.22.0,<0.24.0`.
- Regenerate `poetry.lock` so the lockfile selects `thrift 0.23.0` and includes the updated thrift extras metadata.

## Decisions

- Kept `0.22.0` as the lower bound so existing compatible installs remain valid.
- Capped the dependency at `<0.24.0` to allow the 0.23.x line without automatically accepting a future thrift minor release.

## Validation

- `uvx --from poetry==2.3.1 poetry check --lock` passes with existing Poetry deprecation warnings.
- `poetry install -E pyarrow` installs `thrift 0.23.0`, `pyarrow 22.0.0`, and the current project.
- `poetry run python -c 'from importlib.metadata import version; print(version("thrift"))'` reports `0.23.0`.
- `PYTHONPATH=src poetry run python -c 'import thrift.transport.THttpClient; import thrift.protocol.TBinaryProtocol; from databricks.sql.backend.thrift_backend import ThriftDatabricksClient; print("ok")'` passes.
- `poetry run python -m pytest tests/unit/test_thrift_backend.py -rs` passes: 66 passed in 6.92s.
- `poetry run python -m pytest tests/unit` passes: 742 passed, 4 skipped in 103.76s.
- `poetry build -f wheel` succeeds; inspected wheel metadata contains `Requires-Dist: thrift (>=0.22.0,<0.24.0)`.
