### PR TITLE
Bump to version 4.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Release History
 
-# Unreleased
+# 4.4.0 (2026-07-22)
+- Raised the minimum supported Python version to 3.10, dropping the end-of-life 3.8/3.9, to update the lockfile and clear CVE-flagged dependencies in the repo (databricks/databricks-sql-python#798)
 - Fix: `REMOVE` staging operations no longer require `staging_allowed_local_path` to be set, since removing a remote file does not touch the local filesystem (databricks/databricks-sql-python#726)
 - Report `cursor.rowcount` for DML on the Thrift backend: INSERT/UPDATE/DELETE/MERGE now set `rowcount` to the server's affected-row count instead of the hardcoded `-1`; SELECT (and statements the server does not report a count for) still return `-1`. `executemany` aggregates the count across all parameter sets per PEP 249 ([#784](https://github.com/databricks/databricks-sql-python/issues/784))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "databricks-sql-connector"
-version = "4.3.0"
+version = "4.4.0"
 description = "Databricks SQL Connector for Python"
 authors = ["Databricks <databricks-sql-connector-maintainers@databricks.com>"]
 license = "Apache-2.0"

--- a/src/databricks/sql/__init__.py
+++ b/src/databricks/sql/__init__.py
@@ -71,7 +71,7 @@ DATETIME = DBAPITypeObject("timestamp")
 DATE = DBAPITypeObject("date")
 ROWID = DBAPITypeObject()
 
-__version__ = "4.3.0"
+__version__ = "4.4.0"
 USER_AGENT_NAME = "PyDatabricksSqlConnector"
 
 # These two functions are pyhive legacy


### PR DESCRIPTION
## Summary
Bump version to `4.4.0` and add the `4.4.0` section to `CHANGELOG.md`.

This release is versioned `4.4.0` (minor) rather than a patch because it raises the minimum supported Python to 3.10 (dropping end-of-life 3.8/3.9), which changes the install contract for downstream users.

### Notable changes since 4.3.0
- Raised the minimum supported Python version to 3.10, dropping the end-of-life 3.8/3.9, to update the lockfile and clear CVE-flagged dependencies in the repo (#798)
- Fix: `REMOVE` staging operations no longer require `staging_allowed_local_path` to be set (#726)
- Report `cursor.rowcount` for DML on the Thrift backend; `executemany` aggregates the count across parameter sets per PEP 249 (#784)

## Test plan
- [x] `pytest tests/unit/` passes locally (879 passed, realkernel test passes in its required isolated invocation)
- [x] Multi-DBR suites in `universe/peco/correctness/python` passed on Python 3.12: PythonSuite (thrift + SEA) and PythonUnityCatalogSuite (thrift)
- [ ] CI green

This pull request was AI-assisted by Isaac.