### PR TITLE
Security: Potential Sensitive Information Exposure in Logging

### DIFF
--- a/src/databricks/sql/experimental/oauth_persistence.py
+++ b/src/databricks/sql/experimental/oauth_persistence.py
@@ -40,11 +40,13 @@ class OAuthPersistenceCache(OAuthPersistence):
 
 # Note this is only intended to be used for development
 class DevOnlyFilePersistence(OAuthPersistence):
+        if not os.environ.get('ENVIRONMENT') == 'dev':
+            logger.warning('DevOnlyFilePersistence is not intended for production use.')
     def __init__(self, file_path):
         self._file_path = file_path
 
     def persist(self, hostname: str, token: OAuthToken):
-        logger.info(f"persisting token in {self._file_path}")
+        logger.debug(f"persisting token in {self._file_path}")
 
         # Data to be written
         dictionary = {


### PR DESCRIPTION
## Summary

Security: Potential Sensitive Information Exposure in Logging

## Problem

**Severity**: `Medium` | **File**: `src/databricks/sql/experimental/oauth_persistence.py:L56`

The `src/databricks/sql/experimental/oauth_persistence.py` file logs token persistence operations at INFO level, including the file path where OAuth tokens are stored. While not the tokens themselves, the file path could be sensitive. More critically, the `DevOnlyFilePersistence` class stores OAuth tokens (access_token and refresh_token) in plaintext JSON without encryption, which is noted as development-only but still presents a risk if misused in production.

## Solution

Add warnings when DevOnlyFilePersistence is instantiated in non-development environments. Consider encrypting the file or using OS keyring services. Reduce log level for persistence operations or ensure no sensitive data is logged.

## Changes

- `src/databricks/sql/experimental/oauth_persistence.py` (modified)