### PR TITLE
ci: stop secondary fork-PR checks from failing (#831)

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -37,6 +37,15 @@ concurrency:
 
 jobs:
   test-with-coverage:
+    # This job runs the e2e suite against a live warehouse, so it needs the
+    # azure-prod secrets. FORK PRs never receive those secrets (Secret source:
+    # None), so on a fork the job can only fail. Skip it on fork PRs — the real
+    # coverage gate runs on the merge_group's transient branch (base context,
+    # secrets present), which is what actually protects main. Same-repo PRs and
+    # merge_group are unaffected.
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on:
       group: databricks-protected-runner-group
       labels: linux-ubuntu-latest

--- a/.github/workflows/kernel-e2e.yml
+++ b/.github/workflows/kernel-e2e.yml
@@ -106,19 +106,35 @@ jobs:
         with:
           github-token: ${{ github.token }}
           script: |
-            await github.rest.checks.create({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              name: 'Kernel E2E',
-              head_sha: context.payload.pull_request.head.sha,
-              status: 'completed',
-              conclusion: 'success',
-              completed_at: new Date().toISOString(),
-              output: {
-                title: 'Skipped on PR — runs in merge queue',
-                summary: 'Kernel E2E is skipped on PRs and runs as a required gate in the merge queue. Add the `kernel-e2e` label to preview on this PR.'
+            // On FORK PRs GitHub forces GITHUB_TOKEN to read-only regardless of
+            // the declared `checks: write`, so checks.create 403s ("Resource
+            // not accessible by integration"). That's expected — a fork can't
+            // post check-runs on the base repo. Swallow the 403 for forks so
+            // this poster doesn't show a spurious failure; the real Kernel E2E
+            // required check is posted by the merge_group run (full perms) when
+            // a maintainer queues the PR. Any other error still fails loudly.
+            const isFork = context.payload.pull_request.head.repo.fork;
+            try {
+              await github.rest.checks.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: 'Kernel E2E',
+                head_sha: context.payload.pull_request.head.sha,
+                status: 'completed',
+                conclusion: 'success',
+                completed_at: new Date().toISOString(),
+                output: {
+                  title: 'Skipped on PR — runs in merge queue',
+                  summary: 'Kernel E2E is skipped on PRs and runs as a required gate in the merge queue. Add the `kernel-e2e` label to preview on this PR.'
+                }
+              });
+            } catch (e) {
+              if (isFork && e.status === 403) {
+                core.notice('Fork PR: cannot post the Kernel E2E check-run (read-only token). It will be posted by the merge queue at merge time.');
+              } else {
+                throw e;
               }
-            });
+            }
 
   # ───────────────────────────────────────────────────────────────
   # Detect whether kernel-relevant files changed. Used by both the

--- a/.github/workflows/trigger-integration-tests.yml
+++ b/.github/workflows/trigger-integration-tests.yml
@@ -137,21 +137,37 @@ jobs:
         with:
           github-token: ${{ github.token }}
           script: |
+            // On FORK PRs GitHub forces GITHUB_TOKEN to read-only regardless of
+            // the declared `checks: write`, so checks.create 403s ("Resource
+            // not accessible by integration"). Expected — a fork can't post
+            // check-runs on the base repo. Swallow the 403 for forks so this
+            // poster doesn't show a spurious failure; the real Python Proxy
+            // Tests required checks are posted by the merge_group run (full
+            // perms) when a maintainer queues the PR. Other errors fail loudly.
+            const isFork = context.payload.pull_request.head.repo.fork;
             const MODES = ['thrift', 'kernel'];
             for (const mode of MODES) {
-              await github.rest.checks.create({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                name: `Python Proxy Tests / ${mode}`,
-                head_sha: context.payload.pull_request.head.sha,
-                status: 'completed',
-                conclusion: 'success',
-                completed_at: new Date().toISOString(),
-                output: {
-                  title: 'Skipped on PR — runs in merge queue',
-                  summary: `Python Proxy Tests (${mode}) are skipped on PRs and run as a required gate in the merge queue. Add the \`integration-test\` label to preview them on this PR.`
+              try {
+                await github.rest.checks.create({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: `Python Proxy Tests / ${mode}`,
+                  head_sha: context.payload.pull_request.head.sha,
+                  status: 'completed',
+                  conclusion: 'success',
+                  completed_at: new Date().toISOString(),
+                  output: {
+                    title: 'Skipped on PR — runs in merge queue',
+                    summary: `Python Proxy Tests (${mode}) are skipped on PRs and run as a required gate in the merge queue. Add the \`integration-test\` label to preview them on this PR.`
+                  }
+                });
+              } catch (e) {
+                if (isFork && e.status === 403) {
+                  core.notice(`Fork PR: cannot post the Python Proxy Tests / ${mode} check-run (read-only token). It will be posted by the merge queue at merge time.`);
+                } else {
+                  throw e;
                 }
-              });
+              }
             }
 
   # =============================================================================


### PR DESCRIPTION
## Summary
After the offline-CI fix (#845/#848/#850/#851) turned the 37 unit/lint/type checks green on fork PRs, **3 checks remained red** on the fork verification PR (#849). They are **pre-existing** (also red on the original fork PR #671), unrelated to the cache work, and all rooted in GitHub's fork restrictions:

1. **`skip-integration-tests-pr` / `skip-kernel-e2e-pr`** post synthetic-success check-runs (`checks.create`), which need `checks: write`. On **fork** PRs GitHub forces `GITHUB_TOKEN` to read-only regardless of the declared permission, so the call **403s** (`Resource not accessible by integration`). Fix: swallow the 403 **only for forks** (`head.repo.fork`) so the poster doesn't show a spurious failure. The **real** required checks (`Python Proxy Tests / thrift|kernel`, `Kernel E2E`) are posted by the **`merge_group`** run — which runs in the base-repo context with full permissions and secrets, checks out the queue branch (fork's merged code), and dispatches the actual proxy tests. So the fork's code *is* integration-tested, at merge-queue time. Non-fork and other errors still fail loudly.

2. **`test-with-coverage`** runs the e2e suite against a live warehouse and needs the `azure-prod` secrets, which forks never receive (`Secret source: None`) — so it could only fail on a fork. Skip it on fork PRs; the real coverage gate runs on the `merge_group` transient branch (secrets present), which is what actually protects `main`.

Same-repo PRs and `merge_group` are unaffected by all three changes.

## Before / after (fork PR)
| | #671 (pre-fix) | #849 after #851 | #849 after this PR (expected) |
|---|---|---|---|
| fail | 40 | 3 | **0** |
| pass | 4 | 41 | 44 |

## Test plan
- [x] actionlint clean (only pre-existing SC2086 infos in the untouched coverage script).
- [ ] After merge: re-run fork PR #849 → the two check-posters succeed (swallow 403), `test-with-coverage` skips on the fork; no red checks remain.

## Maintainer note
For a fork PR to be *addable* to the merge queue, branch protection must allow the required checks (`Python Proxy Tests / *`, `Kernel E2E`, coverage) to be satisfied by the `merge_group` run rather than at PR time. Please confirm the ruleset is in merge-queue mode for these — this is the standing branch-protection follow-up for #831.

Refs #831

This pull request and its description were written by Isaac.