### PR TITLE
Bump to version 4.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Release History
 
-# 4.3.0rc1 (2026-06-11)
-- Add optional Rust kernel backend for `use_kernel=True`, installable via the new `databricks-sql-connector[kernel]` extra (requires Python >= 3.10). Routes connections through the native `databricks-sql-kernel` client, with parity work across cursor-state tracking, metadata, logging (kernel logs surface through Python `logging`), staging fail-loud behavior, error context, and sync cancel (databricks/databricks-sql-python#824, #825, #830, #838, #839 by @vikrantpuppala)
+# 4.3.0 (2026-06-12)
+- **New: optional Rust kernel backend (`use_kernel=True`).** Adds an alternative connection path backed by the native [`databricks-sql-kernel`](https://pypi.org/project/databricks-sql-kernel/) client (a Rust core exposed via PyO3), installable with the new `databricks-sql-connector[kernel]` extra. The kernel talks to Databricks over the **SEA (Statement Execution API) HTTP transport** — not Thrift — with CloudFetch and inline-Arrow result fetching, so `use_kernel=True` gives you a modern SEA-native client through the same DB-API surface. Supports PAT, OAuth M2M, and OAuth U2M auth. Requires Python >= 3.10 (the kernel wheel is `cp310-abi3`); on older interpreters the extra is a no-op and `use_kernel=True` raises a clear `ImportError`. The default backend remains Thrift — opt in per connection.
+- Kernel backend behavior is aligned with the Thrift backend so application code works the same either way: consistent cursor-state tracking (`query_id` / `get_query_state`), metadata (catalogs/schemas/tables/columns with JDBC-style filter semantics and case-insensitive `table_types`), DML `rowcount`, server-sourced async execution state, sync `cancel()`, fail-loud staging/volume operations, and structured error context (SQLSTATE, diagnostic info). Kernel logs surface through Python `logging` under the `databricks.sql.kernel` logger (databricks/databricks-sql-python#824, #825, #830, #838, #839 by @vikrantpuppala)
 - Revert the thrift 0.23.0 bump that broke installation on DBR LTS (ES-1960554) (databricks/databricks-sql-python#840 by @vikrantpuppala)
 
 # 4.2.7 (2026-06-02)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "databricks-sql-connector"
-version = "4.3.0rc1"
+version = "4.3.0"
 description = "Databricks SQL Connector for Python"
 authors = ["Databricks <databricks-sql-connector-maintainers@databricks.com>"]
 license = "Apache-2.0"

--- a/src/databricks/sql/__init__.py
+++ b/src/databricks/sql/__init__.py
@@ -71,7 +71,7 @@ DATETIME = DBAPITypeObject("timestamp")
 DATE = DBAPITypeObject("date")
 ROWID = DBAPITypeObject()
 
-__version__ = "4.3.0rc1"
+__version__ = "4.3.0"
 USER_AGENT_NAME = "PyDatabricksSqlConnector"
 
 # These two functions are pyhive legacy


### PR DESCRIPTION
## Summary
Promote `4.3.0rc1` to the final `4.3.0` release. Bumps `pyproject.toml` + `__init__.py` to `4.3.0` and renames the `4.3.0rc1` CHANGELOG section to `4.3.0` (with a more holistic description of the kernel backend). No code changes since `4.3.0rc1` (`8dd350dc`) — this is a version-only promotion.

### Highlights
- **New: optional Rust kernel backend (`use_kernel=True`)** via the `databricks-sql-connector[kernel]` extra — a native `databricks-sql-kernel` (Rust/PyO3) client over the **SEA HTTP transport** (CloudFetch + inline Arrow), Python >= 3.10, PAT/OAuth-M2M/U2M. Default backend stays Thrift; opt in per connection.
- Behavior aligned with Thrift (cursor state, metadata, rowcount, async state, cancel, staging, error context, logging).
- Revert the thrift 0.23.0 bump that broke install on DBR LTS (ES-1960554).

## Test plan
- [x] `pytest tests/unit -m "not realkernel"` passes locally (864 passed)
- [x] Multi-DBR validated on `4.3.0rc1` (3/3) — `4.3.0` is identical code, so that signal carries over
- [ ] CI green

This is the final `4.3.0` — unpinned `pip install databricks-sql-connector` will resolve to it.

This pull request was AI-assisted by Isaac.