### PR TITLE
docs(kernel-e2e): refresh workflow header — setup is done, queue is live

### DIFF
--- a/.github/workflows/kernel-e2e.yml
+++ b/.github/workflows/kernel-e2e.yml
@@ -20,18 +20,17 @@ name: Kernel E2E Tests
 #   - merge_group fires the real gate — dispatches when kernel-relevant
 #     files changed, auto-passes otherwise.
 #
-# Required external setup:
-#   1. `kernel-e2e` label exists in this repo.
-#   2. `INTEGRATION_TEST_APP_ID` / `INTEGRATION_TEST_PRIVATE_KEY`
-#      secrets exist (already installed for the proxy-tests workflow).
-#      The GitHub App's repo allowlist must include
-#      `databricks/databricks-sql-kernel` — extend the existing App
-#      config; do not create a new App.
-#   3. `KERNEL_REV` file at the repo root containing a 40-char kernel
-#      commit SHA.
-#   4. `azure-prod` environment exposes DATABRICKS_HOST /
-#      TEST_PECO_WAREHOUSE_HTTP_PATH / DATABRICKS_TOKEN
-#      (already configured for code-coverage.yml).
+# External setup that this workflow depends on (already in place,
+# documented here for future debugging):
+#   - `kernel-e2e` label exists in this repo.
+#   - `INTEGRATION_TEST_APP_ID` / `INTEGRATION_TEST_PRIVATE_KEY`
+#     secrets are installed and the App's repo allowlist includes
+#     `databricks/databricks-sql-kernel`.
+#   - `KERNEL_REV` file at the repo root pins the kernel commit SHA.
+#   - `azure-prod` environment exposes DATABRICKS_HOST /
+#     TEST_PECO_WAREHOUSE_HTTP_PATH / DATABRICKS_TOKEN.
+#   - `Kernel E2E` is listed as a required status check on the
+#     `main` ruleset, so merge queue waits for it.
 
 on:
   pull_request:


### PR DESCRIPTION
## Summary

Comments-only refresh of the `kernel-e2e.yml` header. The old block read like a TODO list ("Required external setup: 1. … 2. … 3. …") but every item is now in place:

- `kernel-e2e` label exists.
- GitHub App allowlist includes `databricks/databricks-sql-kernel`.
- `KERNEL_REV` pins the kernel commit.
- `azure-prod` env exposes the dogfood warehouse creds.
- `Kernel E2E` is now a required status check on `main`'s ruleset.

Rewords the block as a "what this depends on" debugging crib and adds the ruleset note so future readers understand why the `merge_group` path matters.

## Why this PR

Also serving as the **merge-queue pilot**. The `main` ruleset was just updated to require `Python Proxy Tests` + `Kernel E2E` and enable merge queue with `ALLGREEN` grouping. This is a comments-only diff with no behavioral change — the lowest-risk way to exercise the new queue end-to-end.

Expected behavior when added to the queue:
1. `merge_group` event fires.
2. `Kernel E2E` workflow auto-passes (`detect-changes` sees no kernel-relevant files changed).
3. `Python Proxy Tests` workflow auto-passes (no driver source changed).
4. Queue merges.

If anything in that chain hangs, the queue's `check_response_timeout_minutes: 60` will release the PR after an hour rather than blocking forever.

## Test plan

- [ ] CI passes on this PR (synthetic-success path).
- [ ] "Add to merge queue" → both required checks land green within a few minutes → PR merges automatically.
- [ ] If queue stalls: edit the `CoPilotReview` ruleset to remove the required-checks rule temporarily, debug, re-add.

This pull request and its description were written by Isaac.