### PR TITLE
ci(warm-deps): fix empty --extras on base matrix legs (#831)

### DIFF
--- a/.github/workflows/warm-deps-cache.yml
+++ b/.github/workflows/warm-deps-cache.yml
@@ -141,7 +141,11 @@ jobs:
           python-version: ${{ matrix.python-version }}
           # extras="" -> base install (no --extras). Otherwise install exactly
           # the one extra this leg targets, matching the PR job's isolation.
-          install-args: ${{ matrix.extras == '' && '' || format('--extras {0}', matrix.extras) }}
+          # NB: the non-empty branch must come FIRST — GitHub's `A && B || C`
+          # treats an empty-string B as falsy and would fall through to C, so
+          # `extras=='' && '' || format(...)` wrongly yields "--extras " (no
+          # value) for the base leg. Test for non-empty and default to "".
+          install-args: ${{ matrix.extras != '' && format('--extras {0}', matrix.extras) || '' }}
           # Distinct suffix per leg so setup-poetry's own "venv-*" cache (used by
           # same-repo PRs) never collides across dependency-version / extras.
           cache-suffix: "warm-${{ matrix.dependency-version }}-${{ matrix.extras || 'base' }}-"


### PR DESCRIPTION
## Summary
Follow-up to #845. The warmer's first dispatch failed on all `extras=base` legs with:

```
Run poetry install --no-interaction --extras
The "--extras" option requires a value
```

Root cause: the `install-args` expression was `matrix.extras == '' && '' || format('--extras {0}', matrix.extras)`. GitHub Actions' `A && B || C` treats the empty-string middle operand `''` as **falsy**, so the base leg fell through to the `format(...)` branch and emitted `--extras ` with no value. pyarrow/kernel legs (non-empty `extras`) were unaffected — which is exactly the observed split.

Fix: test for non-empty extras first, default to `''`:
```yaml
install-args: ${{ matrix.extras != '' && format('--extras {0}', matrix.extras) || '' }}
```

## Test plan
- [x] actionlint clean.
- [ ] Re-dispatch the warmer on `main` after this merges; confirm all 25 legs (incl. base) succeed and save `forkvenv-*` caches. Then verify a fork PR restores them.

Refs #831

This pull request and its description were written by Isaac.