### PR TITLE
Bump to version 4.2.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Release History
 
+# 4.2.7 (2026-05-21)
+- Add experimental Rust kernel backend (opt-in via `use_kernel=True`) — routes execution through the Databricks SQL kernel via PyO3, with TSparkParameter binding, Thrift backend feature parity, and `_use_arrow_native_complex_types` support (databricks/databricks-sql-python#787, #789, #793, #795 by @vikrantpuppala)
+- Add opt-in `_respect_server_retry_after_header` retry mode that only retries 429/503 when the server sends a `Retry-After` header — prevents duplicate side effects for non-idempotent operations (databricks/databricks-sql-python#756 by @sd-db)
+- Allow pandas 3.x in dependency constraints (databricks/databricks-sql-python#768 by @moomindani)
+- Telemetry: unwrap `TokenFederationProvider` to report inner auth mechanism/flow (databricks/databricks-sql-python#781 by @samikshya-db)
+- Test fixes for MST metadata expectations and User-Agent env leak (databricks/databricks-sql-python#788 by @vikrantpuppala)
+
 # 4.2.6 (2026-04-22)
 - Add SPOG routing support for account-level vanity URLs (databricks/databricks-sql-python#767 by @msrathore-db)
 - Fix dependency_manager: handle PEP 440 ~= compatible release syntax (databricks/databricks-sql-python#776 by @vikrantpuppala)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "databricks-sql-connector"
-version = "4.2.6"
+version = "4.2.7"
 description = "Databricks SQL Connector for Python"
 authors = ["Databricks <databricks-sql-connector-maintainers@databricks.com>"]
 license = "Apache-2.0"

--- a/src/databricks/sql/__init__.py
+++ b/src/databricks/sql/__init__.py
@@ -71,7 +71,7 @@ DATETIME = DBAPITypeObject("timestamp")
 DATE = DBAPITypeObject("date")
 ROWID = DBAPITypeObject()
 
-__version__ = "4.2.6"
+__version__ = "4.2.7"
 USER_AGENT_NAME = "PyDatabricksSqlConnector"
 
 # These two functions are pyhive legacy


### PR DESCRIPTION
## Summary
Bump version to `4.2.7` and add the `4.2.7` section to `CHANGELOG.md`.

### Notable changes since v4.2.6
- Add experimental Rust kernel backend (opt-in via `use_kernel=True`) — routes execution through the Databricks SQL kernel via PyO3, with TSparkParameter binding, Thrift backend feature parity, and `_use_arrow_native_complex_types` support (#787, #789, #793, #795)
- Add opt-in `_respect_server_retry_after_header` retry mode that only retries 429/503 when the server sends a `Retry-After` header — prevents duplicate side effects for non-idempotent operations (#756)
- Allow pandas 3.x in dependency constraints (#768)
- Telemetry: unwrap `TokenFederationProvider` to report inner auth mechanism/flow (#781)
- Test fixes for MST metadata expectations and User-Agent env leak (#788)

## Test plan
- [x] `pytest tests/unit/` passes locally (751 passed, 4 skipped)
- [ ] Multi-DBR tests in `universe/peco/correctness/python` passing — running on https://github.com/databricks-eng/universe/pull/1967448
- [ ] CI green

This pull request was AI-assisted by Isaac.