### PR TITLE
ci(code-coverage): move push:main trigger to merge_group

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -5,21 +5,27 @@ permissions:
   id-token: write
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
+  merge_group:
   workflow_dispatch:
 
+# `pull_request` gives the PR author fast feedback as they iterate.
+# `merge_group` runs the same suite against the queue's transient
+# branch (current main + the queued PR diff, freshly merged) and is
+# the run that actually protects main — by the time `push:main` fires,
+# the merge has already happened and the coverage check has no power
+# to block. Hence we deliberately don't subscribe to `push:main`.
+#
 # Serialise E2E runs per ref so a force-push (or a fast follow-up commit)
 # on a PR cancels the previous run instead of racing it against shared
 # warehouse state (Delta tables, UC Volume files, etc.).
 #
-# Pushes to main are NOT cancelled — each merge commit needs its own clean
-# CI signal so a regression on commit N doesn't get hidden by commit N+1
-# arriving seconds later. (Concurrent main runs can still collide on shared
-# state, but that's the cost of preserving per-commit signal; the
-# uuid-suffix conventions in the e2e tests are what keep them isolated.)
+# Merge-queue runs are NOT cancelled — each queue entry needs its own
+# clean CI signal so a regression on entry N doesn't get hidden by
+# entry N+1 arriving seconds later. (Concurrent queue runs can still
+# collide on shared warehouse state, but that's the cost of preserving
+# per-entry signal; the uuid-suffix conventions in the e2e tests are
+# what keep them isolated.)
 concurrency:
   group: e2e-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
@@ -63,6 +69,11 @@ jobs:
       - name: Check for coverage override
         id: override
         env:
+          # PR_BODY is empty on `merge_group` (no pull_request payload).
+          # That's intentional — coverage overrides are an author-time
+          # escape hatch, not a queue-time bypass, so the queue run
+          # always enforces the threshold regardless of the PR's
+          # SKIP_COVERAGE_CHECK marker.
           PR_BODY: ${{ github.event.pull_request.body }}
         run: |
           OVERRIDE_COMMENT=$(echo "$PR_BODY" | grep -E "SKIP_COVERAGE_CHECK\s*=" || echo "")


### PR DESCRIPTION
## Summary

Replaces the `push: main` trigger on `code-coverage.yml` with `merge_group`. `pull_request` and `workflow_dispatch` stay as-is.

## Why

Today the suite runs twice per PR-to-main lifecycle:

1. On `pull_request` (fast feedback for the author while iterating).
2. On `push: main` after the merge has already happened.

Run #2 is observational — by the time it fires, the merge is done. A failure can't block anything; it can only tell you "main is broken, go fix it." That's not protection; that's an alert.

`merge_group` fires while the queue is processing the PR (against a transient branch = current main + the queued PR diff, freshly merged). Same SHA-equivalent state that `push:main` would have tested, but a failure here actually ejects the PR from the queue before it damages main.

The principle (from this morning's audit):
- **`pull_request`** = fast iteration for the author.
- **`merge_group`** = the gate that protects main.
- **`push:main`** = observational only, useful for post-deploy smoke tests or release artifact triggers — not for protective checks.

This PR moves the workflow from the third category back into the second.

## Why this PR doesn't also make it required

The suite takes ~17 min and would be added to every queue merge, including PRs that don't touch driver code. Queue throughput would drop materially. The right move is:

1. Land this PR. Watch a few merges; confirm the `merge_group` run posts a clean check.
2. If main breakages slip past it (e.g., someone admin-merges despite a red merge_group result), then promote `E2E Tests and Code Coverage` to a required status check on the ruleset.

The current setup is: queue runs the suite, you see the result, but it's not gating. Strictly better than today (where the result lands after the merge), without adding queue-time cost.

## Subtlety: coverage override

The `SKIP_COVERAGE_CHECK` PR-body override only applies under `pull_request` events (where `github.event.pull_request.body` is populated). Under `merge_group`, the variable resolves to empty, the grep returns no match, and the threshold is enforced. That's intentional — overrides are an author-time escape hatch, not a queue-time bypass. Documented inline.

## Test plan

- [ ] CI passes on this PR (will run `pull_request` event end-to-end, including coverage check).
- [ ] After merge: confirm no `push:main` run of `E2E Tests and Code Coverage` fires.
- [ ] On a follow-up PR going through the queue, confirm the `merge_group` run of `test-with-coverage` fires against the transient queue branch.

This pull request and its description were written by Isaac.