### PR TITLE
[PECOBLR-2461] fix(tests/e2e): de-collide MST + UC Volume tests across concurrent CI jobs

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -11,6 +11,19 @@ on:
   pull_request:
   workflow_dispatch:
 
+# Serialise E2E runs per ref so a force-push (or a fast follow-up commit)
+# on a PR cancels the previous run instead of racing it against shared
+# warehouse state (Delta tables, UC Volume files, etc.).
+#
+# Pushes to main are NOT cancelled — each merge commit needs its own clean
+# CI signal so a regression on commit N doesn't get hidden by commit N+1
+# arriving seconds later. (Concurrent main runs can still collide on shared
+# state, but that's the cost of preserving per-commit signal; the
+# uuid-suffix conventions in the e2e tests are what keep them isolated.)
+concurrency:
+  group: e2e-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   test-with-coverage:
     runs-on:

--- a/tests/e2e/common/uc_volume_tests.py
+++ b/tests/e2e/common/uc_volume_tests.py
@@ -1,5 +1,6 @@
 import os
 import tempfile
+from uuid import uuid4
 
 import pytest
 import databricks.sql as sql
@@ -40,12 +41,16 @@ class PySQLUCVolumeTestSuiteMixin:
         with open(fh, "wb") as fp:
             fp.write(original_text)
 
+        # Unique per-run path so concurrent CI jobs sharing the same volume
+        # don't step on each other's PUT/GET/REMOVE.
+        volume_path = f"/Volumes/{catalog}/{schema}/e2etests/life_cycle_{uuid4().hex[:8]}.csv"
+
         with self.connection(
             extra_params={"staging_allowed_local_path": temp_path}
         ) as conn:
 
             cursor = conn.cursor()
-            query = f"PUT '{temp_path}' INTO '/Volumes/{catalog}/{schema}/e2etests/file1.csv' OVERWRITE"
+            query = f"PUT '{temp_path}' INTO '{volume_path}' OVERWRITE"
             cursor.execute(query)
 
         # GET should succeed
@@ -56,7 +61,7 @@ class PySQLUCVolumeTestSuiteMixin:
             extra_params={"staging_allowed_local_path": new_temp_path}
         ) as conn:
             cursor = conn.cursor()
-            query = f"GET '/Volumes/{catalog}/{schema}/e2etests/file1.csv' TO '{new_temp_path}'"
+            query = f"GET '{volume_path}' TO '{new_temp_path}'"
             cursor.execute(query)
 
         with open(new_fh, "rb") as fp:
@@ -66,7 +71,7 @@ class PySQLUCVolumeTestSuiteMixin:
 
         # REMOVE should succeed
 
-        remove_query = f"REMOVE '/Volumes/{catalog}/{schema}/e2etests/file1.csv'"
+        remove_query = f"REMOVE '{volume_path}'"
 
         # Use minimal retry settings to fail fast
         extra_params = {
@@ -84,7 +89,7 @@ class PySQLUCVolumeTestSuiteMixin:
                 Error, match="Staging operation over HTTP was unsuccessful: 404"
             ):
                 cursor = conn.cursor()
-                query = f"GET '/Volumes/{catalog}/{schema}/e2etests/file1.csv' TO '{new_temp_path}'"
+                query = f"GET '{volume_path}' TO '{new_temp_path}'"
                 cursor.execute(query)
 
         os.remove(temp_path)
@@ -151,19 +156,22 @@ class PySQLUCVolumeTestSuiteMixin:
         with open(fh, "wb") as fp:
             fp.write(original_text)
 
+        # Unique per-run path so a concurrent CI job's REMOVE doesn't delete
+        # our file between the two PUTs and silently turn the expected
+        # FILE_IN_STAGING_PATH_ALREADY_EXISTS into a successful PUT.
+        volume_path = f"/Volumes/{catalog}/{schema}/e2etests/put_conflict_{uuid4().hex[:8]}.csv"
+
         def perform_put():
             with self.connection(
                 extra_params={"staging_allowed_local_path": temp_path}
             ) as conn:
                 cursor = conn.cursor()
-                query = f"PUT '{temp_path}' INTO '/Volumes/{catalog}/{schema}/e2etests/file1.csv'"
+                query = f"PUT '{temp_path}' INTO '{volume_path}'"
                 cursor.execute(query)
 
         def perform_remove():
             try:
-                remove_query = (
-                    f"REMOVE '/Volumes/{catalog}/{schema}/e2etests/file1.csv'"
-                )
+                remove_query = f"REMOVE '{volume_path}'"
 
                 with self.connection(
                     extra_params={"staging_allowed_local_path": "/"}

--- a/tests/e2e/test_transactions.py
+++ b/tests/e2e/test_transactions.py
@@ -35,10 +35,17 @@ logger = logging.getLogger(__name__)
 
 
 def _unique_table_name(request):
-    """Derive a unique Delta table name from the test node id."""
+    """Derive a unique Delta table name from the test node id.
+
+    The uuid suffix keeps tables unique across concurrent CI jobs that
+    share the same warehouse/catalog — without it, two runs racing on
+    the same test name collide on CREATE/DROP.
+    """
     node_id = request.node.name
     sanitized = re.sub(r"[^a-z0-9_]", "_", node_id.lower())
-    return f"mst_pysql_{sanitized}"[:80]
+    suffix = uuid.uuid4().hex[:8]
+    # Reserve room for the 9-char "_{suffix}" tail so total stays <= 80.
+    return f"mst_pysql_{sanitized}"[:71] + f"_{suffix}"
 
 
 def _unique_table_name_raw(suffix):


### PR DESCRIPTION
## Summary

Three changes, all targeting the same underlying problem: e2e tests share a single Databricks warehouse + catalog + UC volume across CI runs, and were racing on shared paths.

1. **`tests/e2e/test_transactions.py`** — `_unique_table_name` derived the Delta table name purely from the pytest node id, so two CI jobs racing on the same warehouse would both target `peco.default.mst_pysql_<test_name>` and step on each other's CREATE / DROP / DML. Apply the same `uuid4().hex[:8]` suffix that the sibling helper `_unique_table_name_raw` already used. (Oversight from #775.)
2. **`tests/e2e/common/uc_volume_tests.py`** — `test_uc_volume_life_cycle` and `test_uc_volume_put_fails_if_file_exists_and_overwrite_not_set` PUT/GET/REMOVE against the hardcoded path `/Volumes/{catalog}/{schema}/e2etests/file1.csv`. When runs overlap, one run's REMOVE deletes the other's file between its two PUTs and the expected `FILE_IN_STAGING_PATH_ALREADY_EXISTS` never fires. Suffix the volume path the same way. The other UC Volume tests exercise client-side / server-parse failure paths that never touch the file, so they're left alone.
3. **`.github/workflows/code-coverage.yml`** — add a `concurrency` group so a new push to a PR cancels the previous run on that ref. `cancel-in-progress` is enabled only for `pull_request` events, **not** for pushes to `main`, so each merge commit keeps its own clean CI signal (a regression on commit N can't be hidden by commit N+1 landing seconds later).

## Why this matters

The "flaky" failures we've been seeing on `main` (e.g. run [26410038645](https://github.com/databricks/databricks-sql-python/actions/runs/26410038645/job/77742272041), which started 43 s after another E2E run on `main` finished) are all explained by this one shared-warehouse collision:

| Failing test | Symptom | Caused by |
|---|---|---|
| `TestMstCorrectness::test_multi_table_commit` | `TRANSACTION_ROLLBACK_REQUIRED_AFTER_ABORT.PREVIOUS_QUERY_FAILURE` | Concurrent run wrote to the same table → write conflict aborted the txn → `finally` block hit the aborted state |
| `TestMstExecuteVariants::test_executemany_rollback_in_txn` | `TABLE_OR_VIEW_NOT_FOUND` | Concurrent run's teardown dropped the table mid-test |
| `TestMstCorrectness::test_write_conflict_single_table` | `TABLE_OR_VIEW_ALREADY_EXISTS` (setup ERROR) | Concurrent run's fixture created the table between this run's `DROP IF EXISTS` and `CREATE` |
| `TestPySQLCoreSuite::test_uc_volume_put_fails_if_file_exists_and_overwrite_not_set` | `Failed: DID NOT RAISE ServerOperationError` | Concurrent run's REMOVE deleted the file between this run's two PUTs |

The fourth row was caught on this PR itself — the force-push to add DCO sign-off triggered a second E2E run on the same PR ref while the first was still running. That's the trigger the new `concurrency` block targets.

I also audited the rest of the e2e suite (`test_complex_types`, `test_variant_types`, `test_parameterized_queries`, `test_driver`) — they all already use `uuid4()`-suffixed names. `test_transactions.py` and `uc_volume_tests.py` were the only outliers.

## Test plan

- [x] Local sanity check: confirmed the new MST table names stay ≤ 80 chars even for the longest test names, and that successive calls return distinct names.
- [x] Workflow YAML parses (`yaml.safe_load`).
- [ ] CI: E2E suite passes; the four previously-failing tests pass green.
- [ ] Optional: push a follow-up commit to this PR to verify `concurrency` cancels the in-progress run on the PR ref (and that pushes to main still queue independently).