### PR TITLE
test(e2e/mst): DESCRIBE QUERY is now allowed in transactions

### DIFF
--- a/tests/e2e/test_transactions.py
+++ b/tests/e2e/test_transactions.py
@@ -565,17 +565,19 @@ class TestMstBlockedSql:
     "Only SELECT / INSERT / MERGE / UPDATE / DELETE / DESCRIBE TABLE are supported."
 
     The server has since broadened the allowlist to include SHOW COLUMNS
-    (ShowDeltaTableColumnsCommand), observed on current DBSQL warehouses.
+    (ShowDeltaTableColumnsCommand) and DESCRIBE QUERY (DescribeQueryCommand),
+    observed on current DBSQL warehouses.
 
     Blocked (throw + abort txn):
     - SHOW TABLES, SHOW SCHEMAS, SHOW CATALOGS, SHOW FUNCTIONS
-    - DESCRIBE QUERY, DESCRIBE TABLE EXTENDED
+    - DESCRIBE TABLE EXTENDED
     - SELECT FROM information_schema
     - Thrift Get{Catalogs,Schemas,Tables,Columns} RPCs (see TestMstMetadata)
 
     Allowed:
     - DESCRIBE TABLE (basic form)
     - SHOW COLUMNS
+    - DESCRIBE QUERY
     """
 
     def _assert_blocked_and_txn_aborted(self, mst_conn_params, fq_table, blocked_sql):
@@ -652,10 +654,14 @@ class TestMstBlockedSql:
             mst_conn_params, fq_table, f"SHOW COLUMNS IN {fq_table}"
         )
 
-    def test_describe_query_blocked(self, mst_conn_params, mst_table):
-        """DESCRIBE QUERY is blocked in MST (DescribeQueryCommand)."""
+    def test_describe_query_not_blocked(self, mst_conn_params, mst_table):
+        """DESCRIBE QUERY succeeds in MST — now allowed by the server's MSTCheckRule allowlist.
+
+        Previously blocked (DescribeQueryCommand), the server has since broadened
+        the allowlist to include it, mirroring the earlier SHOW COLUMNS change.
+        """
         fq_table, _ = mst_table
-        self._assert_blocked_and_txn_aborted(
+        self._assert_not_blocked(
             mst_conn_params,
             fq_table,
             f"DESCRIBE QUERY SELECT * FROM {fq_table}",


### PR DESCRIPTION
## Summary

The e2e test `TestMstBlockedSql::test_describe_query_blocked` started failing in CI with `Failed: DID NOT RAISE <class 'Exception'>`. This is a server-side behavior change, not a connector regression: the server's `MSTCheckRule` allowlist has been broadened to include `DESCRIBE QUERY` (`DescribeQueryCommand`), so it no longer throws inside an active multi-statement transaction.

This mirrors the earlier `SHOW COLUMNS` change (#778), where a previously-blocked introspection statement became allowed and the test was flipped accordingly.

## Changes

- Rename `test_describe_query_blocked` -> `test_describe_query_not_blocked` and switch it from `_assert_blocked_and_txn_aborted` to `_assert_not_blocked` (which verifies the statement succeeds and returns >0 rows inside the txn).
- Update the `TestMstBlockedSql` docstring: move `DESCRIBE QUERY` from the Blocked list to the Allowed list.

## Testing

Verified against a live DBSQL warehouse:
- `test_describe_query_not_blocked` - PASS (DESCRIBE QUERY succeeds in MST, returns rows)
- Full `TestMstBlockedSql` class (9 tests) - all PASS