### PR TITLE
fix(utils): import ProgrammingError instead of bare `exc.` reference

### DIFF
--- a/src/databricks/sql/utils.py
+++ b/src/databricks/sql/utils.py
@@ -19,6 +19,7 @@ except ImportError:
     pyarrow = None
 
 from databricks.sql import OperationalError
+from databricks.sql.exc import ProgrammingError
 from databricks.sql.cloudfetch.download_manager import ResultFileDownloadManager
 from databricks.sql.thrift_api.TCLIService.ttypes import (
     TRowSet,
@@ -548,7 +549,7 @@ class ParamEscaper:
         elif isinstance(parameters, (list, tuple)):
             return tuple(self.escape_item(x) for x in parameters)
         else:
-            raise exc.ProgrammingError(
+            raise ProgrammingError(
                 "Unsupported param format: {}".format(parameters)
             )
 
@@ -606,7 +607,7 @@ class ParamEscaper:
         elif isinstance(item, Mapping):
             return self.escape_mapping(item)
         else:
-            raise exc.ProgrammingError("Unsupported object {}".format(item))
+            raise ProgrammingError("Unsupported object {}".format(item))
 
 
 def inject_parameters(operation: str, parameters: Dict[str, str]):


### PR DESCRIPTION
## Summary

`ParamEscaper.escape_args` and `ParamEscaper.escape_item` both raise `exc.ProgrammingError(...)` (lines 551 and 609 of `utils.py`), but `exc` is never imported. On any unsupported parameter shape the user sees `NameError: name 'exc' is not defined` instead of a clean PEP-249 `ProgrammingError`.

Surfaced via the python-comparator audit harness running the `INLINE_PARAMS` connection config: both backends raised `NameError: name 'exc' is not defined`, which the comparator's class+message match treated as parity — a false-positive that hid both the real driver bug and the underlying caller-side type mismatch.

## Fix

Import `ProgrammingError` directly from `databricks.sql.exc` (matching the pattern used in `session.py`, `client.py`, `result_set.py`, etc.) and replace the two `exc.ProgrammingError(...)` sites with bare `ProgrammingError(...)`.

## Test plan

- [x] Manual repro: `pe = ParamEscaper(); pe.escape_args(object())` now raises `ProgrammingError`, not `NameError`. Same for `pe.escape_item(object())`.
- [ ] Existing test suite — no behaviour change beyond the exception class on a previously-unreachable error path.

This pull request and its description were written by Isaac.