### PR TITLE
ci(warm-deps): key cache on pristine lock hash so fork restores hit (#831)

### DIFF
--- a/.github/workflows/warm-deps-cache.yml
+++ b/.github/workflows/warm-deps-cache.yml
@@ -129,6 +129,18 @@ jobs:
           git checkout FETCH_HEAD -- poetry.lock pyproject.toml
           echo "Overlaid poetry.lock / pyproject.toml from the fork branch."
 
+      # Capture the lock hash from the PRISTINE, committed poetry.lock BEFORE
+      # setup-poetry runs (it calls `poetry lock`, which rewrites poetry.lock
+      # in place and changes hashFiles's result). restore-deps in the PR jobs
+      # hashes the pristine lock, so the warmer MUST hash it at the same point
+      # or the keys never match and every fork restore misses.
+      - name: Capture pristine lock hash
+        id: lockhash
+        run: |
+          set -euo pipefail
+          echo "value=${{ hashFiles('**/poetry.lock') }}" >> "$GITHUB_OUTPUT"
+          echo "Pristine poetry.lock hash: ${{ hashFiles('**/poetry.lock') }}"
+
       - name: Install Kerberos system dependencies
         if: matrix.extras == 'pyarrow' || matrix.extras == 'kernel'
         run: |
@@ -186,7 +198,9 @@ jobs:
         run: |
           set -euo pipefail
           TIMESTAMP=$(date -u +%Y%m%d%H%M%S)
-          LOCK_HASH="${{ hashFiles('**/poetry.lock') }}"
+          # Pristine hash captured BEFORE setup-poetry's `poetry lock` mutated
+          # the file — matches what restore-deps computes in the PR jobs.
+          LOCK_HASH="${{ steps.lockhash.outputs.value }}"
           PY="${{ matrix.python-version }}"
           DEP="${{ matrix.dependency-version }}"
           EXTRAS="${{ matrix.extras || 'base' }}"


### PR DESCRIPTION
## Summary
Second follow-up to #845 (after #848). The fork verification PR (#849) surfaced that **every** `Unit Tests` leg missed the prewarmed cache and fell back to the JFrog path (which forks can't authenticate to), failing the jobs.

Root cause: a **lockfile-hash mismatch** between warmer and consumer.
- `setup-poetry` runs `poetry lock`, which **rewrites `poetry.lock` in place**.
- The warmer computed its cache key with `hashFiles('**/poetry.lock')` **after** `setup-poetry` → hash `143cf261…`.
- `restore-deps` (PR jobs) hashes the **pristine** committed `poetry.lock` (it runs before `setup-poetry`) → hash `46e4852b…`.

The two never matched, so every fork restore missed:
```
Cache not found for input keys: forkvenv-Linux-3.9-min-base-46e4852b…-, …
```
(warmer had saved `forkvenv-Linux-3.9-min-base-143cf261…`).

Fix: capture the pristine lock hash in a step **before** `setup-poetry` and use that for the cache key, matching what `restore-deps` computes.

## Test plan
- [x] actionlint clean.
- [ ] After merge: re-dispatch the warmer on `main`, then re-run the fork verification PR (#849) and confirm all Unit/lint/type legs restore the cache and run offline (no JFrog).

Refs #831

This pull request and its description were written by Isaac.