### PR TITLE
test: verify fork-PR CI runs offline from prewarmed cache (#831) [DO NOT MERGE]

### DIFF
--- a/src/databricks/sql/__init__.py
+++ b/src/databricks/sql/__init__.py
@@ -3,7 +3,7 @@ import datetime
 from databricks.sql.exc import *
 
 # PEP 249 module globals
-apilevel = "2.0"
+apilevel = "2.0"  # PEP 249 DB-API level (see #831 fork-CI verification)
 threadsafety = 1  # Threads may share the module, but not connections.
 
 paramstyle = "named"


### PR DESCRIPTION
**Verification PR — [DO NOT MERGE], safe to close/delete after checks report.**

Fork PR from `vikrantpuppala/databricks-sql-python` with a single trivial comment edit. Confirms the fix in #845 + #848 end-to-end: fork PRs should now restore the `forkvenv-*` cache seeded on `main` and run unit / lint / type checks **offline**, instead of dying on the JFrog OIDC step (the original #831 symptom).

Expected: all Code Quality Checks (unit base/pyarrow/kernel, lint, types) go green via the cache-restore path with no JFrog access.

Refs #831

This pull request and its description were written by Isaac.