### PR TITLE
fix(learning): repair MODEL_ENDPOINT 400 in the retrospective cron

### DIFF
--- a/.github/workflows/engineer-bot-learning.yml
+++ b/.github/workflows/engineer-bot-learning.yml
@@ -99,11 +99,15 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.prelude.outputs.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
-          # Only the `<workspace>/serving-endpoints/` prefix matters:
-          # sdk_agent.translate_endpoint rewrites this to `.../serving-endpoints/anthropic`
-          # and discards the model path segment. The effective model comes from
-          # .bot/config.yaml `retrospective.model` (or the engine default).
-          MODEL_ENDPOINT: https://${{ secrets.DATABRICKS_HOST }}/serving-endpoints/anthropic/invocations
+          # Use the concrete `.../serving-endpoints/<model>/invocations` form (same
+          # as reviewer-bot.yml / engineer-bot.yml). sdk_agent.translate_endpoint
+          # strips it to the `.../serving-endpoints/anthropic` base the CLI needs.
+          # Do NOT use `.../serving-endpoints/anthropic/invocations` here: that hits
+          # translate_endpoint's already-v2 early-return, which keeps the trailing
+          # `invocations`, so the CLI appends `/v1/messages` →
+          # `.../anthropic/invocations/v1/messages` → HTTP 400 (unsupported path).
+          # The effective model is set by the engine default (no retrospective.model).
+          MODEL_ENDPOINT: https://${{ secrets.DATABRICKS_HOST }}/serving-endpoints/databricks-claude-opus-4-8/invocations
           DATABRICKS_TOKEN: ${{ secrets.DATABRICKS_TOKEN }}
           RUNNER_TEMP: ${{ runner.temp }}
           SINCE: ${{ inputs.since }}


### PR DESCRIPTION
## What

Fix the `MODEL_ENDPOINT` in `engineer-bot-learning.yml`: `.../serving-endpoints/anthropic/invocations` → `.../serving-endpoints/databricks-claude-opus-4-8/invocations`.

## Why (follow-up to #905)

#905 bumped the engine pin but **merged before this endpoint fix landed** — so the learning cron on `main` is still broken. The daily scheduled run fails every time with:

```
API Error: 400 Unsupported native API path
'/serving-endpoints/anthropic/invocations/v1/messages' for provider 'anthropic'
```

Root cause: `sdk_agent.translate_endpoint` early-returns on URLs already containing `/serving-endpoints/anthropic`, keeping the trailing `/invocations`. The CLI then appends `/v1/messages`, producing the rejected path. The concrete `.../serving-endpoints/databricks-claude-opus-4-8/invocations` form (used by `reviewer-bot.yml` / `engineer-bot.yml`, which run successfully) is stripped by `translate_endpoint` to the correct `.../serving-endpoints/anthropic` base.

The model segment in the URL is cosmetic — the effective model is engine-owned (`repo_conventions.engineer_bot_model()`); this is a routing/base-URL fix only. Same fix is going out to the sibling driver repos' learning PRs.

## Validation

Post-merge, the daily cron should stop 400ing. Can be checked immediately with a manual `workflow_dispatch` (recent `since`).

This pull request and its description were written by Isaac.