### PR TITLE
chore(bots): bump engine pin to 5368de77 (can_use_tool PermissionResult fix)

### DIFF
--- a/.github/actions/bot-prelude/action.yml
+++ b/.github/actions/bot-prelude/action.yml
@@ -31,7 +31,7 @@ inputs:
     # value to move every bot to a new engine commit; never @main.
     description: 'Engine commit SHA (full 40-char) to install.'
     required: false
-    default: '3569dae31280628fcaf1b6e49c0193bc2fe48a4d'
+    default: '5368de773858bef9b2a8bbf3099d08a4132a8487'
   engine-repo:
     description: 'owner/name of the engine repo.'
     required: false


### PR DESCRIPTION
Bumps the engine pin (bot-prelude's single `engine-ref` default) `3569dae3` → `5368de77`, picking up databricks/databricks-bot-engine#122.

## Why

#122 fixes the `can_use_tool` permission callback: it returned a plain dict, but `claude-agent-sdk` requires a `PermissionResult` object, so **every `edit_file`/`bash` call failed** with `TypeError: Tool permission callback must return PermissionResult ... got dict`. The engineer bot could read but not edit or run tests — on #791, two runs hung to the 45-min job timeout. The fix is runtime-verified against the pinned SDK (0.2.102): the old dict is rejected by the SDK's own validation, the new typed objects are accepted.

## After merge

Re-triggering the engineer-bot on #791 is the end-to-end confirmation that the bot can now edit + run its `tests/e2e` repro.

This pull request and its description were written by Isaac.