### PR TITLE
fix(bots): revert poetry lock/pyproject churn before engineer-bot publish

### DIFF
--- a/.github/workflows/engineer-bot-followup.yml
+++ b/.github/workflows/engineer-bot-followup.yml
@@ -94,6 +94,15 @@ jobs:
         with:
           python-version: '3.11'
 
+      # setup-poetry runs `poetry lock` (to reconcile the lock with the internal
+      # JFrog source it injects), which REWRITES tracked poetry.lock / pyproject.toml
+      # in the working tree. The venv is already built, so the tree no longer needs
+      # that churn — revert it, else the followup's fixup commit (or its leftover
+      # check) would sweep up these bot-untouched dirty files. Keep ONLY the
+      # agent's edits in the tree.
+      - name: Revert poetry lock/pyproject churn (keep only the agent's edits)
+        run: git checkout -- poetry.lock pyproject.toml || true
+
       # Shared prelude: mint the engineer-bot token (pushes fixup commits, posts
       # replies) + the engine-scoped token, set up Node, install the engine.
       - name: Bot prelude (tokens + Node + engine install)

--- a/.github/workflows/engineer-bot-followup.yml
+++ b/.github/workflows/engineer-bot-followup.yml
@@ -101,7 +101,12 @@ jobs:
       # check) would sweep up these bot-untouched dirty files. Keep ONLY the
       # agent's edits in the tree.
       - name: Revert poetry lock/pyproject churn (keep only the agent's edits)
-        run: git checkout -- poetry.lock pyproject.toml || true
+        # No `|| true`: `git checkout -- <tracked-file>` exits 0 for both the
+        # clean and the reverted-churn cases, so a non-zero exit means the revert
+        # genuinely failed (e.g. the files went untracked/missing) and the dirty
+        # tree would otherwise be swept into the followup's fixup commit. Fail
+        # loudly here instead of masking it.
+        run: git checkout -- poetry.lock pyproject.toml
 
       # Shared prelude: mint the engineer-bot token (pushes fixup commits, posts
       # replies) + the engine-scoped token, set up Node, install the engine.

--- a/.github/workflows/engineer-bot.yml
+++ b/.github/workflows/engineer-bot.yml
@@ -88,7 +88,12 @@ jobs:
       # bot-untouched dirty files and refuses to open the PR (they aren't in the
       # agent's touched_files). Keep ONLY the agent's edits in the tree.
       - name: Revert poetry lock/pyproject churn (keep only the agent's edits)
-        run: git checkout -- poetry.lock pyproject.toml || true
+        # No `|| true`: `git checkout -- <tracked-file>` exits 0 for both the
+        # clean and the reverted-churn cases, so a non-zero exit means the revert
+        # genuinely failed (e.g. the files went untracked/missing) and the dirty
+        # tree would otherwise resurface as a confusing publish-time error. Fail
+        # loudly here instead of masking it.
+        run: git checkout -- poetry.lock pyproject.toml
 
       # Shared prelude: mint the engineer-bot token (pushes the fix branch,
       # comments) + the engine-scoped token, set up Node, install the pinned

--- a/.github/workflows/engineer-bot.yml
+++ b/.github/workflows/engineer-bot.yml
@@ -81,6 +81,15 @@ jobs:
         with:
           python-version: '3.11'
 
+      # setup-poetry runs `poetry lock` (to reconcile the lock with the internal
+      # JFrog source it injects), which REWRITES tracked poetry.lock / pyproject.toml
+      # in the working tree. The venv is already built, so the tree no longer needs
+      # that churn — revert it, else publish's leftover safety-net sees these
+      # bot-untouched dirty files and refuses to open the PR (they aren't in the
+      # agent's touched_files). Keep ONLY the agent's edits in the tree.
+      - name: Revert poetry lock/pyproject churn (keep only the agent's edits)
+        run: git checkout -- poetry.lock pyproject.toml || true
+
       # Shared prelude: mint the engineer-bot token (pushes the fix branch,
       # comments) + the engine-scoped token, set up Node, install the pinned
       # engine (PAT-free). `token` output is used by the steps below.


### PR DESCRIPTION
## Problem

The engineer-bot author run on issue #860 ([failed run](https://github.com/databricks/databricks-sql-python/actions/runs/29544082439)) succeeded at authoring the fix (correct `max`→`min` change in `retry.py` + tests, 494 passed) but **failed at "Open / update fix PR"**:

```
##[error]Unstaged paths remain after explicit staging. These were written by the
agent but not tracked in touched_files ...
```

## Root cause

The shared `setup-poetry` action runs **`poetry lock`** (to reconcile the lock with the internal JFrog source it injects for the egress-blocked runner), which **rewrites the tracked `poetry.lock` + `pyproject.toml`** in the working tree. At publish time the tree therefore has 4 dirty paths: the agent's 2 (`retry.py`, `test_retry.py`) **plus** `poetry.lock` + `pyproject.toml`. Publish stages only the agent's `touched_files`, then its leftover safety-net sees the two poetry files still dirty (not in `touched_files`) and correctly refuses.

This is harmless for the 5 real-CI consumers of `setup-poetry` (they commit nothing) but poisons the two engineer-bot workflows, which publish a PR from the working tree. It affects **every** engineer-bot run on this repo, so the bot cannot open a PR until fixed.

## Fix

Engineer-bot side only (leave the shared action untouched so real CI is unaffected): after the Poetry setup, `git checkout -- poetry.lock pyproject.toml` to drop the churn once the venv is built. Only the agent's edits remain in the tree at publish time. Applied to both `engineer-bot.yml` (author) and `engineer-bot-followup.yml`.

## Testing
Both workflow YAMLs parse; actionlint clean. Will re-trigger the engineer-bot on #860 once this lands to confirm the full author→publish→PR path.

This pull request and its description were written by Isaac.