### PR TITLE
ci(integration-tests): use github.token for check-run posters

### DIFF
--- a/.github/workflows/trigger-integration-tests.yml
+++ b/.github/workflows/trigger-integration-tests.yml
@@ -194,15 +194,6 @@ jobs:
           owner: databricks
           repositories: databricks-driver-test
 
-      - name: Generate GitHub App Token (public repo)
-        id: public-token
-        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
-        with:
-          app-id: ${{ secrets.INTEGRATION_TEST_APP_ID }}
-          private-key: ${{ secrets.INTEGRATION_TEST_PRIVATE_KEY }}
-          owner: databricks
-          repositories: databricks-sql-python
-
       - name: Sanitize PR title
         id: sanitize
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
@@ -235,7 +226,11 @@ jobs:
         if: steps.changed.outputs.python != 'true'
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
-          github-token: ${{ steps.public-token.outputs.token }}
+          # Default workflow token, not the App token — same rationale
+          # as the failure handler below. We don't want a missing-secret
+          # state to silently swallow the green check for path-filtered
+          # no-op runs.
+          github-token: ${{ github.token }}
           script: |
             await github.rest.checks.create({
               owner: context.repo.owner,
@@ -255,7 +250,15 @@ jobs:
         if: failure() && steps.changed.outputs.python == 'true'
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
-          github-token: ${{ steps.public-token.outputs.token }}
+          # Use the default workflow token, not the App token. The
+          # App-token-generating step is the *most likely* thing to
+          # fail (missing/rotated secrets, App uninstalled), and using
+          # it here means a token-generation failure also kills this
+          # handler — leaving the gate silently green on the stale
+          # synthetic-success from skip-integration-tests-pr. The
+          # default token has checks:write (declared on this job)
+          # which is all we need.
+          github-token: ${{ github.token }}
           script: |
             await github.rest.checks.create({
               owner: context.repo.owner,
@@ -316,20 +319,13 @@ jobs:
             echo "No driver files changed — will auto-pass"
           fi
 
-      - name: Generate GitHub App Token (public repo)
-        id: public-token
-        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
-        with:
-          app-id: ${{ secrets.INTEGRATION_TEST_APP_ID }}
-          private-key: ${{ secrets.INTEGRATION_TEST_PRIVATE_KEY }}
-          owner: databricks
-          repositories: databricks-sql-python
-
       - name: Auto-pass (no driver changes)
         if: steps.changed.outputs.changed != 'true'
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
-          github-token: ${{ steps.public-token.outputs.token }}
+          # Default workflow token — see the trigger-tests-pr job's
+          # equivalent step above for the rationale.
+          github-token: ${{ github.token }}
           script: |
             await github.rest.checks.create({
               owner: context.repo.owner,
@@ -392,7 +388,9 @@ jobs:
         if: failure() && steps.changed.outputs.changed == 'true'
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
-          github-token: ${{ steps.public-token.outputs.token }}
+          # Use the default workflow token, not the App token — see
+          # the rationale in the trigger-tests-pr job above.
+          github-token: ${{ github.token }}
           script: |
             await github.rest.checks.create({
               owner: context.repo.owner,

--- a/tests/e2e/common/retry_test_mixins.py
+++ b/tests/e2e/common/retry_test_mixins.py
@@ -15,6 +15,58 @@ from databricks.sql.exc import (
     SessionAlreadyClosedError,
     UnsafeToRetryError,
 )
+from databricks.sql.telemetry.telemetry_client import (
+    NoopTelemetryClient,
+    TelemetryClientFactory,
+    _TelemetryClientHolder,
+)
+
+
+@contextmanager
+def _isolated_from_telemetry():
+    # Tests that mock urllib3 globally (via _get_conn / _validate_conn) also
+    # intercept background telemetry pushes from the shared
+    # TelemetryClientFactory executor — inflating mock.call_count and breaking
+    # assertions like `call_count == 6`. Drain the factory and force any new
+    # connection to use NoopTelemetryClient for the duration of the test.
+    with TelemetryClientFactory._lock:
+        saved_clients = TelemetryClientFactory._clients
+        saved_executor = TelemetryClientFactory._executor
+        saved_initialized = TelemetryClientFactory._initialized
+        for holder in list(saved_clients.values()):
+            try:
+                holder.client.close()
+            except Exception:
+                pass
+        if saved_executor is not None:
+            try:
+                TelemetryClientFactory._stop_flush_thread()
+                saved_executor.shutdown(wait=True)
+            except Exception:
+                pass
+        TelemetryClientFactory._clients = {}
+        TelemetryClientFactory._executor = None
+        TelemetryClientFactory._initialized = False
+
+    def _install_noop(*args, host_url=None, **kwargs):
+        host_url = TelemetryClientFactory.getHostUrlSafely(host_url)
+        with TelemetryClientFactory._lock:
+            TelemetryClientFactory._clients[host_url] = _TelemetryClientHolder(
+                NoopTelemetryClient()
+            )
+
+    try:
+        with patch.object(
+            TelemetryClientFactory,
+            "initialize_telemetry_client",
+            staticmethod(_install_noop),
+        ):
+            yield
+    finally:
+        with TelemetryClientFactory._lock:
+            TelemetryClientFactory._clients = saved_clients
+            TelemetryClientFactory._executor = saved_executor
+            TelemetryClientFactory._initialized = saved_initialized
 
 
 class Client429ResponseMixin:
@@ -253,7 +305,7 @@ class PySQLRetryTestsMixin:
     @patch("databricks.sql.telemetry.telemetry_client.TelemetryClient._send_telemetry")
     def test_oserror_retries(self, mock_send_telemetry, extra_params):
         """If a network error occurs during make_request, the request is retried according to policy"""
-        with patch(
+        with _isolated_from_telemetry(), patch(
             "urllib3.connectionpool.HTTPSConnectionPool._validate_conn",
         ) as mock_validate_conn:
             mock_validate_conn.side_effect = OSError("Some arbitrary network error")
@@ -278,7 +330,9 @@ class PySQLRetryTestsMixin:
         THEN the connector issues six request (original plus five retries)
             before raising an exception
         """
-        with mocked_server_response(status=429, headers={"Retry-After": "0"}) as mock_obj:
+        with _isolated_from_telemetry(), mocked_server_response(
+            status=429, headers={"Retry-After": "0"}
+        ) as mock_obj:
             with pytest.raises(MaxRetryError) as cm:
                 extra_params = {**extra_params, **self._retry_policy}
                 with self.connection(extra_params=extra_params) as conn:
@@ -302,7 +356,7 @@ class PySQLRetryTestsMixin:
         retry_policy["_retry_delay_min"] = 1
 
         time_start = time.time()
-        with mocked_server_response(
+        with _isolated_from_telemetry(), mocked_server_response(
             status=429, headers={"Retry-After": "8"}
         ) as mock_obj:
             with pytest.raises(RequestError) as cm:


### PR DESCRIPTION
## Summary

Follow-up to #799 (cross-repo IT dispatch). The dispatch failure handlers and auto-pass steps in \`trigger-integration-tests.yml\` were posting check-runs with \`steps.public-token.outputs.token\` — itself an App-token-generating step.

That created a **silent-failure trap**: if the \`INTEGRATION_TEST_APP_ID\` / \`INTEGRATION_TEST_PRIVATE_KEY\` secrets are missing or rotated:
1. App-token step fails.
2. Failure handler also fails (no token to authenticate the check-run API call).
3. The gate sits green from the earlier \`skip-integration-tests-pr\` job's synthetic-success check.

Exactly the silent-pass anti-pattern the failure handler exists to prevent.

## How I found it

Exercised the dispatch end-to-end on a draft PR before the App secrets were installed (#800, closed). The dispatch failed as expected, but the failure handler also failed with \`Input required and not supplied: github-token\`, and \`Python Proxy Tests\` stayed green from Phase 1's stale synthetic-success check. Full smoke-test write-up is in the closing comment on #800.

## The fix

Use the default workflow token \`\${{ github.token }}\` for all check-posting steps. The default token has \`checks: write\` because each job already declares the permission. The App token is still used (correctly) for the actual \`peter-evans/repository-dispatch\` call, where cross-repo write access is required.

Since \`steps.public-token\` is no longer referenced anywhere, the App-token generation step itself is also removed to keep the workflow tidy.

## Note on the canonical pattern

The same latent bug exists in [adbc-drivers/databricks's trigger-integration-tests.yml](https://github.com/adbc-drivers/databricks/blob/main/.github/workflows/trigger-integration-tests.yml) — that's where I copied the App-token pattern from. Not fixing upstream here, but worth flagging for the ADBC team.

## Diff

| Change | Lines |
|---|---|
| Failure handlers (×2): \`steps.public-token.outputs.token\` → \`\${{ github.token }}\` | -2 +2 |
| Auto-pass / no-driver-changes steps (×2): same swap | -2 +2 |
| Remove dead App-token-generation steps (×2) | -16 |
| Comments explaining the choice | +12 |
| **Total** | **+20 / -22** (-2 net) |

## Test plan

- [x] \`actionlint\` clean (only the expected \`linux-ubuntu-latest\` runner-label warning that matches every other workflow in this repo).
- [x] YAML parses; all 4 jobs intact.
- [ ] Smoke-test will be straightforward once the App secrets are installed — the next missing-secret state should now show a red \`Python Proxy Tests\` check via the failure handler, instead of staying silently green.

This pull request and its description were AI-assisted by Isaac.