### PR TITLE
Revert "Bump thrift to 0.23.0 (#796)" — fixes install failure on DBR LTS (ES-1960554)

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1849,19 +1849,19 @@ files = [
 
 [[package]]
 name = "thrift"
-version = "0.23.0"
+version = "0.22.0"
 description = "Python bindings for the Apache Thrift RPC system"
 optional = false
 python-versions = "*"
 groups = ["main"]
 files = [
-    {file = "thrift-0.23.0.tar.gz", hash = "sha256:5f43448a92c36ed6a450048355d10e231a1787e4c28965f08fabac0eb978914c"},
+    {file = "thrift-0.22.0.tar.gz", hash = "sha256:42e8276afbd5f54fe1d364858b6877bc5e5a4a5ed69f6a005b94ca4918fe1466"},
 ]
 
 [package.extras]
-all = ["tornado (>=6.3.0)", "twisted (>=24.3.0)", "zope.interface (>=6.1)"]
-tornado = ["tornado (>=6.3.0)"]
-twisted = ["twisted (>=24.3.0)", "zope.interface (>=6.1)"]
+all = ["tornado (>=4.0)", "twisted"]
+tornado = ["tornado (>=4.0)"]
+twisted = ["twisted"]
 
 [[package]]
 name = "tomli"
@@ -1966,4 +1966,4 @@ pyarrow = ["pyarrow", "pyarrow", "pyarrow"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.8.0"
-content-hash = "57acf6fd11366f2c4952f904e54084533866126686043525ef6ca5f2f1a73df6"
+content-hash = "d1739e84dcbd6e7ac311eb6fbb9cf87ad110491f7d954f07fdfc32b704b4413f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ include = ["CHANGELOG.md"]
 
 [tool.poetry.dependencies]
 python = "^3.8.0"
-thrift = ">=0.22.0,<0.24.0"
+thrift = "~=0.22.0"
 pandas = [
     { version = ">=1.2.5,<4.0.0", python = ">=3.8,<3.13" },
     { version = ">=2.2.3,<4.0.0", python = ">=3.13" }


### PR DESCRIPTION
## What

Reverts #796 ("Bump thrift to 0.23.0"), restoring the thrift pin to `~=0.22.0` (`>=0.22.0,<0.23.0`) and `poetry.lock` to thrift 0.22.0.

This is an exact `git revert` of commit 95352557.

## Why

`databricks-sql-connector` 4.2.7 widened the thrift pin to `>=0.22.0,<0.24.0`, which allowed thrift **0.23.0** to be resolved. thrift ships **sdist-only** (no wheels), so every install builds `setup.py` from source. thrift 0.23.0's `setup.py` calls `sys.exit(0)` on the build success path, which terminates the PEP 517 in-process build backend before pip writes its expected `output.json`. On **setuptools ≤ 68** (shipped by DBR 14.3 LTS and 15.4 LTS) pip treats this as a hard failure:

```
ERROR: Could not install packages due to an OSError:
[Errno 2] No such file or directory: '.../output.json'
```

This caused install/job failures for customers on those runtimes with an unpinned (transitive) dependency on the connector. Tracked as SEV0 **ES-1960554**; 4.2.7 was yanked from PyPI as the immediate mitigation.

## Follow-ups (not in this PR)

- The upstream root cause (the `sys.exit(0)`) has a fix submitted to Apache Thrift: **THRIFT-6067 / apache/thrift#3584**.
- Once a fixed thrift (0.23.1 / 0.24.0) ships, the pin can be re-widened to restore the CVE remediation that #796 originally intended (#783).
- Pre-release CI to install the built artifact on DBR-LTS-like toolchains (old setuptools) so this class is caught before release.

Co-authored-by: Claude Opus 4.8 <noreply@anthropic.com>
