### PR TITLE
fix(learning): repair MODEL_ENDPOINT 400 + bump engine to 654a31d0

### DIFF
--- a/.github/actions/bot-prelude/action.yml
+++ b/.github/actions/bot-prelude/action.yml
@@ -31,7 +31,7 @@ inputs:
     # value to move every bot to a new engine commit; never @main.
     description: 'Engine commit SHA (full 40-char) to install.'
     required: false
-    default: 'd05dcb113332401b4aee8d6aa05c7107399ad44f'
+    default: '654a31d0d26d2b77bcb58e84f1e4abe018f9fd5a'
   engine-repo:
     description: 'owner/name of the engine repo.'
     required: false


### PR DESCRIPTION
## What

Two changes to the engineer-bot learning flow:

1. **Fix the daily-failing cron (`MODEL_ENDPOINT`).** The learning workflow used `.../serving-endpoints/anthropic/invocations`, which is **not** translated correctly: `sdk_agent.translate_endpoint` early-returns on URLs already containing `/serving-endpoints/anthropic`, keeping the trailing `/invocations`. The CLI then appends `/v1/messages` → `.../serving-endpoints/anthropic/invocations/v1/messages` → **`400 Unsupported native API path`**. This repo's learning cron has failed every scheduled run with exactly this error ([e.g. run 31624062797](https://github.com/databricks/databricks-sql-python/actions/runs/31624062797)). Switch to the concrete `.../serving-endpoints/databricks-claude-opus-4-8/invocations` form that `reviewer-bot.yml` / `engineer-bot.yml` use successfully.

2. **Bump the engine pin** `d05dcb11` → `654a31d0` (engine `main`, 30 commits): brings per-bot model selection. SDK/CLI (`0.2.102` / `2.1.61`) unchanged at that SHA — SHA-only.

## Why together

The endpoint bug is why the retrospective never actually ran here despite the flow being wired up. Fixing it + bumping to the current engine gets the daily learning extraction working on `main` for the first time. The same endpoint fix is going out to the sibling driver repos' learning PRs.

## Note

The effective model is engine-owned (`repo_conventions.engineer_bot_model()` = `databricks-claude-opus-4-8[1m]`, override via `ENGINEER_BOT_MODEL_OVERRIDE`); the model segment in the URL is discarded by `translate_endpoint`, so this is purely a routing/base-URL fix.

This pull request and its description were written by Isaac.