### PR TITLE
ci/test: deflake retry tests under merge-queue load

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -16,18 +16,23 @@ on:
 # the merge has already happened and the coverage check has no power
 # to block. Hence we deliberately don't subscribe to `push:main`.
 #
-# Serialise E2E runs per ref so a force-push (or a fast follow-up commit)
-# on a PR cancels the previous run instead of racing it against shared
-# warehouse state (Delta tables, UC Volume files, etc.).
-#
-# Merge-queue runs are NOT cancelled — each queue entry needs its own
-# clean CI signal so a regression on entry N doesn't get hidden by
-# entry N+1 arriving seconds later. (Concurrent queue runs can still
-# collide on shared warehouse state, but that's the cost of preserving
-# per-entry signal; the uuid-suffix conventions in the e2e tests are
-# what keep them isolated.)
+# Concurrency groups:
+#   - pull_request: per-ref + cancel-in-progress. A force-push or fast
+#     follow-up commit on a PR cancels the previous run instead of
+#     racing it against shared warehouse state (Delta tables, UC Volume
+#     files, telemetry endpoints, etc.).
+#   - merge_group: serialised globally with a fixed group name. The
+#     warehouse can't tolerate two parallel queue entries hammering
+#     telemetry / retry paths simultaneously — we have observed flaky
+#     retry-test failures (extra `/telemetry-ext` retries inflating
+#     mock.call_count) under that load. Running queue entries one at a
+#     time costs queue throughput (one entry at a time, ~17 min each)
+#     but keeps signal trustworthy. cancel-in-progress is off so each
+#     entry gets a complete run.
+#   - workflow_dispatch: shares the merge_group group; manual triggers
+#     are rare enough that serialising them with the queue is fine.
 concurrency:
-  group: e2e-${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.event_name == 'pull_request' && format('e2e-pr-{0}', github.ref) || 'e2e-mq-serial' }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/tests/e2e/common/retry_test_mixins.py
+++ b/tests/e2e/common/retry_test_mixins.py
@@ -17,6 +17,7 @@ from databricks.sql.exc import (
 )
 from databricks.sql.telemetry.telemetry_client import (
     NoopTelemetryClient,
+    TelemetryClient,
     TelemetryClientFactory,
     _TelemetryClientHolder,
 )
@@ -27,8 +28,22 @@ def _isolated_from_telemetry():
     # Tests that mock urllib3 globally (via _get_conn / _validate_conn) also
     # intercept background telemetry pushes from the shared
     # TelemetryClientFactory executor — inflating mock.call_count and breaking
-    # assertions like `call_count == 6`. Drain the factory and force any new
-    # connection to use NoopTelemetryClient for the duration of the test.
+    # assertions like `call_count == 6`. Three layers of defence:
+    #
+    #   1. Drain TelemetryClientFactory and override initialize_telemetry_client
+    #      so new connections install NoopTelemetryClient (which submits nothing).
+    #   2. Patch TelemetryClient._send_telemetry to a no-op as a backstop — covers
+    #      any real TelemetryClient instance that slips in (e.g. a stale module-
+    #      global, a code path that bypasses initialize_telemetry_client, or
+    #      anything created before this context entered).
+    #   3. Patch TelemetryClient._export_event to a no-op so even if a real
+    #      client receives an event, the event never reaches the queue and the
+    #      flush logic never fires.
+    #
+    # Without layer 2/3 we have observed `/telemetry-ext` requests showing up
+    # in merge_group runs (concurrent CI load on the warehouse stresses paths
+    # that single-test runs don't hit), inflating retry-test counts and
+    # producing flaky AssertionErrors.
     with TelemetryClientFactory._lock:
         saved_clients = TelemetryClientFactory._clients
         saved_executor = TelemetryClientFactory._executor
@@ -55,11 +70,21 @@ def _isolated_from_telemetry():
                 NoopTelemetryClient()
             )
 
+    def _noop_send(self, events):
+        return None
+
+    def _noop_export(self, event):
+        return None
+
     try:
         with patch.object(
             TelemetryClientFactory,
             "initialize_telemetry_client",
             staticmethod(_install_noop),
+        ), patch.object(
+            TelemetryClient, "_send_telemetry", _noop_send
+        ), patch.object(
+            TelemetryClient, "_export_event", _noop_export
         ):
             yield
     finally:


### PR DESCRIPTION
## Summary

Two compounding fixes for the flake observed on PR #812's `merge_group` run where `test_oserror_retries` and `test_retry_max_count_not_exceeded` failed with `assert mock_validate_conn.call_count == 6` — unexpected `/telemetry-ext` requests were counted alongside the intended session-endpoint retries, inflating the count.

## Why it was happening

Two interacting causes:

1. **`_isolated_from_telemetry()` only patches `TelemetryClientFactory.initialize_telemetry_client`.** That covers new connections created during the test, but not real `TelemetryClient` instances that slip in via:
   - Stale module-global state from a previous test.
   - Code paths that bypass `initialize_telemetry_client` (e.g. `connection_failure_log` already passes through the patch, but other paths might not in the future).
   - Pre-existing clients created before the context manager entered.

2. **The merge queue ran multiple entries in parallel** against the same warehouse. The previous concurrency group was keyed on `github.ref` (per-PR in queue: `gh-readonly-queue/main/pr-N-…`), so PR #810's and PR #812's queue entries ran concurrently. The warehouse was fine for individual queue entries but couldn't handle two simultaneous loads — telemetry/retry paths started intermittently failing on `/telemetry-ext`, and those failures got counted by `mock_validate_conn`.

## What this PR changes

### 1. `tests/e2e/common/retry_test_mixins.py`

Strengthens `_isolated_from_telemetry()` with two backstop patches:
- `TelemetryClient._send_telemetry` → no-op
- `TelemetryClient._export_event` → no-op

These cover any path that could reach the telemetry HTTP layer, regardless of how the `TelemetryClient` instance was created. Layer 1 (factory swap) catches the common case; layers 2 and 3 catch edge cases.

The existing `@patch("...TelemetryClient._send_telemetry")` decorators on individual tests stay in place. They're now redundant with the context manager's layer-2 patch, but removing them would expand the diff for no functional benefit.

**Local verification**: `test_oserror_retries` runs 5/5 green in a row (previously: flaky on CI, deterministic locally because no warehouse contention).

### 2. `.github/workflows/code-coverage.yml`

Serialises `merge_group` runs under a single fixed concurrency group (`e2e-mq-serial`). Only one queue entry runs the suite at a time; subsequent entries queue up behind it. `pull_request` runs keep their per-ref + `cancel-in-progress` behaviour for fast author feedback.

**Trade-off**: queue throughput drops to one ~17-min run at a time. Acceptable for this repo's PR volume. The alternative is the flake we've been chasing.

## What's NOT in this PR

`test_retry_max_count_not_exceeded` still fails on this branch — but it **also fails on baseline main**, with `'SimpleHttpResponse' object has no attribute 'version_string'`. That's an unrelated pre-existing issue (looks like an urllib3 version drift or `mocked_server_response` mock breakage). Worth tracking separately; out of scope here.

## Test plan

- [ ] CI passes on this PR (the queue-serialisation kicks in once this lands; until then PR-event runs use the existing pattern).
- [ ] PR #812 (telemetry deflake) re-queues and merges cleanly.
- [ ] Future merge_group runs show no `test_oserror_retries` flakes under concurrent queue load.

This pull request and its description were written by Isaac.