### PR TITLE
Bump to version 4.3.0rc1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+# 4.3.0rc1 (2026-06-11)
+- Add optional Rust kernel backend for `use_kernel=True`, installable via the new `databricks-sql-connector[kernel]` extra (requires Python >= 3.10). Routes connections through the native `databricks-sql-kernel` client, with parity work across cursor-state tracking, metadata, logging (kernel logs surface through Python `logging`), staging fail-loud behavior, error context, and sync cancel (databricks/databricks-sql-python#824, #825, #830, #838, #839 by @vikrantpuppala)
+- Revert the thrift 0.23.0 bump that broke installation on DBR LTS (ES-1960554) (databricks/databricks-sql-python#840 by @vikrantpuppala)
+
 # 4.2.7 (2026-06-02)
 - Extract SPOG org-id from cluster http_path for non-Thrift requests (databricks/databricks-sql-python#817 by @msrathore-db)
 - Remove empty chunks in CloudFetch concatenation (databricks/databricks-sql-python#814 by @jprakash-db)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "databricks-sql-connector"
-version = "4.2.7"
+version = "4.3.0rc1"
 description = "Databricks SQL Connector for Python"
 authors = ["Databricks <databricks-sql-connector-maintainers@databricks.com>"]
 license = "Apache-2.0"

--- a/src/databricks/sql/__init__.py
+++ b/src/databricks/sql/__init__.py
@@ -71,7 +71,7 @@ DATETIME = DBAPITypeObject("timestamp")
 DATE = DBAPITypeObject("date")
 ROWID = DBAPITypeObject()
 
-__version__ = "4.2.7"
+__version__ = "4.3.0rc1"
 USER_AGENT_NAME = "PyDatabricksSqlConnector"
 
 # These two functions are pyhive legacy


### PR DESCRIPTION
## Summary
Bump version to `4.3.0rc1` and add the `4.3.0rc1` section to `CHANGELOG.md`. First release candidate of 4.3.0, carrying the optional `[kernel]` extra.

### Notable changes since v4.2.7
- Add optional Rust kernel backend for `use_kernel=True`, installable via the new `databricks-sql-connector[kernel]` extra (requires Python >= 3.10). Routes connections through the native `databricks-sql-kernel` client, with parity work across cursor-state tracking, metadata, logging, staging fail-loud behavior, error context, and sync cancel (#824, #825, #830, #838, #839).
- Revert the thrift 0.23.0 bump that broke installation on DBR LTS (ES-1960554) (#840).

## Test plan
- [x] `pytest tests/unit -m "not realkernel"` passes locally (864 passed)
- [x] Multi-DBR suites in `universe/peco/correctness/python` passed for 4.3.0rc1 (PythonSuite thrift + sea on 18.x; PythonUnityCatalogSuite thrift on 17.3.x — the 18.x UC run hit a known, non-driver test-harness env flake)
- [ ] CI green

This is a release-candidate (`4.3.0rc1`); unpinned `pip install` users continue to resolve to the latest stable. Published to PyPI via the secure-release pipeline.

This pull request was AI-assisted by Isaac.